### PR TITLE
Clear results from the server instead of when Run button is pressed

### DIFF
--- a/polynote-frontend/polynote/cell.js
+++ b/polynote-frontend/polynote/cell.js
@@ -215,12 +215,6 @@ export class CodeCell extends Cell {
 
         this.onWindowResize = (evt) => this.editor.layout();
         window.addEventListener('resize', this.onWindowResize);
-
-        this.addEventListener('BeforeCellRun', evt => {
-            if (evt.detail.cellId === this.id) {
-                this.setErrors([]);
-            }
-        })
     }
 
 
@@ -375,9 +369,7 @@ export class CodeCell extends Cell {
     }
 
     clearResult() {
-        this.cellOutputDisplay.innerHTML = '';
-        this.cellOutput.classList.remove('errors');
-        this.cellOutput.classList.remove('output');
+        this.setErrors([]);
     }
 
     requestCompletion(pos) {

--- a/polynote-frontend/polynote/result.js
+++ b/polynote-frontend/polynote/result.js
@@ -13,10 +13,6 @@ export class Result {
     static encode(msg) {
         return Codec.encode(Result.codec, msg);
     }
-
-    encode() {
-        return Message.encode(this);
-    }
 }
 
 export class Output extends Result {
@@ -177,10 +173,30 @@ export class RuntimeError extends Result {
 
 RuntimeError.codec = combined(KernelErrorWithCause.codec).to(RuntimeError);
 
+export class ClearResults extends Result {
+    static get msgTypeId() { return 3; }
+
+    static unapply(inst) {
+        return [];
+    }
+
+    constructor() {
+        super();
+        Object.freeze(this);
+    }
+}
+
+ClearResults.instance = new ClearResults();
+ClearResults.codec = Object.freeze({
+  encode: (value, writer) => undefined,
+  decode: (reader) => ClearResults.instance
+});
+
 Result.codecs = [
   Output,
   CompileErrors,
   RuntimeError,
+  ClearResults
 ];
 
 Result.codec = discriminated(

--- a/polynote-frontend/polynote/ui.js
+++ b/polynote-frontend/polynote/ui.js
@@ -12,7 +12,7 @@ import { Cell, TextCell, CodeCell, BeforeCellRunEvent } from "./cell.js"
 import { tag, para, span, button, iconButton, div, table, h2, h3, h4, textbox, dropdown } from './tags.js'
 import { TaskStatus } from './messages.js';
 import * as messages from './messages.js'
-import { CompileErrors, Output, RuntimeError } from './result.js'
+import { CompileErrors, Output, RuntimeError, ClearResults } from './result.js'
 import { Prefs, prefs } from './prefs.js'
 
 
@@ -789,6 +789,8 @@ export class NotebookUI {
                         cell.setRuntimeError(result.error);
                     } else if (result instanceof Output) {
                         cell.addResult(result.contentType, result.content);
+                    } else if (result instanceof ClearResults) {
+                        cell.clearResult();
                     }
                 }
                 //console.log("Cell result:", path, id, result);

--- a/polynote-kernel/src/main/scala/polynote/kernel/PolyKernel.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/PolyKernel.scala
@@ -117,7 +117,7 @@ class PolyKernel private[kernel] (
     symbolTable.drain() *> Queue.unbounded[IO, Option[Result]].flatMap {
       oq =>
           val oqSome = new EnqueueSome(oq)
-          withKernel(id) {
+          oq.enqueue1(Some(ClearResults())) *> withKernel(id) {
             (notebook, cell, kernel) =>
               val prevCellIds = prevCells(notebook, id)
               taskQueue.runTaskIO(id, id, s"Running $id") {

--- a/polynote-kernel/src/main/scala/polynote/kernel/Result.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/Result.scala
@@ -2,13 +2,13 @@ package polynote.kernel
 
 import java.nio.charset.{Charset, StandardCharsets}
 
-import scodec.{Attempt, Codec, Err}
+import scodec.{Attempt, Codec, DecodeResult, Err}
 import scodec.codecs._
 import scodec.codecs.implicits._
 import shapeless.cachedImplicit
-
-import io.circe.{Encoder, Decoder}
+import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import scodec.bits.BitVector
 
 import scala.collection.mutable.ListBuffer
 
@@ -125,6 +125,11 @@ object RuntimeError extends ResultCompanion[RuntimeError](2) {
 
   implicit val codec: Codec[RuntimeError] = throwableWithCausesCodec.as[RuntimeError]
 }
+
+
+final case class ClearResults() extends Result
+
+object ClearResults extends ResultCompanion[ClearResults](3)
 
 sealed trait Result
 

--- a/polynote-server/src/main/scala/polynote/server/repository/MarkdownNotebookRepository.scala
+++ b/polynote-server/src/main/scala/polynote/server/repository/MarkdownNotebookRepository.scala
@@ -107,6 +107,8 @@ class MarkdownNotebookRepository(
           }
           }</ul>
       </div>.toString()
+
+    case ClearResults() => ""
   }
 
   private def htmlToResult(html: scala.xml.Elem, id: String): Option[Result] = html.attribute("class").map(_.head.value.toString).flatMap {


### PR DESCRIPTION
Currently, the client clears the results when the run button is pressed. But, now that the results are broadcast, we need to control clearing of previous results as part of that broadcast. Otherwise, other clients will just accumulate more results.

This commit adds a new `Result` message, `ClearResults`, which the kernel emits just before the cell starts running. When the client gets that result, it clears any existing results and error messages.