### PR TITLE
Make Completion Errors less severe

### DIFF
--- a/polynote-server/src/main/scala/polynote/server/SocketSession.scala
+++ b/polynote-server/src/main/scala/polynote/server/SocketSession.scala
@@ -151,7 +151,7 @@ class SocketSession(
       for {
         notebookRef <- getNotebook(notebook, oq)
         kernel      <- notebookRef.getKernel
-        completions <- kernel.completionsAt(id, pos)
+        completions <- kernel.completionsAt(id, pos).handleErrorWith(err => IO(err.printStackTrace(System.err)).map(_ => Nil))
       } yield Stream.emit(req.copy(completions = ShortList(completions)))
 
     case req@ParametersAt(notebook, id, pos, _) =>


### PR DESCRIPTION
Looks like we lost the `handleErrorWith` clause in #23, which wasn't great coupled with #28

Doesn't solve #29 but at least mitigates its effects.