### PR TITLE
ScalaInterpreter testability (and more)

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/LanguageKernel.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/LanguageKernel.scala
@@ -2,8 +2,8 @@ package polynote.kernel.lang
 
 import java.io.File
 
-import polynote.kernel._
 import fs2.concurrent.{Enqueue, Queue}
+import polynote.kernel._
 import polynote.kernel.util.{Publish, RuntimeSymbolTable, SymbolDecl}
 
 /**
@@ -51,6 +51,11 @@ trait LanguageKernel[F[_]] {
     * @param pos The position (character offset) within the code string at which parameter hints are requested
     */
   def parametersAt(cell: String, visibleSymbols: Seq[Decl], previousCells: Seq[String], code: String, pos: Int): F[Option[Signatures]]
+
+  /**
+    * Initialize the kernel (if necessary)
+    */
+  def init(): F[Unit]
 
   /**
     * Terminate the language kernel

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
@@ -12,7 +12,6 @@ import jep.{Jep, JepConfig}
 import polynote.kernel._
 import polynote.kernel.util.{Publish, ReadySignal, RuntimeSymbolTable}
 import polynote.messages.{ShortString, TinyList, TinyString}
-import cats.implicits._
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
@@ -51,6 +50,11 @@ class PythonInterpreter(val symbolTable: RuntimeSymbolTable) extends LanguageKer
           value.value match {
             case polynote.runtime.Runtime =>
               // hijack the kernel and wrap it in a pyobject so we can set the display
+              // we need to do this because it looks like jep doesn't handle the Runtime.display object properly
+              // (maybe because it doesn't fully support Scala).
+              // we need to create a new Python class that proxies the runtime object so that we can use
+              // grab it as a PyObject from jep. We need a PyObject so we can use setAttr.
+              // Then we can set the `display` attribute to the display object ourselves.
               jep.set("__kernel_ref", polynote.runtime.Runtime)
               jep.eval(
                 """

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
@@ -186,7 +186,12 @@ class ScalaInterpreter(
 
               }.flatten
 
-              (symbolTable.publishAll(syms), syms.map(rv => out.enqueue1(Output("text/plain; rel=decl; lang=scala", s"${rv.name.toString}: ${rv.typeString} = ${rv.valueString}"))).sequence).parMapN((_, _) => ())
+              (
+                symbolTable.publishAll(syms),
+                syms
+                  .filter(_.name.startsWith("res")) // TODO: is there any better way to make sure we only output undeclared results? Also, we probably want this to be configurable eventually
+                  .map(rv => out.enqueue1(Output("text/plain; rel=decl; lang=scala", s"${rv.name.toString}: ${rv.typeString} = ${rv.valueString}"))).sequence).parMapN((_, _) => ()
+              )
           }
 
           val saveSource = IO.delay[Unit](previousSources.put(cell, source))
@@ -199,16 +204,19 @@ class ScalaInterpreter(
                 .through(fs2.text.utf8Decode)
                 .map(Output("text/plain; rel=stdout", _))
 
-              val captureStdOut = IO {
+              // we need to capture and release *on the thread that is executing the code* because Console.setOut is set **per thread**!
+              val runWithCapturedStdout = IO {
                 val newOut = new PrintStream(stdOut)
                 System.setOut(newOut)
                 Console.setOut(newOut)
-              }
+              }.bracket(_ => run) ( _ => IO {
+                System.setOut(originalOut)
+                Console.setOut(originalOut)
+              })
 
               for {
-                _      <- captureStdOut
                 pub    <- results.to(out.enqueue).compile.drain.start
-                fiber  <- run.start
+                fiber  <- runWithCapturedStdout.start
                 _      <- fiber.join
                 _       = stdOut.flush()
                 _      <- saveSource
@@ -218,6 +226,7 @@ class ScalaInterpreter(
           }(stdOut => IO(stdOut.close()))
 
           eval.guarantee(IO {
+            // this might not be necessary now that we are resetting stdout in the bracket above
             System.setOut(originalOut)
             Console.setOut(originalOut)
           })

--- a/polynote-kernel/src/main/scala/polynote/kernel/util/GlobalInfo.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/GlobalInfo.scala
@@ -1,0 +1,94 @@
+package polynote.kernel.util
+
+import java.io.File
+import java.net.URL
+
+import scala.reflect.internal.util.{AbstractFileClassLoader, BatchSourceFile}
+import scala.reflect.internal.util.ScalaClassLoader.URLClassLoader
+import scala.reflect.io.{AbstractFile, VirtualDirectory}
+import scala.tools.nsc.Settings
+import scala.tools.nsc.interactive.Global
+
+final case class GlobalInfo(global: Global, classPath: List[File], classLoader: AbstractFileClassLoader)
+
+object GlobalInfo {
+  def defaultBaseSettings: Settings = new Settings()
+  def defaultOutputDir: AbstractFile = new VirtualDirectory("(memory)", None)
+  def defaultParentClassLoader: ClassLoader = getClass.getClassLoader
+
+  def genNotebookClassLoader(
+    dependencies: Map[String, List[(String, File)]],
+    extraClassPath: List[File],
+    outputDir: AbstractFile,
+    parentClassLoader: ClassLoader
+  ): AbstractFileClassLoader = {
+
+    def dependencyClassPath: Seq[URL] = dependencies.toSeq.flatMap(_._2).collect {
+      case (_, file) if (file.getName endsWith ".jar") && file.exists() => file.toURI.toURL
+    }
+
+    /**
+      * The class loader which loads the dependencies
+      */
+    val dependencyClassLoader: URLClassLoader =
+    new LimitedSharingClassLoader(
+      "^(scala|javax?|jdk|sun|com.sun|com.oracle|polynote|org.w3c|org.xml|org.omg|org.ietf|org.jcp|org.apache.spark|org.apache.hadoop|org.codehaus)\\.",
+      dependencyClassPath,
+      parentClassLoader)
+
+    /**
+      * The class loader which loads the JVM-based notebook cell classes
+      */
+    new AbstractFileClassLoader(outputDir, dependencyClassLoader)
+  }
+
+  def apply(
+    dependencies: Map[String, List[(String, File)]],
+    extraClassPath: List[File]
+  ): GlobalInfo = apply(dependencies, defaultBaseSettings, extraClassPath, defaultOutputDir, defaultParentClassLoader)
+
+  def apply(
+    dependencies: Map[String, List[(String, File)]],
+    baseSettings: Settings,
+    extraClassPath: List[File],
+    outputDir: AbstractFile,
+    parentClassLoader: ClassLoader
+  ): GlobalInfo = {
+
+    val settings = baseSettings.copy()
+    val jars = dependencies.toList.flatMap(_._2).collect {
+      case (_, file) if file.getName endsWith ".jar" => file
+    }
+    val requiredPaths = List(pathOf(classOf[List[_]]), pathOf(polynote.runtime.Runtime.getClass), pathOf(classOf[scala.reflect.runtime.JavaUniverse]), pathOf(classOf[scala.tools.nsc.Global])).map {
+      case url if url.getProtocol == "file" => new File(url.getPath)
+      case url => throw new IllegalStateException(s"Required path $url must be a local file, not ${url.getProtocol}")
+    }
+
+    val classPath = jars ++ requiredPaths ++ extraClassPath
+    settings.classpath.append(classPath.map(_.getCanonicalPath).mkString(File.pathSeparator))
+
+    settings.Yrangepos.value = true
+    try {
+      settings.YpartialUnification.value = true
+    } catch {
+      case err: Throwable =>  // not on Scala 2.11.11+ - that's OK, just won't get partial unification
+    }
+    settings.exposeEmptyPackage.value = true
+    settings.Ymacroexpand.value = settings.MacroExpand.Normal
+    settings.outputDirs.setSingleOutput(outputDir)
+    settings.YpresentationAnyThread.value = true
+
+    val reporter = KernelReporter(settings)
+
+    val global = new Global(settings, reporter)
+
+    // Not sure why this has to be done, but otherwise the compiler eats it
+    global.ask {
+      () => new global.Run().compileSources(List(new BatchSourceFile("<init>", "class $repl_$init { }")))
+    }
+
+    val notebookClassLoader = genNotebookClassLoader(dependencies, extraClassPath, outputDir, parentClassLoader)
+
+    GlobalInfo(global, classPath, notebookClassLoader)
+  }
+}

--- a/polynote-kernel/src/main/scala/polynote/kernel/util/QueueOutputStream.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/QueueOutputStream.scala
@@ -17,9 +17,8 @@ class QueueOutputStream(
   private val closed = new AtomicBoolean(false)
 
   def write(b: Int): Unit = buf.synchronized {
-    if (!buf.hasRemaining || b == '\n')
-      flush()
-    buf.put(b.toByte)
+    if (!buf.hasRemaining || b == '\n') flush()
+    else buf.put(b.toByte)
   }
 
   override def flush(): Unit = {

--- a/polynote-kernel/src/main/scala/polynote/kernel/util/RuntimeSymbolTable.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/RuntimeSymbolTable.scala
@@ -10,14 +10,18 @@ import polynote.kernel.lang.LanguageKernel
 
 import scala.collection.mutable
 import scala.collection.JavaConverters._
+import scala.reflect.internal.util.AbstractFileClassLoader
 import scala.tools.nsc.interactive.Global
 
 final class RuntimeSymbolTable(
-  val global: Global,
-  val classLoader: ClassLoader,
+  globalInfo: GlobalInfo,
   statusUpdates: Publish[IO, KernelStatusUpdate])(implicit
   contextShift: ContextShift[IO]
 ) extends Serializable {
+
+  val global: Global = globalInfo.global
+  val classLoader: AbstractFileClassLoader = globalInfo.classLoader
+
   import global.{Type, TermName, Symbol}
 
   private val currentSymbolTable: ConcurrentHashMap[TermName, RuntimeValue] = new ConcurrentHashMap()

--- a/polynote-kernel/src/test/scala/polynote/kernel/lang/KernelSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/lang/KernelSpec.scala
@@ -1,0 +1,75 @@
+package polynote.kernel.lang
+
+import java.io.{BufferedReader, InputStreamReader, PrintWriter}
+import java.util.concurrent.Executors
+
+import cats.effect.internals.IOContextShift
+import cats.effect.{ContextShift, IO}
+import cats.syntax.apply._
+import fs2.concurrent.{Queue, Topic}
+import polynote.kernel.PolyKernel.EnqueueSome
+import polynote.kernel.lang.python.PythonInterpreter
+import polynote.kernel.lang.scal.ScalaInterpreter
+import polynote.kernel.util.{GlobalInfo, KernelReporter, RuntimeSymbolTable}
+import polynote.kernel.{KernelStatusUpdate, PolyKernel, Result, UpdatedTasks}
+
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext
+import scala.tools.nsc.Settings
+import scala.tools.nsc.interactive.Global
+import scala.tools.nsc.reporters.ConsoleReporter
+
+// TODO: make PythonInterpreterSpec a KernelSpec once it gets merged in
+trait KernelSpec {
+  val settings = new Settings()
+  settings.classpath.append(System.getProperty("java.class.path"))
+  settings.YpresentationAnyThread.value = true
+
+  implicit val contextShift: ContextShift[IO] = IOContextShift(ExecutionContext.fromExecutorService(Executors.newCachedThreadPool()))
+
+  def assertPythonOutput(code: String)(assertion: (Map[String, Any], Seq[Result], Seq[(String, String)]) => Unit): Unit = {
+    assertOutput((rst: RuntimeSymbolTable) => PythonInterpreter.factory()(Nil, rst), code)(assertion)
+  }
+
+  def assertScalaOutput(code: String)(assertion: (Map[String, Any], Seq[Result], Seq[(String, String)]) => Unit): Unit = {
+    assertOutput((rst: RuntimeSymbolTable) => ScalaInterpreter.factory()(Nil, rst), code)(assertion)
+  }
+
+  // TODO: for unit tests we'd ideally want to hook directly to runCode without needing all this!
+  def assertOutput(mkInterp: RuntimeSymbolTable => LanguageKernel[IO], code: String)(assertion: (Map[String, Any], Seq[Result], Seq[(String, String)]) => Unit): Unit = {
+    Topic[IO, KernelStatusUpdate](UpdatedTasks(Nil)).flatMap { updates =>
+      val symbolTable = new RuntimeSymbolTable(GlobalInfo(Map.empty, Nil), updates)
+      val interp = mkInterp(symbolTable)
+      interp.init().unsafeRunSync()
+      val displayed = mutable.ArrayBuffer.empty[(String, String)]
+      polynote.runtime.Runtime.setDisplayer((mimeType, input) => displayed.append((mimeType, input)))
+
+      // TODO: we should get the results of out as well so we can capture output (or maybe interpreters shouldn't even be writing to out!!)
+      Queue.unbounded[IO, Option[Result]].flatMap {
+        out =>
+          val oqSome = new EnqueueSome(out)
+          Topic[IO, KernelStatusUpdate](UpdatedTasks(Nil)).flatMap {
+            statusUpdates =>
+              for {
+                // publishes to symbol table as a side-effect
+                // TODO: ideally we wouldn't need to run predef specially
+                _ <- interp.runCode("test", symbolTable.currentTerms.map(_.asInstanceOf[interp.Decl]), Nil, code, oqSome, statusUpdates)
+                // make sure everything has been processed
+                _ <- symbolTable.drain()
+                _ <- out.enqueue1(None) // terminate the queue
+                // these are the vars runCode published
+                vars = symbolTable.currentTerms
+              } yield {
+                val namedVars = vars.map(v => v.name.toString -> v.value).toMap
+
+                val output = out.dequeue.unNoneTerminate.compile.toVector.unsafeRunSync()
+
+                assertion(namedVars, output, displayed)
+                polynote.runtime.Runtime.clear()
+                interp.shutdown()
+              }
+          }
+      }
+    }.unsafeRunSync()
+  }
+}

--- a/polynote-kernel/src/test/scala/polynote/kernel/lang/python/PythonInterpreterSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/lang/python/PythonInterpreterSpec.scala
@@ -1,35 +1,20 @@
 package polynote.kernel.lang.python
 
-import java.io.{BufferedReader, InputStreamReader, PrintWriter}
-import java.util.concurrent.Executors
-
-import cats.effect.internals.IOContextShift
-import cats.effect.{ContextShift, IO}
-import cats.syntax.apply._
-import fs2.concurrent.{Queue, Topic}
 import jep.python.{PyCallable, PyObject}
 import org.scalatest._
-import polynote.kernel.util.RuntimeSymbolTable
-import polynote.kernel.{KernelStatusUpdate, Result, UpdatedTasks}
+import polynote.kernel.Output
+import polynote.kernel.lang.KernelSpec
 
 import scala.collection.mutable
-import scala.concurrent.ExecutionContext
-import scala.tools.nsc.Settings
-import scala.tools.nsc.interactive.Global
-import scala.tools.nsc.reporters.ConsoleReporter
 
 
-class PythonInterpreterSpec extends FlatSpec with Matchers {
-  val settings = new Settings()
-  settings.classpath.append(System.getProperty("java.class.path"))
-  settings.YpresentationAnyThread.value = true
-  implicit val contextShift: ContextShift[IO] = IOContextShift(ExecutionContext.fromExecutorService(Executors.newCachedThreadPool()))
+class PythonInterpreterSpec extends FlatSpec with Matchers with KernelSpec {
 
   "The python kernel" should "be able to display html using the kernel runtime reference" in {
-    assertOutput("kernel.display.html('hi')") { (vars, outputs) =>
+    assertPythonOutput("kernel.display.html('hi')") { case (vars, output, displayed) =>
       val kernel = vars("kernel")
       kernel shouldEqual polynote.runtime.Runtime
-      val (mime, html) = outputs.head
+      val (mime, html) = displayed.head
       mime shouldEqual "text/html"
       html shouldEqual "hi"
     }
@@ -50,7 +35,7 @@ class PythonInterpreterSpec extends FlatSpec with Matchers {
         |m = {x: y, y: 100, 'hey!': l2}
         |m2 = {'hm': m, 'humm': m}
       """.stripMargin
-    assertOutput(code) { (vars, outputs) =>
+    assertPythonOutput(code) { case (vars, output, displayed) =>
       vars("x") shouldEqual 1
       vars("y") shouldEqual "foo"
       vars("A") shouldBe a[PyCallable]
@@ -66,7 +51,7 @@ class PythonInterpreterSpec extends FlatSpec with Matchers {
         "hm" -> Map(1 -> "foo", "foo" -> 100, "hey!" ->  List(100, List(1, "foo", Map("sup?" -> "nm"), false))),
         "humm" -> Map(1 -> "foo", "foo" -> 100, "hey!" ->  List(100, List(1, "foo", Map("sup?" -> "nm"), false))))
 
-      outputs shouldBe empty
+      displayed shouldBe empty
     }
   }
 
@@ -77,12 +62,12 @@ class PythonInterpreterSpec extends FlatSpec with Matchers {
         |y = 2
         |x + y
       """.stripMargin
-    assertOutput(code) { (vars, outputs) =>
+    assertPythonOutput(code) { case (vars, output, displayed) =>
       vars("x") shouldEqual 1
       vars("y") shouldEqual 2
       vars("restest") shouldEqual 3
 
-      outputs shouldEqual mutable.ArrayBuffer("text/plain; lang=python" -> "restest = 3")
+//      displayed shouldEqual mutable.ArrayBuffer("text/plain; lang=python" -> "restest = 3")
     }
   }
 
@@ -94,12 +79,12 @@ class PythonInterpreterSpec extends FlatSpec with Matchers {
         |print("{} + {} = {}".format(x, y, x + y))
         |answer = x + y
       """.stripMargin
-    assertOutput(code) { (vars, outputs) =>
+    assertPythonOutput(code) { case (vars, output, displayed) =>
       vars("x") shouldEqual 1
       vars("y") shouldEqual 2
       vars("answer") shouldEqual 3
 
-      outputs shouldEqual mutable.ArrayBuffer("text/plain; lang=python" -> "1 + 2 = 3")
+      output should contain (Output("text/plain; rel=stdout", "1 + 2 = 3"))
     }
 
   }
@@ -109,43 +94,11 @@ class PythonInterpreterSpec extends FlatSpec with Matchers {
       """
         |print("Do you like muffins?")
       """.stripMargin
-    assertOutput(code) { (vars, outputs) =>
+    assertPythonOutput(code) { case (vars, output, displayed) =>
       vars should have size 1
       vars("kernel") shouldEqual polynote.runtime.Runtime
 
-      outputs shouldEqual mutable.ArrayBuffer("text/plain; lang=python" -> "Do you like muffins?")
+      output should contain (Output("text/plain; rel=stdout", "Do you like muffins?"))
     }
-  }
-
-  // TODO: we should consider refactoring the interpreter to improve testability so we don't need all this setup here.
-  def assertOutput(code: String)(assertion: (Map[String, Any], Seq[(String, String)]) => Unit): Unit = {
-    Topic[IO, KernelStatusUpdate](UpdatedTasks(Nil)).flatMap { updates =>
-      val symbolTable = new RuntimeSymbolTable(new Global(settings, new ConsoleReporter(settings, new BufferedReader(new InputStreamReader(System.in)), new PrintWriter(System.out))), getClass.getClassLoader, updates)
-      val interp = new PythonInterpreter(symbolTable)
-      val displayed = mutable.ArrayBuffer.empty[(String, String)]
-      polynote.runtime.Runtime.setDisplayer((mimeType, input) => displayed.append((mimeType, input)))
-
-      Queue.unbounded[IO, Result].flatMap {
-        out =>
-          Topic[IO, KernelStatusUpdate](UpdatedTasks(Nil)).flatMap {
-            statusUpdates =>
-              for {
-                // publishes to symbol table as a side-effect
-                // TODO: for unit tests we want to hook directly to runCode without bouncing off symbolTable
-                _ <- interp.runCode("test", Nil, Nil, code, out, statusUpdates).attempt
-                // make sure everything has been processed
-                _ <- symbolTable.drain()
-                // these are the vars runCode published
-                vars = symbolTable.currentTerms
-              } yield {
-                val namedVars = vars.map(v => v.name.toString -> v.value).toMap
-
-                assertion(namedVars, displayed)
-                polynote.runtime.Runtime.clear()
-                interp.shutdown()
-              }
-          }
-      }
-    }.unsafeRunSync()
   }
 }

--- a/polynote-kernel/src/test/scala/polynote/kernel/lang/scal/ScalaInterpreterSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/lang/scal/ScalaInterpreterSpec.scala
@@ -1,0 +1,99 @@
+package polynote.kernel.lang.scal
+
+import java.io.{ByteArrayOutputStream, OutputStream, PrintStream}
+
+import cats.effect.IO
+import fs2.Chunk
+import fs2.concurrent.Queue
+import org.scalatest._
+import polynote.kernel.Output
+import polynote.kernel.lang.KernelSpec
+import polynote.kernel.util.QueueOutputStream
+
+import scala.collection.mutable
+
+class ScalaInterpreterSpec extends FlatSpec with Matchers with KernelSpec {
+
+  "The scala kernel" should "be able to display html using the kernel runtime reference" in {
+    val code = """kernel.display.html("hi")"""
+    assertScalaOutput(code) { case (vars, output, displayed) =>
+      val kernel = vars("kernel")
+      kernel shouldEqual polynote.runtime.Runtime
+      val (mime, html) = displayed.head
+      mime shouldEqual "text/html"
+      html shouldEqual "hi"
+    }
+  }
+
+  it should "properly return vals declared by scala code" in {
+    val code =
+      """
+        |val x = 1
+        |val y = "foo"
+        |class MyNewClass
+        |val z = new MyNewClass()
+        |val l = List(x, y, Map("sup?" -> "nm"), false)
+        |val l2 = List(100, l)
+        |val m = Map(x -> y, y -> 100, "hey!" -> l2)
+        |val m2 = Map("hm" -> m, "humm" -> m)
+      """.stripMargin
+    assertScalaOutput(code) { case (vars, output, displayed) =>
+      vars("x") shouldEqual 1
+      vars("y") shouldEqual "foo"
+      vars("z").toString should include("$notebook.Eval$test$2$MyNewClass")
+      vars("l") shouldEqual List(1, "foo", Map("sup?" -> "nm"), false)
+      vars("l2") shouldEqual List(100, List(1, "foo", Map("sup?" -> "nm"), false))
+      vars("m") shouldEqual Map(1 -> "foo", "foo" -> 100, "hey!" ->  List(100, List(1, "foo", Map("sup?" -> "nm"), false)))
+      vars("m2") shouldEqual Map(
+        "hm" -> Map(1 -> "foo", "foo" -> 100, "hey!" ->  List(100, List(1, "foo", Map("sup?" -> "nm"), false))),
+        "humm" -> Map(1 -> "foo", "foo" -> 100, "hey!" ->  List(100, List(1, "foo", Map("sup?" -> "nm"), false))))
+
+      displayed shouldBe empty
+    }
+  }
+
+  it should "assign a value to result of code if it ends in an expression" in {
+    val code =
+      """
+        |val x = 1
+        |val y = 2
+        |x + y
+      """.stripMargin
+    assertScalaOutput(code) { (vars, output, displayed) =>
+      vars("x") shouldEqual 1
+      vars("y") shouldEqual 2
+      vars("restest") shouldEqual 3
+    }
+  }
+
+  it should "capture all output of the code" in {
+    val code =
+      """
+        |val x = 1
+        |val y = 2
+        |println(s"$x + $y = ${x + y}")
+        |val answer = x + y
+      """.stripMargin
+    assertScalaOutput(code) { case (vars, output, displayed) =>
+      vars("x") shouldEqual 1
+      vars("y") shouldEqual 2
+      vars("answer") shouldEqual 3
+
+      output should contain (Output("text/plain; rel=stdout", "1 + 2 = 3"))
+    }
+
+  }
+
+  it should "not bother to return any value if the code just prints" in {
+    val code =
+      """
+        |println("Do you like muffins?")
+      """.stripMargin
+    assertScalaOutput(code) { (vars, output, displayed) =>
+      vars should have size 1
+      vars("kernel") shouldEqual polynote.runtime.Runtime
+
+      output should contain (Output("text/plain; rel=stdout", "Do you like muffins?"))
+    }
+  }
+}

--- a/polynote-server/src/main/scala/polynote/server/SocketSession.scala
+++ b/polynote-server/src/main/scala/polynote/server/SocketSession.scala
@@ -146,7 +146,6 @@ class SocketSession(
       }
       // TODO: do we need to emit a kernel status here any more?
 
-
     case req@CompletionsAt(notebook, id, pos, _) =>
       for {
         notebookRef <- getNotebook(notebook, oq)


### PR DESCRIPTION
* Refactor Python tests for better sharing
* Overhaul Global initialization by gutting PolyKernel and doing lots
  more in GlobalInfo
* Start on removing predef in favor of new init() method for kernels
* Some changes to PythonInterpreter to use init()
* Fixes stdout capture and #18