### PR TITLE
Disallow missing cell metadata on ipynb encode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,10 @@ val commonSettings = Seq(
     "-language:higherKinds",
     "-unchecked"
   ),
+  libraryDependencies ++= Seq(
+    "org.scalatest" %% "scalatest" % "3.0.5" % "test",
+    "org.scalacheck" %% "scalacheck" % "1.14.0" % "test"
+  ),
   fork := true,
   assemblyMergeStrategy in assembly := {
     case PathList("META-INF", "CHANGES") => MergeStrategy.discard
@@ -41,9 +45,7 @@ val `polynote-kernel` = project.settings(
     "io.circe" %% "circe-generic" % "0.10.0",
     "io.get-coursier" %% "coursier" % "1.1.0-M9",
     "io.get-coursier" %% "coursier-cache" % "1.1.0-M9",
-    "black.ninia" % "jep" % "3.8.2",
-    "org.scalatest" %% "scalatest" % "3.0.5" % "test",
-    "org.scalacheck" %% "scalacheck" % "1.14.0" % "test"
+    "black.ninia" % "jep" % "3.8.2"
   )
 ).dependsOn(`polynote-runtime`)
 

--- a/polynote-server/src/main/scala/polynote/server/repository/ipynb/ast.scala
+++ b/polynote-server/src/main/scala/polynote/server/repository/ipynb/ast.scala
@@ -1,6 +1,6 @@
 package polynote.server.repository.ipynb
 
-import io.circe.{Decoder, Encoder, Json, JsonObject}
+import io.circe._
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.syntax._
 import polynote.data.Rope
@@ -131,7 +131,10 @@ final case class JupyterCell(
 )
 
 object JupyterCell {
-  implicit val encoder: Encoder[JupyterCell] = deriveEncoder[JupyterCell]
+  implicit val encoder: ObjectEncoder[JupyterCell] = deriveEncoder[JupyterCell].contramapObject[JupyterCell] {
+    cell => if (cell.metadata.isEmpty) cell.copy(metadata = Some(JsonObject.empty)) else cell
+  }
+
   implicit val decoder: Decoder[JupyterCell] = deriveDecoder[JupyterCell]
 
   def toNotebookCell(cell: JupyterCell, index: Int): NotebookCell = {

--- a/polynote-server/src/test/scala/polynote/server/repository/ipynb/IPythonNotebookRepositorySpec.scala
+++ b/polynote-server/src/test/scala/polynote/server/repository/ipynb/IPythonNotebookRepositorySpec.scala
@@ -1,0 +1,16 @@
+package polynote.server.repository.ipynb
+
+import io.circe.JsonObject
+import org.scalatest.{FreeSpec, Matchers}
+import io.circe.syntax._
+
+class IPythonNotebookRepositorySpec extends FreeSpec with Matchers {
+
+  "adds blank cell metadata on encode" in {
+    // this is needed for compatibility with jupyter tooling
+    val cell = JupyterCell(Code, Some(1), metadata = None, Some("scala"), Nil, None).asJsonObject
+    assert(cell("metadata").isDefined)
+    cell("metadata").flatMap(_.asObject).get.keys.toList shouldEqual Nil
+  }
+
+}


### PR DESCRIPTION
Should fix #13

It would be great if there were a way to actually check compatibility with Jupyter tooling in the test suite... I'm all ears. But anecdotally this should fix the error when opening our ipynb files from Jupyter.