### PR TITLE
Fix typing of runtime elements; static types for python results

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,10 @@ val commonSettings = Seq(
 )
 
 val `polynote-runtime` = project.settings(
-  commonSettings
+  commonSettings,
+  libraryDependencies ++= Seq(
+    "black.ninia" % "jep" % "3.8.2"
+  )
 )
 
 val `polynote-kernel` = project.settings(
@@ -41,7 +44,6 @@ val `polynote-kernel` = project.settings(
     "io.circe" %% "circe-generic" % "0.10.0",
     "io.get-coursier" %% "coursier" % "1.1.0-M9",
     "io.get-coursier" %% "coursier-cache" % "1.1.0-M9",
-    "black.ninia" % "jep" % "3.8.2",
     "org.scalatest" %% "scalatest" % "3.0.5" % "test",
     "org.scalacheck" %% "scalacheck" % "1.14.0" % "test"
   )

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
@@ -143,7 +143,14 @@ class PythonInterpreter(val symbolTable: RuntimeSymbolTable) extends LanguageKer
     out: Enqueue[IO, Result],
     statusUpdates: Publish[IO, KernelStatusUpdate]
   ): IO[Unit] = if (code.trim().isEmpty) IO.unit else {
+    import symbolTable.global
+
     val stdout = new PythonDisplayHook(out)
+
+    global.demandNewCompilerRun()
+    val run = new global.Run()
+    global.newCompilationUnit("", cell)
+
     withJep {
 
       jep.set("__polynote_displayhook__", stdout)
@@ -182,13 +189,11 @@ class PythonInterpreter(val symbolTable: RuntimeSymbolTable) extends LanguageKer
         } else None
       } else None
 
-      (getPyResults(newDecls), maybeOutput)
+      (getPyResults(newDecls, cell), maybeOutput)
 
     }.flatMap {
       case (resultDict, maybeOutput) =>
-        val symbolPub = symbolTable.publishAll(resultDict.toList.filterNot(_._2 == null).map {
-          case (name, value) => symbolTable.RuntimeValue(name, value, Some(this), cell)
-        })
+        val symbolPub = symbolTable.publishAll(resultDict.filterNot(_._2.value == null).values.toList)
 
         maybeOutput
           .map(o => out.enqueue1(o))
@@ -200,32 +205,54 @@ class PythonInterpreter(val symbolTable: RuntimeSymbolTable) extends LanguageKer
     }
   }
 
-  def getPyResults(decls: Seq[String]): Map[String, Any] = {
-    decls.map { name =>
-      val resultType = jep.getValue(s"type($name).__name__", classOf[String])
-      val typedResult = resultType match {
-        case "int" => jep.getValue(name, classOf[java.lang.Number]).longValue()
-        case "float" => jep.getValue(name, classOf[java.lang.Number]).doubleValue()
-        case "str" => jep.getValue(name, classOf[String])
-        case "bool" => jep.getValue(name, classOf[java.lang.Boolean])
-        case "tuple" => getPyResults(Seq(s"list($name)"))
-        case "dict" =>
-          val numElements = jep.getValue(s"len($name)", classOf[java.lang.Number]).longValue()
-          val keyElems = (0L until numElements).map(n => s"list($name.items())[$n][0]")
-          val valElems = (0L until numElements).map(n => s"list($name.items())[$n][1]")
-
-          val keys = getPyResults(keyElems).values
-          val values = getPyResults(valElems).values
-          keys.zip(values).toMap
-        case "list" =>
-          val numElements = jep.getValue(s"len($name)", classOf[java.lang.Number]).longValue()
-          val elems = (0L until numElements).map(n => s"$name[$n]")
-          getPyResults(elems).values.toList
-        case "PyJObject" => jep.getValue(name)
-        case _ => jep.getValue(name, classOf[PyObject])
+  def getPyResults(decls: Seq[String], sourceCellId: String): Map[String, symbolTable.RuntimeValue] =
+    decls.map {
+      name => name -> {
+        getPyResult(name) match {
+          case (value, Some(typ)) => symbolTable.RuntimeValue(symbolTable.global.TermName(name), value, typ, Some(this), sourceCellId)
+          case (value, _) => symbolTable.RuntimeValue(name, value, Some(this), sourceCellId)
+        }
       }
-      name -> typedResult
     }.toMap
+
+  def getPyResult(accessor: String): (Any, Option[symbolTable.global.Type]) = {
+    val resultType = jep.getValue(s"type($accessor).__name__", classOf[String])
+    import symbolTable.global.{typeOf, weakTypeOf}
+    resultType match {
+      case "int" => jep.getValue(accessor, classOf[java.lang.Number]).longValue() -> Some(typeOf[Long])
+      case "float" => jep.getValue(accessor, classOf[java.lang.Number]).doubleValue() -> Some(typeOf[Double])
+      case "str" => jep.getValue(accessor, classOf[String]) -> Some(typeOf[String])
+      case "bool" => jep.getValue(accessor, classOf[java.lang.Boolean]).booleanValue() -> Some(typeOf[Boolean])
+      case "tuple" => getPyResult(s"list($accessor)")
+      case "dict" =>
+        val keys = getPyResult(s"list($accessor.keys())")._1.asInstanceOf[List[Any]]
+        val values = getPyResult(s"list($accessor.values())")._1.asInstanceOf[List[Any]]
+        keys.zip(values).toMap -> Some(typeOf[Map[Any, Any]])
+      case "list" =>
+        val numElements = jep.getValue(s"len($accessor)", classOf[java.lang.Number]).longValue()
+        val (elems, types) = (0L until numElements).map(n => getPyResult(s"$accessor[$n]")).toList.unzip
+
+
+
+        // TODO: below doesn't work... complains about PythonInterpreter not being in compiler classpath. Should it be?
+        //val listType = symbolTable.global.appliedType(typeOf[List[_]].typeConstructor, lubType)
+        val listType = symbolTable.global.ask {
+          () =>
+            val lubType = types.flatten.toList match {
+              case Nil      => typeOf[Any]
+              case typeList => try symbolTable.global.lub(typeList) catch {
+                case err: Throwable => typeOf[Any]
+              }
+            }
+            symbolTable.global.appliedType(typeOf[List[Any]].typeConstructor, lubType)
+        }
+
+        elems -> Some(listType)
+      case "PyJObject" =>
+        jep.getValue(accessor) -> Some(typeOf[AnyRef])
+      case _ =>
+        jep.getValue(accessor, classOf[PyObject]) -> Some(typeOf[PyObject])
+    }
   }
 
   override def completionsAt(

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
@@ -232,10 +232,6 @@ class PythonInterpreter(val symbolTable: RuntimeSymbolTable) extends LanguageKer
         val numElements = jep.getValue(s"len($accessor)", classOf[java.lang.Number]).longValue()
         val (elems, types) = (0L until numElements).map(n => getPyResult(s"$accessor[$n]")).toList.unzip
 
-
-
-        // TODO: below doesn't work... complains about PythonInterpreter not being in compiler classpath. Should it be?
-        //val listType = symbolTable.global.appliedType(typeOf[List[_]].typeConstructor, lubType)
         val listType = symbolTable.global.ask {
           () =>
             val lubType = types.flatten.toList match {

--- a/polynote-kernel/src/main/scala/polynote/kernel/util/GlobalInfo.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/GlobalInfo.scala
@@ -59,7 +59,13 @@ object GlobalInfo {
     val jars = dependencies.toList.flatMap(_._2).collect {
       case (_, file) if file.getName endsWith ".jar" => file
     }
-    val requiredPaths = List(pathOf(classOf[List[_]]), pathOf(polynote.runtime.Runtime.getClass), pathOf(classOf[scala.reflect.runtime.JavaUniverse]), pathOf(classOf[scala.tools.nsc.Global])).map {
+    val requiredPaths = List(
+      pathOf(classOf[List[_]]),
+      pathOf(polynote.runtime.Runtime.getClass),
+      pathOf(classOf[scala.reflect.runtime.JavaUniverse]),
+      pathOf(classOf[scala.tools.nsc.Global]),
+      pathOf(classOf[jep.python.PyObject])
+    ).distinct.map {
       case url if url.getProtocol == "file" => new File(url.getPath)
       case url => throw new IllegalStateException(s"Required path $url must be a local file, not ${url.getProtocol}")
     }


### PR DESCRIPTION
Fixes #17 in two ways:

- Better handling of runtime types – previously a runtime type that had type parameters would result in a type constructor being assigned as the static type. We can't recover the actual type parameters due to erasure, so instead we now fill in `Any` for them.
- Python interpreter now assigns static types to its results, to the best of its ability.