### PR TITLE
Fix KernelSpec to avoid race conditions

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
@@ -322,11 +322,11 @@ class PythonInterpreter(val symbolTable: RuntimeSymbolTable) extends LanguageKer
 object PythonInterpreter {
   class Factory extends LanguageKernel.Factory[IO] {
     override val languageName: String = "Python"
-    override def apply(dependencies: List[(String, File)], symbolTable: RuntimeSymbolTable): LanguageKernel[IO] =
+    override def apply(dependencies: List[(String, File)], symbolTable: RuntimeSymbolTable): PythonInterpreter =
       new PythonInterpreter(symbolTable)
   }
 
-  def factory(): LanguageKernel.Factory[IO] = new Factory()
+  def factory(): Factory = new Factory()
 
 }
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
@@ -182,10 +182,10 @@ class PythonInterpreter(val symbolTable: RuntimeSymbolTable) extends LanguageKer
       val newDecls = jep.getValue("list(__polynote_locals__.keys())", classOf[java.util.List[String]]).asScala.toList
 
       // TODO: We talked about potentially creating an `Out` map, inspired by ipython, instead of these resCell# vars
-      val maybeOutput = if (newDecls.last == resultName){
+      val maybeOutput = if (lastIsExpr) {
         val hasLastValue = jep.getValue(s"$resultName != None", classOf[java.lang.Boolean])
         if (hasLastValue) {
-          Option(Output("text/plain; rel=decl; lang=python", s"$resultName = ${jep.getValue(s"repr(${newDecls.last})", classOf[String])}"))
+          Option(Output("text/plain; rel=decl; lang=python", s"$resultName = ${jep.getValue(s"repr($resultName)", classOf[String])}"))
         } else None
       } else None
 
@@ -334,7 +334,7 @@ class PythonDisplayHook(out: Enqueue[IO, Result]) {
   private var current = ""
   def output(str: String): Unit =
     if (str != null && str.nonEmpty)
-      out.enqueue1(Output("text/plain; rel=stdout", str)).unsafeRunAsyncAndForget() // TODO: probably should do better than this
+      out.enqueue1(Output("text/plain; rel=stdout", str)).unsafeRunSync() // TODO: probably should do better than this
 
   def write(str: String): Unit = synchronized {
     current = current + str

--- a/polynote-kernel/src/test/scala/polynote/kernel/lang/KernelSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/lang/KernelSpec.scala
@@ -53,7 +53,7 @@ trait KernelSpec {
               statusUpdates =>
 
                 // without this, symbolTable.drain() doesn't do anything
-                symbolTable.subscribe()(_ => IO.unit)
+                symbolTable.subscribe()(_ => IO.unit).prefetch
 
                 for {
                   // publishes to symbol table as a side-effect


### PR DESCRIPTION
Changes KernelSpec to actually wait until all output and symbols are published before running assertion. This should fix test flakiness in travis.