### PR TITLE
Fix spark assembly

### DIFF
--- a/polynote-spark/src/main/scala/polynote/kernel/SparkPolyKernel.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/SparkPolyKernel.scala
@@ -41,17 +41,18 @@ class SparkPolyKernel(
 
   val global = globalInfo.global
 
+  val polynoteRuntimeJar = "polynote-runtime.jar"
+
   private def runtimeJar(tmp: Path) = {
-    val resourceURL = getClass.getClassLoader.getResource("polynote-runtime.jar")
+    val resourceURL = getClass.getClassLoader.getResource(polynoteRuntimeJar)
     resourceURL.getProtocol match {
       case "jar" =>
-        val jarConn = resourceURL.openConnection().asInstanceOf[JarURLConnection]
         val jarFS = FileSystems.newFileSystem(
-          jarConn.getJarFileURL.toURI,
+          resourceURL.toURI,
           Collections.emptyMap[String, Any]
         )
-        val inPath = jarFS.getPath(jarConn.getEntryName)
-        val runtimeJar = new File(tmp.toFile, "polynote-runtime.jar").toPath
+        val inPath = jarFS.getPath(polynoteRuntimeJar)
+        val runtimeJar = new File(tmp.toFile, polynoteRuntimeJar).toPath
         Files.copy(inPath, runtimeJar, StandardCopyOption.REPLACE_EXISTING)
         runtimeJar
 


### PR DESCRIPTION
Fix the 
```
java.lang.IllegalArgumentException: Path component should be '/'
        at sun.nio.fs.UnixFileSystemProvider.checkUri(UnixFileSystemProvider.java:77)
        at sun.nio.fs.UnixFileSystemProvider.newFileSystem(UnixFileSystemProvider.java:86)
        at java.nio.file.FileSystems.newFileSystem(FileSystems.java:326)
        at java.nio.file.FileSystems.newFileSystem(FileSystems.java:276)
        at polynote.kernel.SparkPolyKernel.runtimeJar(SparkPolyKernel.scala:49)
        at polynote.kernel.SparkPolyKernel.dependencyJars$lzycompute(SparkPolyKernel.scala:75)
        at polynote.kernel.SparkPolyKernel.dependencyJars(SparkPolyKernel.scala:63)
        at polynote.kernel.SparkPolyKernel.polynote$kernel$SparkPolyKernel$$session$lzycompute(SparkPolyKernel.scala:97)
        at polynote.kernel.SparkPolyKernel.polynote$kernel$SparkPolyKernel$$session(SparkPolyKernel.scala:94)
        at polynote.kernel.SparkPolyKernel$$anonfun$2$$anonfun$apply$4$$anonfun$apply$5.apply(SparkPolyKernel.scala:131)
        at polynote.kernel.SparkPolyKernel$$anonfun$2$$anonfun$apply$4$$anonfun$apply$5.apply(SparkPolyKernel.scala:131)
``` 

we get when trying to run using the assembly jar. 