### PR TITLE
Remove proliferation of `oq`

### DIFF
--- a/polynote-server/src/main/scala/polynote/server/Server.scala
+++ b/polynote-server/src/main/scala/polynote/server/Server.scala
@@ -46,7 +46,7 @@ trait Server extends IOApp with Http4sDsl[IO] {
 
   def route(implicit timer: Timer[IO]): HttpRoutes[IO] = {
     HttpRoutes.of[IO] {
-      case GET -> Root / "ws" => new SocketSession(notebookManager).toResponse
+      case GET -> Root / "ws" => SocketSession(notebookManager).flatMap(_.toResponse)
       case req @ GET -> Root  => serveFile(indexFile, req)
       case req @ GET -> Root / "notebook" / _ => serveFile(indexFile, req)
       case req @ GET -> path  =>

--- a/polynote-server/src/main/scala/polynote/server/SocketSession.scala
+++ b/polynote-server/src/main/scala/polynote/server/SocketSession.scala
@@ -9,10 +9,11 @@ import cats.syntax.all._
 import cats.instances.list._
 import cats.~>
 import fs2.Stream
-import fs2.concurrent.{Queue, SignallingRef, Topic}
+import fs2.concurrent.{Enqueue, Queue, SignallingRef, Topic}
 import org.http4s.Response
 import org.http4s.server.websocket.WebSocketBuilder
-import org.http4s.websocket.WebSocketFrame, WebSocketFrame._
+import org.http4s.websocket.WebSocketFrame
+import WebSocketFrame._
 import org.log4s.getLogger
 import polynote.kernel._
 import polynote.kernel.util.{ReadySignal, WindowBuffer}
@@ -24,8 +25,7 @@ import scala.collection.JavaConverters._
 
 class SocketSession(
   notebookManager: NotebookManager[IO],
-  inBufferLength: Int = 100,
-  outBufferLength: Int = 100)(implicit
+  oq: Queue[IO, Message])(implicit
   contextShift: ContextShift[IO],
   timer: Timer[IO]
 ) {
@@ -54,17 +54,8 @@ class SocketSession(
     } yield ()
   }
 
-  lazy val toResponse: IO[Response[IO]] = {
-    for {
-      iq <- Queue.bounded[IO, WebSocketFrame](inBufferLength)
-      oq <- Queue.bounded[IO, Message](outBufferLength)
-    } yield {
-
-      val fromClient = iq.enqueue
-
-      // TODO: handle continuations/non-final?
-
-
+  lazy val toResponse: IO[Response[IO]] = Queue.unbounded[IO, WebSocketFrame].flatMap {
+    iq =>
       /**
         * The evaluation semantics here are tricky. respond() is going to return a suspension which contains a
         * Stream with its own suspensions. We want to allow both the outer suspensions and the inner suspensions
@@ -77,7 +68,7 @@ class SocketSession(
       val responses = iq.dequeue.evalMap {
 
         case Binary(bytes, true) => Message.decode[IO](bytes).flatMap {
-          message => respond(message, oq).start
+          message => respond(message).start
         }
 
         case Close(data) => IO.pure(Stream.eval(shutdown()).drain).start
@@ -108,17 +99,17 @@ class SocketSession(
           }
         }.interruptWhen(closeSignal())
 
-      WebSocketBuilder[IO].build(toClient, fromClient, onClose = IO.delay(shutdown()).flatten) <* oq.enqueue1(handshake)
-    }
-  }.flatten
+      WebSocketBuilder[IO].build(toClient, iq.enqueue, onClose = IO.delay(shutdown()).flatten) <* oq.enqueue1(handshake)
+  }
 
-  private def getNotebook(path: String, oq: Queue[IO, Message]) = loadingNotebook.acquire.bracket { _ =>
+  private def getNotebook(path: String) = loadingNotebook.acquire.bracket { _ =>
     Option(notebooks.get(path)).map(IO.pure).getOrElse {
       notebookManager.getNotebook(path).flatMap {
-        sharedNotebook =>
-          sharedNotebook.open(name, oq).flatMap {
-            notebookRef => IO { notebooks.put(path, notebookRef); () }.as(notebookRef)
-          }
+        sharedNotebook => for {
+          notebookRef <- sharedNotebook.open(name)
+          _            = notebooks.put(path, notebookRef)
+          _           <- notebookRef.messages.interruptWhen(closeSignal()).through(oq.enqueue).compile.drain.start
+        } yield notebookRef
       }
     }
   }(_ => loadingNotebook.release)
@@ -126,14 +117,14 @@ class SocketSession(
   private def handshake: ServerHandshake =
     ServerHandshake(notebookManager.interpreterNames.asInstanceOf[TinyMap[TinyString, TinyString]])
 
-  def respond(message: Message, oq: Queue[IO, Message]): IO[Stream[IO, Message]] = message match {
+  def respond(message: Message): IO[Stream[IO, Message]] = message match {
     case ListNotebooks(_) =>
       notebookManager.listNotebooks().map {
         notebooks => Stream.emit(ListNotebooks(notebooks.asInstanceOf[List[ShortString]]))
       }
 
     case LoadNotebook(path) =>
-      getNotebook(path, oq).map {
+      getNotebook(path).map {
         notebookRef =>
           Stream.eval(notebookRef.get) ++ Stream.eval(notebookRef.currentStatus).map(KernelStatus(path, _))
       }
@@ -149,7 +140,7 @@ class SocketSession(
 
 
     case upConfig @ UpdateConfig(path, _, _, config) =>
-      getNotebook(path, oq).flatMap {
+      getNotebook(path).flatMap {
         notebookRef => notebookRef.update(upConfig).flatMap {
           globalVersion =>
             notebookRef.isKernelStarted.flatMap {
@@ -161,39 +152,39 @@ class SocketSession(
 
 
     case NotebookUpdate(update) =>
-      getNotebook(update.notebook, oq).flatMap {
+      getNotebook(update.notebook).flatMap {
         notebookRef => notebookRef.update(update).map(globalVersion => Stream.empty) // TODO: notify client of global version
       }
 
     case RunCell(path, ids) =>
-      getNotebook(path, oq).flatMap {
+      getNotebook(path).flatMap {
         notebookRef => notebookRef.runCells(ids)
       }
       // TODO: do we need to emit a kernel status here any more?
 
     case req@CompletionsAt(notebook, id, pos, _) =>
       for {
-        notebookRef <- getNotebook(notebook, oq)
+        notebookRef <- getNotebook(notebook)
         kernel      <- notebookRef.getKernel
         completions <- kernel.completionsAt(id, pos).handleErrorWith(err => IO(err.printStackTrace(System.err)).map(_ => Nil))
       } yield Stream.emit(req.copy(completions = ShortList(completions)))
 
     case req@ParametersAt(notebook, id, pos, _) =>
       for {
-        notebookRef <- getNotebook(notebook, oq)
+        notebookRef <- getNotebook(notebook)
         kernel      <- notebookRef.getKernel
         parameters  <- kernel.parametersAt(id, pos)
       } yield Stream.emit(req.copy(signatures = parameters))
 
     case KernelStatus(path, _) =>
       for {
-        notebookRef <- getNotebook(path, oq)
+        notebookRef <- getNotebook(path)
         status      <- notebookRef.currentStatus
       } yield Stream.emit(KernelStatus(path, status))
 
     case StartKernel(path, StartKernel.NoRestart) =>
       for {
-        notebookRef <- getNotebook(path, oq)
+        notebookRef <- getNotebook(path)
         kernel      <- notebookRef.getKernel
         status      <- notebookRef.currentStatus
       } yield Stream.emit(KernelStatus(path, status))
@@ -201,14 +192,14 @@ class SocketSession(
     case StartKernel(path, StartKernel.WarmRestart) => ??? // TODO
     case StartKernel(path, StartKernel.ColdRestart) =>
       for {
-        notebookRef <- getNotebook(path, oq)
+        notebookRef <- getNotebook(path)
         _           <- notebookRef.restartKernel()
         status      <- notebookRef.currentStatus
       } yield Stream.emit(KernelStatus(path, status))
 
     case StartKernel(path, StartKernel.Kill) =>
       for {
-        notebookRef <- getNotebook(path, oq)
+        notebookRef <- getNotebook(path)
         _           <- notebookRef.shutdownKernel()
         status      <- notebookRef.currentStatus
       } yield Stream.emit(KernelStatus(path, status))
@@ -221,5 +212,17 @@ class SocketSession(
   def badMsgErr(msg: WebSocketFrame) = Error(1, new RuntimeException(s"Received bad message frame ${truncate(msg.toString, 32)}"))
 
   def truncate(str: String, len: Int): String = if (str.length < len) str else str.substring(0, len - 4) + "..."
+
+}
+
+object SocketSession {
+
+  def apply(
+    notebookManager: NotebookManager[IO])(implicit
+    contextShift: ContextShift[IO],
+    timer: Timer[IO]
+  ): IO[SocketSession] = Queue.unbounded[IO, Message].map {
+    oq => new SocketSession(notebookManager, oq)
+  }
 
 }


### PR DESCRIPTION
It seems a bit backwards that many functions take an `oq` argument,
which is a queue to which to write. This PR tries to start unwinding
that.

- `SharedNotebook#open` doesn't take an `oq` anymore. Instead, `NotebookRef` has a `messages` stream. This changes the handling of broadcast messages from push to pull, which is a good thing and much more in line with how fs2 is supposed to be used (I think)
- `SocketSession#respond` doesn't take an `oq` anymore. Instead, the `oq` is a private class member and there is an `IO` constructor in the companion which creates it. When a new `NotebookRef` is opened, SocketSession handles piping its messages to the output queue.