### PR TITLE
More straightforward handling of results

### DIFF
--- a/polynote-frontend/polynote/result.js
+++ b/polynote-frontend/polynote/result.js
@@ -5,7 +5,7 @@ import {
     str, shortStr, tinyStr, uint8, uint16, int32
 } from './codec.js'
 
-import { ValueRepr, StringRepr } from './value_repr.js'
+import { ValueRepr, StringRepr, MIMERepr } from './value_repr.js'
 
 export class Result {
     static decode(data) {
@@ -216,6 +216,23 @@ export class ResultValue extends Result {
         const index = this.reprs.findIndex(repr => repr instanceof StringRepr);
         if (index < 0) return "";
         return this.reprs[index].string;
+    }
+
+    /**
+     * Get a default MIME type and string, for display purposes
+     */
+    get displayRepr() {
+        // TODO: make this smarter
+        let index = this.reprs.findIndex(repr => repr instanceof MIMERepr && repr.mimeType.startsWith("text/html"));
+        if (index < 0)
+            index = this.reprs.findIndex(repr => repr instanceof MIMERepr && repr.mimeType.startsWith("text/"));
+
+        if (index < 0) {
+            return ["text/plain", this.valueText];
+        } else {
+            return MIMERepr.unapply(this.reprs[index]);
+        }
+
     }
 }
 

--- a/polynote-frontend/polynote/ui.js
+++ b/polynote-frontend/polynote/ui.js
@@ -879,6 +879,9 @@ export class NotebookUI {
                         cell.addResult(result.contentType, result.content);
                     } else if (result instanceof ClearResults) {
                         cell.clearResult();
+                    } else if (result instanceof ResultValue) {
+                        const [mime, content] = result.displayRepr;
+                        cell.addResult(mime, content);
                     }
                 }
 
@@ -929,6 +932,9 @@ export class NotebookUI {
                             cell.setRuntimeError(result.error)
                         } else if (result instanceof Output) {
                             cell.addResult(result.contentType, result.content)
+                        } else if (result instanceof ResultValue) {
+                            const [mime, content] = result.displayRepr;
+                            cell.addResult(mime, content);
                         }
                     }
                 )

--- a/polynote-frontend/polynote/value_repr.js
+++ b/polynote-frontend/polynote/value_repr.js
@@ -25,21 +25,22 @@ export class StringRepr extends ValueRepr {
 
 StringRepr.codec = combined(str).to(StringRepr);
 
-export class HTMLRepr extends ValueRepr {
+export class MIMERepr extends ValueRepr {
     static get msgTypeId() { return 1; }
 
     static unapply(inst) {
-        return [inst.html];
+        return [inst.mimeType, inst.content];
     }
 
-    constructor(html) {
-        super(html);
-        this.html = html;
+    constructor(mimeType, content) {
+        super(mimeType, content);
+        this.mimeType = mimeType;
+        this.content = content;
         Object.freeze(this);
     }
 }
 
-HTMLRepr.codec = combined(str).to(HTMLRepr);
+MIMERepr.codec = combined(str, str).to(MIMERepr);
 
 export class DataRepr extends ValueRepr {
     static get msgTypeId() { return 2; }
@@ -112,7 +113,7 @@ StreamingDataRepr.codec = combined(int32, DataType.codec, uint32).to(StreamingDa
 
 ValueRepr.codecs = [
     StringRepr,        // 0
-    HTMLRepr,          // 1
+    MIMERepr,          // 1
     DataRepr,          // 2
     LazyDataRepr,      // 3
     UpdatingDataRepr,  // 4

--- a/polynote-kernel/src/main/scala/polynote/kernel/PolyKernel.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/PolyKernel.scala
@@ -64,7 +64,7 @@ class PolyKernel private[kernel] (
           results => results.collect {
             case v: ResultValue => v
           }.evalTap {
-            v => symbolTable.publishAll(List(symbolTable.RuntimeValue.fromResultValue(v, interp)))
+            v => symbolTable.publishAll(symbolTable.RuntimeValue.fromResultValue(v, interp).toList)
           }
         }
 
@@ -153,7 +153,7 @@ class PolyKernel private[kernel] (
                     ).map {
                       results => predefResults merge results.evalMap {
                         case v: ResultValue =>
-                          symbolTable.publishAll(List(symbolTable.RuntimeValue.fromResultValue(v, interp))).as(v)
+                          symbolTable.publishAll(symbolTable.RuntimeValue.fromResultValue(v, interp).toList).as(v)
                         case result =>
                           IO.pure(result)
                       }

--- a/polynote-kernel/src/main/scala/polynote/kernel/Result.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/Result.scala
@@ -144,7 +144,12 @@ final case class ResultValue(
   sourceCell: TinyString,
   value: Any,
   scalaType: Universe#Type
-) extends Result
+) extends Result {
+
+  // TODO: better way to handle "the result" of the cell. Maybe name should be optional?
+  def isCellResult: Boolean = name startsWith "res"
+
+}
 
 object ResultValue extends ResultCompanion[ResultValue](4) {
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/ValueRepr.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/ValueRepr.scala
@@ -38,10 +38,10 @@ final case class StringRepr(string: String) extends ValueRepr
 object StringRepr extends ValueReprCompanion[StringRepr](0)
 
 /**
-  * An HTML representation of a value
+  * A MIME representation of a value. Binary values must be base64-encoded.
   */
-final case class HTMLRepr(html: String) extends ValueRepr
-object HTMLRepr extends ValueReprCompanion[HTMLRepr](1)
+final case class MIMERepr(mimeType: String, content: String) extends ValueRepr
+object MIMERepr extends ValueReprCompanion[MIMERepr](1)
 
 /**
   * A binary representation of a value, encoded in Polynote's format (TODO)

--- a/polynote-kernel/src/main/scala/polynote/kernel/util/RuntimeSymbolTable.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/RuntimeSymbolTable.scala
@@ -127,9 +127,10 @@ final class RuntimeSymbolTable(
       }
     }
 
-    def fromResultValue(resultValue: ResultValue, source: LanguageInterpreter[IO]): RuntimeValue = resultValue match {
+    def fromResultValue(resultValue: ResultValue, source: LanguageInterpreter[IO]): Option[RuntimeValue] = resultValue match {
+      case ResultValue(_, _, _, _, Unit, _) => None
       case ResultValue(name, typeName, reprs, sourceCell, value, scalaType) =>
-        apply(name, value, scalaType.asInstanceOf[global.Type], Option(source), sourceCell)
+        Some(apply(name, value, scalaType.asInstanceOf[global.Type], Option(source), sourceCell))
     }
   }
 

--- a/polynote-kernel/src/test/scala/polynote/kernel/lang/KernelSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/lang/KernelSpec.scala
@@ -66,7 +66,7 @@ trait KernelSpec {
         results <- interp.runCode("test", symbolTable.currentTerms.map(_.asInstanceOf[interp.Decl]), Nil, code)
         output  <- results.evalMap {
             case v: ResultValue =>
-              symbolTable.publishAll(symbolTable.RuntimeValue.fromResultValue(v, interp) :: Nil).map { _ =>
+              symbolTable.publishAll(symbolTable.RuntimeValue.fromResultValue(v, interp).toList).map { _ =>
                 None
               }
             case result =>


### PR DESCRIPTION
- `ResultValue` gets published as `exec_result` to ipynb notebooks if it's "the result" of the cell. `Output` always gets published as `stream` or `display_data`.
- Made `HTMLRepr` a more general `MIMERepr` (hmmm, looks a bit like `Output` now...)
- I think we should remove the `resCell1: Int = 10` output, and just show `10`. That isn't done in this PR; so currently cell results are duplicated in the output (once with the name/type, once without).