### PR TITLE
Add a server config file

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,7 @@ val `polynote-kernel` = project.settings(
     "org.scodec" %% "scodec-core" % "1.10.3",
     "io.circe" %% "circe-yaml" % "0.9.0",
     "io.circe" %% "circe-generic" % "0.10.0",
+    "io.circe" %% "circe-generic-extras" % "0.10.0",
     "io.get-coursier" %% "coursier" % "1.1.0-M9",
     "io.get-coursier" %% "coursier-cache" % "1.1.0-M9"
   )
@@ -66,7 +67,6 @@ val `polynote-server` = project.settings(
     "org.http4s" %% "http4s-dsl" % versions.http4s,
     "org.http4s" %% "http4s-blaze-server" % versions.http4s,
     "org.scodec" %% "scodec-core" % "1.10.3",
-    "io.circe" %% "circe-generic-extras" % "0.10.0",
     "io.circe" %% "circe-parser" % "0.10.0",
     "com.vladsch.flexmark" % "flexmark" % "0.34.32",
     "com.vladsch.flexmark" % "flexmark-ext-yaml-front-matter" % "0.34.32",

--- a/config-template.yml
+++ b/config-template.yml
@@ -1,0 +1,24 @@
+# The host and port can be set by uncommenting and editing the following lines:
+#listen:
+#  host: 0.0.0.0
+#  port: 8192
+
+# Default repositories can be specified. Uncommenting the following lines would add four default repositories which are inherited by new notebooks.
+#repositories:
+#  - ivy:
+#      base: https://my-artifacts.org/artifacts/
+#  - ivy:
+#      base: https://my-custom-ivy-repo.org/artifacts/
+#      artifact_pattern: [orgPath]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]
+#      metadata_pattern: [orgPath]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[module](_[scalaVersion])(_[sbtVersion])-[revision]-ivy.xml
+#      changing: true
+#  - maven:
+#      base: http://central.maven.org/maven2/
+#  - maven:
+#      base: http://oss.sonatype.org/content/repositories/snapshots
+#      changing: true
+
+# Default dependencies can be specified. Uncommenting the following lines would add default dependencies for the Scala interpreter, which are inherited by new notebooks.
+#dependencies:
+#  - org.typelevel:cats-core_2.11:1.6.0
+#  - com.mycompany:my-library:jar:all:1.0.0

--- a/polynote-frontend/polynote/ui.js
+++ b/polynote-frontend/polynote/ui.js
@@ -397,6 +397,7 @@ export class NotebookConfigUI extends EventTarget {
                         if (this.lastConfig) {
                             this.setConfig(this.lastConfig);
                         }
+                        this.el.classList.remove("open");
                     })
                 ])
             ])
@@ -453,8 +454,24 @@ export class NotebookConfigUI extends EventTarget {
         this.resolverContainer.insertBefore(row, this.resolverRowTemplate);
     }
 
+    clearConfig() {
+        while (this.dependencyContainer.childNodes.length > 0) {
+            this.dependencyContainer.removeChild(this.dependencyContainer.childNodes[0]);
+        }
+        this.dependencyContainer.appendChild(this.dependencyRowTemplate);
+        [...this.dependencyContainer.querySelectorAll('input')].forEach(input => input.value = '');
+
+        while (this.resolverContainer.childNodes.length > 0) {
+            this.resolverContainer.removeChild(this.resolverContainer.childNodes[0]);
+        }
+        this.resolverContainer.appendChild(this.resolverRowTemplate);
+        [...this.resolverContainer.querySelectorAll('input')].forEach(input => input.value = '');
+    }
+
     setConfig(config) {
         this.lastConfig = config;
+        this.clearConfig();
+
         if (config.dependencies && config.dependencies.scala) {
             for (const dep of config.dependencies.scala) {
                 this.addDependency(dep);

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -1538,9 +1538,8 @@ button {
   }
 
   .resolver-row {
-    input {
-      width: 33em;
-    }
+    display: grid;
+    grid-template-columns: 7em 2fr 1fr 1fr 32px;
 
     select {
       width: 7em;
@@ -1553,7 +1552,7 @@ button {
 
   .resolver-row.ivy {
     input.ivy {
-      display: inline-block;
+      display: block;
     }
   }
 

--- a/polynote-kernel/src/main/scala/polynote/config/package.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/package.scala
@@ -3,7 +3,9 @@ package polynote
 import io.circe.{Decoder, ObjectEncoder}
 import polynote.messages.{TinyList, TinyMap, TinyString}
 import scodec.codecs.{Discriminated, Discriminator, byte}
-import io.circe.generic.semiauto._
+import io.circe.generic.extras.JsonKey
+import io.circe.generic.extras.semiauto._
+import io.circe.generic.extras.defaults._
 import scodec.Codec
 
 package object config {
@@ -12,13 +14,15 @@ package object config {
   sealed trait RepositoryConfig
   final case class ivy(
     base: String,
-    artifactPatternOpt: Option[String] = None,
-    metadataPatternOpt: Option[String] = None,
+    @JsonKey("artifact_pattern") artifactPatternOpt: Option[String] = None,
+    @JsonKey("metadata_pattern") metadataPatternOpt: Option[String] = None,
     changing: Option[Boolean] = None
   ) extends RepositoryConfig {
 
     def artifactPattern: String = artifactPatternOpt.getOrElse("[orgPath]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]")
     def metadataPattern: String = metadataPatternOpt.getOrElse("[orgPath]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[module](_[scalaVersion])(_[sbtVersion])-[revision]-ivy.xml")
+
+
   }
 
   object ivy {

--- a/polynote-kernel/src/main/scala/polynote/config/package.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/package.scala
@@ -1,6 +1,6 @@
 package polynote
 
-import io.circe.{Decoder, Encoder}
+import io.circe.{Decoder, ObjectEncoder}
 import polynote.messages.{TinyList, TinyMap, TinyString}
 import scodec.codecs.{Discriminated, Discriminator, byte}
 import io.circe.generic.semiauto._
@@ -37,7 +37,7 @@ package object config {
   object RepositoryConfig {
 
     implicit val discriminated: Discriminated[RepositoryConfig, Byte] = Discriminated(byte)
-    implicit val encoder: Encoder[RepositoryConfig] = deriveEncoder
+    implicit val encoder: ObjectEncoder[RepositoryConfig] = deriveEncoder
     implicit val decoder: Decoder[RepositoryConfig] = deriveDecoder
   }
 

--- a/polynote-server/src/main/scala/polynote/server/NotebookManager.scala
+++ b/polynote-server/src/main/scala/polynote/server/NotebookManager.scala
@@ -28,6 +28,7 @@ abstract class NotebookManager[F[_]](implicit F: Monad[F]) {
 }
 
 class IONotebookManager(
+  serverConfig: ServerConfig,
   repository: NotebookRepository[IO],
   kernelFactory: KernelFactory[IO])(implicit
   contextShift: ContextShift[IO]

--- a/polynote-server/src/main/scala/polynote/server/Server.scala
+++ b/polynote-server/src/main/scala/polynote/server/Server.scala
@@ -7,9 +7,10 @@ import cats.effect._
 import org.http4s._
 import org.http4s.dsl.Http4sDsl
 import org.http4s.server.blaze.BlazeBuilder
-import org.log4s.getLogger
+import org.log4s.{Logger, getLogger}
 import polynote.kernel.dependency.CoursierFetcher
 import polynote.kernel.lang.{LanguageInterpreter, LanguageInterpreterService}
+import polynote.server.repository.NotebookRepository
 import polynote.server.repository.ipynb.IPythonNotebookRepository
 
 import scala.collection.JavaConverters._
@@ -22,29 +23,23 @@ trait Server extends IOApp with Http4sDsl[IO] {
 
   private implicit val executionContext: ExecutionContext = ExecutionContext.global  // TODO: use a real one
 
-  protected val logger = getLogger
-
-  protected val repository = new IPythonNotebookRepository(
-    new File(System.getProperty("user.dir")).toPath.resolve("notebooks"),
-    executionContext = executionContext)
-
+  protected val logger: Logger = getLogger
   protected val dependencyFetcher = new CoursierFetcher()
 
-  protected val subKernels = ServiceLoader.load(classOf[LanguageInterpreterService]).iterator.asScala.toSeq
-    .sortBy(_.priority)
-    .foldLeft(Map.empty[String, LanguageInterpreter.Factory[IO]]) {
-      (accum, next) => accum ++ next.interpreters
-    }
+  protected val interpreters: Map[String, LanguageInterpreter.Factory[IO]] =
+    ServiceLoader.load(classOf[LanguageInterpreterService]).iterator.asScala.toSeq
+      .sortBy(_.priority)
+      .foldLeft(Map.empty[String, LanguageInterpreter.Factory[IO]]) {
+        (accum, next) => accum ++ next.interpreters
+      }
 
-  protected lazy val kernelFactory: KernelFactory[IO] = new IOKernelFactory(Map("scala" -> dependencyFetcher), subKernels)
-
-  protected val notebookManager = new IONotebookManager(repository, kernelFactory)
+  protected lazy val kernelFactory: KernelFactory[IO] = new IOKernelFactory(Map("scala" -> dependencyFetcher), interpreters)
 
   def serveFile(path: String, req: Request[IO])(implicit syncIO: Sync[IO]): IO[Response[IO]] = {
     StaticFile.fromResource(path, executionContext, Some(req)).getOrElseF(NotFound())
   }
 
-  def route(implicit timer: Timer[IO]): HttpRoutes[IO] = {
+  def route(notebookManager: NotebookManager[IO])(implicit timer: Timer[IO]): HttpRoutes[IO] = {
     HttpRoutes.of[IO] {
       case GET -> Root / "ws" => SocketSession(notebookManager).flatMap(_.toResponse)
       case req @ GET -> Root  => serveFile(indexFile, req)
@@ -54,43 +49,72 @@ trait Server extends IOApp with Http4sDsl[IO] {
     }
   }
 
-  Ok.apply("foo")
+  protected def splash: IO[Unit] = IO {
+    logger.info(
+      raw"""
+           |
+           |  _____      _                   _
+           | |  __ \    | |                 | |
+           | | |__) |__ | |_   _ _ __   ___ | |_ ___
+           | |  ___/ _ \| | | | | '_ \ / _ \| __/ _ \
+           | | |  | (_) | | |_| | | | | (_) | ||  __/
+           | |_|   \___/|_|\__, |_| |_|\___/ \__\___|
+           |                __/ |
+           |               |___/
+           |
+           |""".stripMargin)
+  }
 
-  def run(args: List[String]): IO[ExitCode] = {
+  protected def createRepository(serverConfig: ServerConfig): NotebookRepository[IO] = new IPythonNotebookRepository(
+    new File(System.getProperty("user.dir")).toPath.resolve("notebooks"),
+    serverConfig,
+    executionContext = executionContext)
+
+  def run(args: List[String]): IO[ExitCode] = for {
     // note, by default our bdas genie script sets log4j.configuration to a nonexistent log4j config. We should either
     // create that config or remove that setting. Until then, be sure to add `--driver-java-options "-Dlog4j.configuration=log4j.properties"
     // to your `spark-submit` call.
+    args            <- parseArgs(args)
+    config          <- ServerConfig.load(args.configFile)
+    port             = config.listen.port
+    address          = config.listen.address
+    host             = if (address == "0.0.0.0") java.net.InetAddress.getLocalHost.getHostAddress else address
+    url              = s"http://$host:$port"
+    _               <- splash
+    _               <- IO(logger.info(s" Running on $url"))
+    repository       = createRepository(config)
+    notebookManager  = new IONotebookManager(config, repository, kernelFactory)
 
-    val port = 8192 // TODO: replace with proper config eventually
-    val hostname = s"http://${java.net.InetAddress.getLocalHost.getHostAddress}:$port"
+    exitCode        <- BlazeBuilder[IO]
+                        .bindHttp(port, address)
+                        .withWebSockets(true)
+                        .mountService(route(notebookManager), "/")
+                        .serve
+                        .compile
+                        .toList
+                        .map(_.head)
+  } yield exitCode
 
-    logger.info(
-      raw"""
-        |
-        |  _____      _                   _
-        | |  __ \    | |                 | |
-        | | |__) |__ | |_   _ _ __   ___ | |_ ___
-        | |  ___/ _ \| | | | | '_ \ / _ \| __/ _ \
-        | | |  | (_) | | |_| | | | | (_) | ||  __/
-        | |_|   \___/|_|\__, |_| |_|\___/ \__\___|
-        |                __/ |
-        |               |___/
-        |
-        |
-        | Running on $hostname
-        |
-      """.stripMargin)
+  protected def parseArgs(args: List[String]): IO[ServerArgs] = IO.fromEither(Server.parseArgs(args))
 
-    BlazeBuilder[IO]
-      .bindHttp(port, "0.0.0.0")
-      .withWebSockets(true)
-      .mountService(route, "/")
-      .serve
-      .compile
-      .toList
-      .map(_.head)
+}
+
+object Server {
+
+  case class Args(
+    configFile: File = new File("config.yml")
+  ) extends ServerArgs
+
+  private def parseArgs(args: List[String], current: Args = Args()): Either[Throwable, Args] = args match {
+    case Nil => Right(current)
+    case ("--config" | "-c") :: filename :: rest => parseArgs(rest, current.copy(configFile = new File(filename)))
+    case other :: rest => Left(new IllegalArgumentException(s"Unknown argument $other"))
   }
 
+}
+
+trait ServerArgs {
+  def configFile: File
 }
 
 

--- a/polynote-server/src/main/scala/polynote/server/ServerConfig.scala
+++ b/polynote-server/src/main/scala/polynote/server/ServerConfig.scala
@@ -1,0 +1,50 @@
+package polynote.server
+
+import java.io.{File, FileNotFoundException, FileReader}
+
+import cats.effect.IO
+import cats.syntax.either._
+import cats.syntax.functor._
+import io.circe.generic.extras.Configuration
+import io.circe.generic.extras.encoding.ConfiguredObjectEncoder
+import io.circe.generic.extras.semiauto._
+import io.circe.{Decoder, ObjectEncoder}
+import io.circe.yaml
+import org.log4s.{Logger, getLogger}
+import polynote.config.{DependencyConfigs, RepositoryConfig}
+import polynote.messages.TinyMap
+
+final case class Listen(
+  port: Int = 8192,
+  address: String = "0.0.0.0"
+)
+
+object Listen {
+  implicit val encoder: ObjectEncoder[Listen] = deriveEncoder
+  implicit val decoder: Decoder[Listen] = deriveDecoder
+}
+
+final case class ServerConfig(
+  listen: Listen = Listen(),
+  repositories: List[RepositoryConfig] = Nil,
+  dependencies: Map[String, List[String]] = Map.empty
+)
+
+
+object ServerConfig {
+  implicit val encoder: ObjectEncoder[ServerConfig] = deriveEncoder
+  implicit val decoder: Decoder[ServerConfig] = deriveDecoder
+
+  private val logger: Logger = getLogger
+
+  def parse(content: String): Either[Throwable, ServerConfig] = yaml.parser.parse(content).flatMap(_.as[ServerConfig])
+
+  def load(file: File): IO[ServerConfig] = IO(new FileReader(file)).bracket {
+    reader => IO.fromEither(yaml.parser.parse(reader).flatMap(_.as[ServerConfig]))
+  }(reader => IO(reader.close())).handleErrorWith {
+    case err: FileNotFoundException =>
+      IO(logger.warn(s"Configuration file $file not found; using default configuration")).as(new ServerConfig())
+    case err: Throwable => IO.raiseError(err)
+  }
+
+}

--- a/polynote-server/src/main/scala/polynote/server/package.scala
+++ b/polynote-server/src/main/scala/polynote/server/package.scala
@@ -1,0 +1,8 @@
+package polynote
+
+import io.circe.generic.extras.Configuration
+
+package object server {
+  implicit val circeConfig: Configuration =
+    Configuration.default.withSnakeCaseConstructorNames.withSnakeCaseMemberNames.withDefaults
+}

--- a/polynote-server/src/main/scala/polynote/server/repository/MarkdownNotebookRepository.scala
+++ b/polynote-server/src/main/scala/polynote/server/repository/MarkdownNotebookRepository.scala
@@ -14,6 +14,7 @@ import io.circe.yaml.Printer
 import polynote.data.Rope
 import polynote.kernel.RuntimeError.RecoveredException
 import polynote.kernel._
+import polynote.server.ServerConfig
 
 import scala.annotation.tailrec
 import scala.collection.immutable.Queue
@@ -23,6 +24,7 @@ import scala.concurrent.ExecutionContext
 
 class MarkdownNotebookRepository(
   val path: Path,
+  val serverConfig: ServerConfig,
   val chunkSize: Int = 8192,
   val executionContext: ExecutionContext = ExecutionContext.global)(implicit
   contextShift: ContextShift[IO]

--- a/polynote-server/src/main/scala/polynote/server/repository/ipynb/IPythonNotebookRepository.scala
+++ b/polynote-server/src/main/scala/polynote/server/repository/ipynb/IPythonNotebookRepository.scala
@@ -9,11 +9,13 @@ import io.circe.parser.parse
 import io.circe.Printer
 import io.circe.syntax._
 import polynote.messages.Notebook
+import polynote.server.ServerConfig
 
 import scala.concurrent.ExecutionContext
 
 class IPythonNotebookRepository(
   val path: Path,
+  val serverConfig: ServerConfig,
   saveVersion: Int = 4,
   val chunkSize: Int = 8192,
   val executionContext: ExecutionContext = ExecutionContext.global)(implicit

--- a/polynote-server/src/test/scala/polynote/server/repository/FileBasedRepositorySpec.scala
+++ b/polynote-server/src/test/scala/polynote/server/repository/FileBasedRepositorySpec.scala
@@ -5,6 +5,7 @@ import java.nio.file.{FileAlreadyExistsException, Files, Path, Paths}
 import cats.effect.{ContextShift, IO}
 import org.scalatest.{FreeSpec, Matchers}
 import polynote.messages.Notebook
+import polynote.server.ServerConfig
 
 import scala.concurrent.ExecutionContext
 
@@ -115,6 +116,7 @@ class FileBasedRepositorySpec extends FreeSpec with Matchers {
 
 class SimpleFileBasedRepo extends FileBasedRepository {
   val tmp: Path = Files.createTempDirectory(getClass.getSimpleName)
+  val serverConfig: ServerConfig = ServerConfig()
 
   sys.addShutdownHook(cleanup())
 

--- a/polynote-spark/src/main/scala/polynote/server/SparkServer.scala
+++ b/polynote-spark/src/main/scala/polynote/server/SparkServer.scala
@@ -11,7 +11,7 @@ import scala.reflect.io.AbstractFile
 import scala.tools.nsc.Settings
 
 object SparkServer extends Server {
-  override protected lazy val kernelFactory: KernelFactory[IO] = new IOKernelFactory(Map("scala" -> dependencyFetcher), subKernels) {
+  override protected lazy val kernelFactory: KernelFactory[IO] = new IOKernelFactory(Map("scala" -> dependencyFetcher), interpreters) {
     override protected def mkKernel(
       getNotebook: () => IO[Notebook],
       deps: Map[String, List[(String, File)]],

--- a/polynote-spark/src/test/scala/polynote/server/SparkServer.scala
+++ b/polynote-spark/src/test/scala/polynote/server/SparkServer.scala
@@ -12,7 +12,7 @@ import scala.reflect.io.AbstractFile
 import scala.tools.nsc.Settings
 
 object SparkServer extends Server {
-  override protected lazy val kernelFactory = new IOKernelFactory(Map("scala" -> dependencyFetcher), subKernels) {
+  override protected lazy val kernelFactory = new IOKernelFactory(Map("scala" -> dependencyFetcher), interpreters) {
     override protected def mkKernel(
       getNotebook: () => IO[Notebook],
       deps: Map[String, List[(String, File)]],


### PR DESCRIPTION
Adds a server config file, `config.yml` which can currently configure HTTP listening, default repositories, and default dependencies.

We might want to switch away from YAML soon, but this was easy enough to implement.

TODO: example/default config file