### PR TITLE
Use `Out` instead of `resCellX`

### DIFF
--- a/polynote-frontend/polynote/cell.js
+++ b/polynote-frontend/polynote/cell.js
@@ -1,6 +1,7 @@
-import {blockquote, div, iconButton, span, tag} from "./tags.js";
+import {blockquote, div, iconButton, span, tag, button} from "./tags.js";
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import * as messages from "./messages.js";
+import { ResultValue } from "./result.js"
 import {RichTextEditor} from "./text_editor.js";
 import {MainToolbar, mainToolbar} from "./ui.js";
 import {UIEvent, UIEventTarget} from "./ui_event.js"
@@ -79,16 +80,19 @@ export class Cell extends UIEventTarget {
         this.id = id;
         this.language = language;
 
+        this.cellIndex = id.match(/^Cell(\d+)$/)[1];
+
         this.container = div(['cell-container', language], [
             this.cellInput = div(['cell-input'], [
                 div(['cell-input-tools'], [
-                    iconButton(['run-cell'], 'Run this cell (only)', '', 'Run'),
+                    div(['run-cell', 'in-ident'], [span(['icon', 'fas'], ''), `In (${this.cellIndex}):`]),
+                    //iconButton(['run-cell'], 'Run this cell (only)', '', 'Run'),
                     //iconButton(['run-cell', 'refresh'], 'Run this cell and all dependent cells', '', 'Run and refresh')
                 ]),
                 this.editorEl = div(['cell-input-editor'], [])
             ]),
             this.cellOutput = div(['cell-output'], [
-                div(['cell-output-tools'], []),
+                this.cellOutputTools = div(['cell-output-tools'], []),
                 this.cellOutputDisplay = div(['cell-output-display'], [])
             ])
         ]).withId(id);
@@ -162,6 +166,8 @@ export class CodeCell extends Cell {
             fontLigatures: true,
             contextmenu: false,
             fixedOverflowWidgets: true,
+            lineNumbers: false, // TODO: preferences to enable line numbers
+            lineDecorationsWidth: 0,
         });
 
         this.editorEl.style.height = (this.editor.getScrollHeight()) + "px";
@@ -260,6 +266,7 @@ export class CodeCell extends Cell {
         // clear the display
         this.cellOutputDisplay.innerHTML = '';
         if (reports.length) {
+            this.container.classList.add('error');
             this.cellOutput.classList.add('errors');
             this.cellOutputDisplay.appendChild(
                 div(
@@ -320,6 +327,8 @@ export class CodeCell extends Cell {
             ])
         );
 
+        this.container.classList.add('error');
+
         if (cellLine !== null && cellLine >= 0) {
             const model = this.editor.getModel();
             monaco.editor.setModelMarkers(
@@ -337,8 +346,11 @@ export class CodeCell extends Cell {
         }
     }
 
-    addResult(contentType, content) {
+    addOutput(contentType, content) {
         this.cellOutput.classList.add('output');
+        if (!this.container.classList.contains('error')) {
+            this.container.classList.add('success');
+        }
         const contentTypeParts = contentType.split(';').map(str => str.replace(/(^\s+|\s+$)/g, ""));
         const mimeType = contentTypeParts.shift();
         const args = {};
@@ -350,15 +362,34 @@ export class CodeCell extends Cell {
         const rel = args.rel || 'none';
         const lang = args.lang || null;
         const self = this;
-        CodeCell.parseContent(content, mimeType, lang).then(function(result) {
-            self.cellOutputDisplay.appendChild(
-                div(['output'], result).attr('rel', rel).attr('mime-type', mimeType)
-            );
+        return CodeCell.parseContent(content, mimeType, lang).then(function(result) {
+            const el = div(['output'], result).attr('rel', rel).attr('mime-type', mimeType);
+            self.cellOutputDisplay.appendChild(el);
+            return el;
         }).catch(function(err) {
             self.cellOutputDisplay.appendChild(
                 div(['output'], err)
             );
         });
+    }
+
+    addResult(result) {
+        if (result instanceof ResultValue) {
+            // TODO: keep "result" and "output" separate for UI... have a way to show declarations, results, outputs, etc. separately
+            if (result.name) {
+                // don't display this; it's a named declaration
+                // TODO: have a way to display these if desired
+            } else {
+                // TODO: have a UI to look at other reprs
+                const [mime, content] = result.displayRepr;
+                this.addOutput(mime, content).then(el => {
+                    const ident = div(['out-ident'], `Out(${result.identifier.right}):`);
+                    el.insertBefore(ident, el.childNodes[0]);
+                });
+            }
+        } else {
+            throw "Result must be a ResultValue"
+        }
     }
 
     static colorize(content, lang) {
@@ -385,6 +416,7 @@ export class CodeCell extends Cell {
     }
 
     clearResult() {
+        this.container.classList.remove('error', 'success');
         this.setErrors([]);
     }
 

--- a/polynote-frontend/polynote/cell.js
+++ b/polynote-frontend/polynote/cell.js
@@ -85,8 +85,7 @@ export class Cell extends UIEventTarget {
         this.container = div(['cell-container', language], [
             this.cellInput = div(['cell-input'], [
                 div(['cell-input-tools'], [
-                    div(['run-cell', 'in-ident'], [span(['icon', 'fas'], ''), `In (${this.cellIndex}):`]),
-                    //iconButton(['run-cell'], 'Run this cell (only)', '', 'Run'),
+                    iconButton(['run-cell'], 'Run this cell (only)', '', 'Run'),
                     //iconButton(['run-cell', 'refresh'], 'Run this cell and all dependent cells', '', 'Run and refresh')
                 ]),
                 this.editorEl = div(['cell-input-editor'], [])
@@ -166,7 +165,8 @@ export class CodeCell extends Cell {
             fontLigatures: true,
             contextmenu: false,
             fixedOverflowWidgets: true,
-            lineNumbers: false, // TODO: preferences to enable line numbers
+            lineNumbers: true,
+            lineNumbersMinChars: 1,
             lineDecorationsWidth: 0,
         });
 
@@ -376,14 +376,14 @@ export class CodeCell extends Cell {
     addResult(result) {
         if (result instanceof ResultValue) {
             // TODO: keep "result" and "output" separate for UI... have a way to show declarations, results, outputs, etc. separately
-            if (result.name) {
+            if (result.name !== "Out") {
                 // don't display this; it's a named declaration
                 // TODO: have a way to display these if desired
             } else {
                 // TODO: have a UI to look at other reprs
                 const [mime, content] = result.displayRepr;
                 this.addOutput(mime, content).then(el => {
-                    const ident = div(['out-ident'], `Out(${result.identifier.right}):`);
+                    const ident = div(['out-ident'], `Out:`);
                     el.insertBefore(ident, el.childNodes[0]);
                 });
             }

--- a/polynote-frontend/polynote/result.js
+++ b/polynote-frontend/polynote/result.js
@@ -198,12 +198,12 @@ export class ResultValue extends Result {
     static get msgTypeId() { return 4; }
 
     static unapply(inst) {
-        return [inst.identifier, inst.typeName, inst.reprs, inst.sourceCell];
+        return [inst.name, inst.typeName, inst.reprs, inst.sourceCell];
     }
 
-    constructor(identifier, typeName, reprs, sourceCell) {
-        super(identifier, typeName, reprs, sourceCell);
-        this.identifier = identifier;
+    constructor(name, typeName, reprs, sourceCell) {
+        super(name, typeName, reprs, sourceCell);
+        this.name = name;
         this.typeName = typeName;
         if (reprs instanceof Array) { // conditional is so IntelliJ knows it's an array. Dem completions.
             this.reprs = reprs;
@@ -216,10 +216,6 @@ export class ResultValue extends Result {
         const index = this.reprs.findIndex(repr => repr instanceof StringRepr);
         if (index < 0) return "";
         return this.reprs[index].string;
-    }
-
-    get name() {
-        return this.identifier.left;
     }
 
     /**
@@ -240,7 +236,7 @@ export class ResultValue extends Result {
     }
 }
 
-ResultValue.codec = combined(ior(tinyStr, int32), tinyStr, arrayCodec(uint8, ValueRepr.codec), tinyStr).to(ResultValue);
+ResultValue.codec = combined(tinyStr, tinyStr, arrayCodec(uint8, ValueRepr.codec), tinyStr).to(ResultValue);
 
 Result.codecs = [
   Output,

--- a/polynote-frontend/polynote/result.js
+++ b/polynote-frontend/polynote/result.js
@@ -2,7 +2,7 @@
 
 import {
     Codec, DataReader, DataWriter, discriminated, combined, arrayCodec,
-    str, shortStr, tinyStr, uint8, uint16, int32
+    str, shortStr, tinyStr, uint8, uint16, int32, ior
 } from './codec.js'
 
 import { ValueRepr, StringRepr, MIMERepr } from './value_repr.js'
@@ -198,12 +198,12 @@ export class ResultValue extends Result {
     static get msgTypeId() { return 4; }
 
     static unapply(inst) {
-        return [inst.name, inst.typeName, inst.reprs, inst.sourceCell];
+        return [inst.identifier, inst.typeName, inst.reprs, inst.sourceCell];
     }
 
-    constructor(name, typeName, reprs, sourceCell) {
-        super(name, typeName, reprs, sourceCell);
-        this.name = name;
+    constructor(identifier, typeName, reprs, sourceCell) {
+        super(identifier, typeName, reprs, sourceCell);
+        this.identifier = identifier;
         this.typeName = typeName;
         if (reprs instanceof Array) { // conditional is so IntelliJ knows it's an array. Dem completions.
             this.reprs = reprs;
@@ -216,6 +216,10 @@ export class ResultValue extends Result {
         const index = this.reprs.findIndex(repr => repr instanceof StringRepr);
         if (index < 0) return "";
         return this.reprs[index].string;
+    }
+
+    get name() {
+        return this.identifier.left;
     }
 
     /**
@@ -236,7 +240,7 @@ export class ResultValue extends Result {
     }
 }
 
-ResultValue.codec = combined(tinyStr, tinyStr, arrayCodec(uint8, ValueRepr.codec), tinyStr).to(ResultValue);
+ResultValue.codec = combined(ior(tinyStr, int32), tinyStr, arrayCodec(uint8, ValueRepr.codec), tinyStr).to(ResultValue);
 
 Result.codecs = [
   Output,

--- a/polynote-frontend/polynote/tags.js
+++ b/polynote-frontend/polynote/tags.js
@@ -185,6 +185,12 @@ export function table(classes, contentSpec) {
                     appendContent(cell, value);
                 }
             }
+            const nextSibling = tr.nextSibling;
+            const parentNode = tr.parentNode;
+            if (parentNode) {
+                parentNode.removeChild(tr);
+                parentNode.insertBefore(tr, nextSibling);   // re-trigger the highlight animation
+            }
         };
 
         return tr;

--- a/polynote-frontend/polynote/ui.js
+++ b/polynote-frontend/polynote/ui.js
@@ -100,6 +100,7 @@ export class KernelSymbolsUI {
                     tr.updateValues({type: span([], type).attr('title', type), value: span([], value).attr('title', value)})
 
                 }
+
             });
         } else {
             const tr = this.tableEl.addRow({name: name, type: span([], type).attr('title', type), value: span([], value).attr('title', value)});
@@ -969,17 +970,19 @@ export class NotebookUI {
                         console.log(result.error);
                         cell.setRuntimeError(result.error);
                     } else if (result instanceof Output) {
-                        cell.addResult(result.contentType, result.content);
+                        cell.addOutput(result.contentType, result.content);
                     } else if (result instanceof ClearResults) {
                         cell.clearResult();
                     } else if (result instanceof ResultValue) {
-                        const [mime, content] = result.displayRepr;
-                        cell.addResult(mime, content);
+                        cell.addResult(result);
                     }
                 }
 
                 if (result instanceof ResultValue) {
-                    this.kernelUI.symbols.setSymbolInfo(result.name, result.typeName, result.valueText);
+                    this.kernelUI.symbols.setSymbolInfo(
+                        result.identifier.fold(name => name, idx => `Out(${idx})`, (name, idx) => name),
+                        result.typeName,
+                        result.valueText);
                 }
             }
         });
@@ -1024,10 +1027,9 @@ export class NotebookUI {
                         } else if (result instanceof RuntimeError) {
                             cell.setRuntimeError(result.error)
                         } else if (result instanceof Output) {
-                            cell.addResult(result.contentType, result.content)
+                            cell.addOutput(result.contentType, result.content)
                         } else if (result instanceof ResultValue) {
-                            const [mime, content] = result.displayRepr;
-                            cell.addResult(mime, content);
+                            cell.addResult(result);
                         }
                     }
                 )

--- a/polynote-frontend/polynote/ui.js
+++ b/polynote-frontend/polynote/ui.js
@@ -980,7 +980,7 @@ export class NotebookUI {
 
                 if (result instanceof ResultValue) {
                     this.kernelUI.symbols.setSymbolInfo(
-                        result.identifier.fold(name => name, idx => `Out(${idx})`, (name, idx) => name),
+                        result.name,
                         result.typeName,
                         result.valueText);
                 }

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -34,8 +34,11 @@
 @ui-border-dark: darken(@ui-border, 20%);
 @ui-selected:   rgb(67, 104, 234);
 @ui-text:       rgb(50, 60, 68);
+@code-fonts:    'Hasklig', 'Fira Code', 'Menlo', fixed;
 
 @toolbar-height: 68px;
+@cell-margin-width: 70pt;
+@cell-margin-width-plus-padding: 80pt;
 
 body {
   font-family: 'Helvetica Neue', 'Segoe UI', sans-serif;
@@ -269,17 +272,38 @@ body {
   .cell-input {
     position: relative;
 
+    .in-ident {
+      color: #303F9F;
+      font-family: @code-fonts;
+      font-size: 11pt;
+      text-align: right;
+      line-height: 11pt;
+      vertical-align: middle;
+      cursor: pointer;
+
+      .icon {
+        font-size: 8pt;
+        line-height: 11pt;
+        vertical-align: middle;
+        float: left;
+        visibility: hidden;
+      }
+
+      &:hover .icon {
+        visibility: visible;
+      }
+    }
+
     .cell-input-tools {
       position: absolute;
       left: 0;
       top: 0;
       bottom: 0;
-      width: 42px;
+      width: @cell-margin-width;
       background: @ui-background;
       border: 1px solid @ui-border;
-      border-width: 1px 0 1px 1px;
-      box-sizing: border-box;
       padding: 4px;
+      box-sizing: border-box;
 
       button.run-cell.refresh .icon {
         font-size: 8px;
@@ -289,7 +313,8 @@ body {
 
     .cell-input-editor {
       border: 1px solid @ui-border;
-      margin-left: 42px;
+      border-left-width: 0;
+      margin-left: @cell-margin-width;
       min-height: 3em;
     }
   }
@@ -318,7 +343,7 @@ body {
     }
 
     .cell-input {
-      border-left: 42px solid transparent;
+      border-left: @cell-margin-width solid transparent;
     }
 
     .cell-input-tools {
@@ -1037,25 +1062,43 @@ body {
     }
 
     .cell-output-tools {
+      display: none;
+    }
+
+    .out-ident {
+      color: #D84315;
+      font-family: @code-fonts;
+      font-size: 11pt;
+      position: absolute;
+      left: 0;
+      width: @cell-margin-width;
+      padding: 0 4px;
+      text-align: right;
+      box-sizing: border-box;
+    }
+
+    .cell-output-display::before {
+      content: " ";
       position: absolute;
       top: 0;
       left: 0;
       bottom: 0;
-      width: 43px;
-      box-sizing: border-box;
+      width: @cell-margin-width;
       border: 1px solid @ui-border;
       border-top: none;
+      border-bottom: none;
       background: @ui-background;
+      box-sizing: border-box;
     }
 
     .cell-output-display {
-      margin-left: 42px;
       font-size: 11pt;
-      padding: .5em;
+      padding: .5em .5em .5em @cell-margin-width-plus-padding;
       border-right: 1px solid @ui-border;
       border-bottom: 1px solid @ui-border;
       overflow: auto;
       resize: vertical;
+      position: relative;
 
       ul.stack-trace {
         margin: 0 0 0 .5em;
@@ -1101,7 +1144,7 @@ body {
       .output[mime-type='text/plain'] {
         white-space: pre;
         line-height: 1.5;
-        font-family: 'Hasklig', 'Fira Code', 'Menlo', fixed;
+        font-family: @code-fonts;
       }
 
       .output[rel='stderr'] {
@@ -1419,10 +1462,14 @@ button {
       }
       tbody {
         overflow-y: auto;
+        background: white;
+
+        tr {
+          animation: highlight 2s;
+        }
 
         th, td {
           text-align: left;
-          background: white;
           line-height: 1.2;
 
           span {
@@ -1448,7 +1495,7 @@ button {
         }
 
         .name, .type {
-          font-family: 'Hasklig', 'Fira Code', 'Menlo', fixed;
+          font-family: @code-fonts;
         }
       }
     }
@@ -1789,7 +1836,7 @@ button {
 
     input {
       width: available;
-      font-family: 'Hasklig', 'Fira Code', 'Menlo', fixed;
+      font-family: @code-fonts;
       font-size: inherit;
     }
   }
@@ -1835,4 +1882,18 @@ button {
     background-color: rgb(240, 240, 240);
   }
 
+}
+
+@keyframes highlight {
+  from {
+    background-color: rgba(253, 246, 227, 1.0);
+  }
+
+  50% {
+    background-color: rgba(253, 246, 227, 1.0);
+  }
+
+  to {
+    background-color: rgba(253, 246, 227, 0.0);
+  }
 }

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -272,28 +272,6 @@ body {
   .cell-input {
     position: relative;
 
-    .in-ident {
-      color: #303F9F;
-      font-family: @code-fonts;
-      font-size: 11pt;
-      text-align: right;
-      line-height: 11pt;
-      vertical-align: middle;
-      cursor: pointer;
-
-      .icon {
-        font-size: 8pt;
-        line-height: 11pt;
-        vertical-align: middle;
-        float: left;
-        visibility: hidden;
-      }
-
-      &:hover .icon {
-        visibility: visible;
-      }
-    }
-
     .cell-input-tools {
       position: absolute;
       left: 0;
@@ -304,6 +282,11 @@ body {
       border: 1px solid @ui-border;
       padding: 4px;
       box-sizing: border-box;
+
+      button {
+        display: block;
+        margin: 0 auto;
+      }
 
       button.run-cell.refresh .icon {
         font-size: 8px;

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -37,8 +37,8 @@
 @code-fonts:    'Hasklig', 'Fira Code', 'Menlo', fixed;
 
 @toolbar-height: 68px;
-@cell-margin-width: 70pt;
-@cell-margin-width-plus-padding: 80pt;
+@cell-margin-width: 40pt;
+@cell-margin-width-plus-padding: 50pt;
 
 body {
   font-family: 'Helvetica Neue', 'Segoe UI', sans-serif;

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -296,7 +296,7 @@ body {
 
     .cell-input-editor {
       border: 1px solid @ui-border;
-      border-left-width: 0;
+      border-left: 2pt solid transparent;
       margin-left: @cell-margin-width;
       min-height: 3em;
     }

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
@@ -173,7 +173,7 @@ class PythonInterpreter(val symbolTable: RuntimeSymbolTable) extends LanguageInt
         jep.eval("__polynote_last__ = __polynote_parsed__[-1]")
         val lastIsExpr = jep.getValue("isinstance(__polynote_last__, ast.Expr)", classOf[java.lang.Boolean])
 
-        val resultName = s"res$cell"
+        val resultName = "Out"
         val maybeModifiedCode = if (lastIsExpr) {
           val lastLine = jep.getValue("__polynote_last__.lineno", classOf[java.lang.Integer]) - 1
           val (prevCode, lastCode) = code.linesWithSeparators.toSeq.splitAt(lastLine)
@@ -209,21 +209,8 @@ class PythonInterpreter(val symbolTable: RuntimeSymbolTable) extends LanguageInt
   }
 
   def getPyResults(decls: Seq[String], sourceCellId: String): Map[String, ResultValue] = {
-    val cellIndex = try sourceCellId.stripPrefix("Cell").toInt catch {
-      case err: Throwable => -1
-    }
-
     decls.map {
-      // TODO avoid creating the resCellX variable, instead evaluate the last expression separately
-      case name if cellIndex != -1 && name == s"res$sourceCellId" => name -> {
-        getPyResult(name) match {
-          case (value, Some(typ)) =>
-            ResultValue.withIndex(kernelContext, name, cellIndex, typ, value, sourceCellId)
-          case (value, _) =>
-            ResultValue.withIndex(kernelContext, name, cellIndex, value, sourceCellId)
-        }
-      }
-      case name => name -> {
+      name => name -> {
         getPyResult(name) match {
           case (value, Some(typ)) =>
             ResultValue(kernelContext, name, typ, value, sourceCellId)

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
@@ -117,8 +117,6 @@ class ScalaInterpreter(
                     // don't publish if the type is Unit
                     if (accessor.info.finalResultType <:< global.typeOf[Unit])
                       None
-                    else if (source.resultName.exists(_.decodedName.toString == name))
-                      Some(ResultValue.withIndex(kernelContext, cellIndex, tpe, value, cell))
                     else
                       Some(ResultValue(kernelContext, accessor.name.toString, tpe, value, cell))
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
@@ -67,6 +67,9 @@ class ScalaInterpreter(
   ): IO[Stream[IO, Result]] = {
     val originalOut = System.out
 
+    // TODO: this is wrong. It doesn't seem good to keep parsing this from "CellXX" though. Maybe cells also (or only?) need a numeric ID?
+    val cellIndex = previousCells.size
+
     val source = new ScalaSource[this.type](this)(cell, visibleSymbols.toSet, previousCells.collect(previousSources).toList, code)
     interpreterLock.acquire.bracket { _ =>
       IO.fromEither(source.compile).flatMap {
@@ -77,7 +80,7 @@ class ScalaInterpreter(
             val resultQ = new EnqueueSome(maybeResultQ)
 
             val symType = sym.asModule.toType
-            val run = IO(importToRuntime.importSymbol(sym)).flatMap {
+            val run = IO(importToRuntime.importSymbol(sym)).map {
               runtimeSym =>
 
                 val moduleMirror = try runtimeMirror.reflectModule(runtimeSym.asModule) catch {
@@ -97,7 +100,7 @@ class ScalaInterpreter(
                 // collect term definitions and values from the cell's object, and publish them to the symbol table
                 // TODO: We probably also want to publish some output for types, like "Defined class Foo" or "Defined type alias Bar".
                 //       But the class story is still WIP (i.e. we might want to pull them out of cells into the notebook package)
-                val syms = symType.nonPrivateDecls.filter(d => d.isTerm && !d.isConstructor && !d.isSetter).collect {
+                symType.nonPrivateDecls.filter(d => d.isTerm && !d.isConstructor && !d.isSetter).collect {
 
                   case accessor if accessor.isGetter || (accessor.isMethod && !accessor.isOverloaded && accessor.asMethod.paramLists.isEmpty && accessor.isStable) =>
                     // if the decl is a val, evaluate it and push it to the symbol table
@@ -114,8 +117,10 @@ class ScalaInterpreter(
                     // don't publish if the type is Unit
                     if (accessor.info.finalResultType <:< global.typeOf[Unit])
                       None
+                    else if (source.resultName.exists(_.decodedName.toString == name))
+                      Some(ResultValue.withIndex(kernelContext, cellIndex, tpe, value, cell))
                     else
-                      Some(ResultValue(kernelContext)(accessor.name.toString, tpe, value, cell))
+                      Some(ResultValue(kernelContext, accessor.name.toString, tpe, value, cell))
 
                   case method if method.isMethod =>
                     // If the decl is a def, we push an anonymous (fully eta-expanded) function value to the symbol table.
@@ -150,19 +155,11 @@ class ScalaInterpreter(
                       runtimeTools.eval(tree) -> typ
                     }
                     val methodType = importFromRuntime.importType(fnType)
-                    Some(ResultValue(kernelContext)(method.name.toString, methodType, runtimeFn, cell))
+
+                    // I guess we're saying a "def" shouldn't become the cell result?
+                    Some(ResultValue(kernelContext, method.name.toString, methodType, runtimeFn, cell))
 
                 }.flatten
-
-                val maybeOutput = syms.find(_.name.startsWith("res"))
-
-                def stringRepr(value: ResultValue): TinyString = // TODO: from reprs?
-                  Option(value).map(_.value).flatMap(Option(_)).map(_.toString).getOrElse("")
-
-                maybeOutput
-                  .map(rv => resultQ.enqueue1(Output("text/plain; rel=decl; lang=scala", s"${rv.name}: ${rv.typeName} = ${stringRepr(rv)}")))
-                  .getOrElse(IO.unit)
-                  .as(syms)
             }
 
             val saveSource = IO.delay[Unit](previousSources.put(cell, source))

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaSource.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaSource.scala
@@ -100,12 +100,12 @@ class ScalaSource[Interpreter <: ScalaInterpreter](val interpreter: Interpreter)
       trees.last match {
         case global.ValDef(mods, name, _, _) if !mods.isPrivate => (Some(name), trees)
         case t@global.ValDef(mods, name, tpt, _) =>
-          val accessorName = global.TermName(s"res$id")
+          val accessorName = global.TermName("Out")
           val pos = t.pos.withStart(t.pos.end)
           (Some(accessorName), trees.dropRight(1) :+
             global.ValDef(global.Modifiers(), accessorName, tpt, global.Ident(name).setPos(pos)).setPos(pos))
         case expr if expr.isTerm =>
-          val accessorName = global.TermName(s"res$id")
+          val accessorName = global.TermName("Out")
           (Some(accessorName), trees.dropRight(1) :+
             global.ValDef(global.Modifiers(), accessorName, global.TypeTree(global.NoType), expr).setPos(expr.pos))
         case _ => (None, trees)

--- a/polynote-kernel/src/main/scala/polynote/kernel/util/RuntimeSymbolTable.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/RuntimeSymbolTable.scala
@@ -108,13 +108,8 @@ final class RuntimeSymbolTable(
     // don't need to hash everything to determine hash code; name collisions are less common than hash comparisons
     override def hashCode(): Int = name.hashCode()
 
-    def toResultValue: ResultValue = name match {
-      case `outRegex`(idx) => ResultValue.withIndex(kernelContext, idx.toInt, scalaTypeHolder, value, sourceCellId)
-      case _ => ResultValue(kernelContext, name, scalaTypeHolder, value, sourceCellId)
-    }
+    def toResultValue: ResultValue = ResultValue(kernelContext, name, scalaTypeHolder, value, sourceCellId)
   }
-
-  private val outRegex = "^Out\\((\\d+)\\)$".r
 
   object RuntimeValue {
     def apply(name: String, value: Any, source: Option[LanguageInterpreter[IO]], sourceCell: String): RuntimeValue = RuntimeValue(
@@ -130,7 +125,7 @@ final class RuntimeSymbolTable(
     def fromResultValue(resultValue: ResultValue, source: LanguageInterpreter[IO]): Option[RuntimeValue] = resultValue match {
       case ResultValue(_, _, _, _, Unit, _) => None
       case ResultValue(name, typeName, reprs, sourceCell, value, scalaType) =>
-        Some(apply(name.fold(identity, i => s"Out($i)", (name, _) => name), value, scalaType.asInstanceOf[global.Type], Option(source), sourceCell))
+        Some(apply(name, value, scalaType.asInstanceOf[global.Type], Option(source), sourceCell))
     }
   }
 

--- a/polynote-kernel/src/test/scala/polynote/kernel/lang/python/PythonInterpreterSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/lang/python/PythonInterpreterSpec.scala
@@ -66,10 +66,10 @@ class PythonInterpreterSpec extends FlatSpec with Matchers with KernelSpec {
         "kernel" -> polynote.runtime.Runtime,
         "x" -> 1,
         "y" -> 2,
-        "restest" -> 3
+        "Out" -> 3
       )
 
-      output should contain only Output("text/plain; rel=decl; lang=python", "restest = 3")
+      output shouldBe empty
       displayed shouldBe empty
     }
   }
@@ -89,12 +89,11 @@ class PythonInterpreterSpec extends FlatSpec with Matchers with KernelSpec {
         "x" -> 1,
         "y" -> 2,
         "answer" -> 3,
-        "restest" -> 3
+        "Out" -> 3
       )
 
       output should contain theSameElementsAs Seq(
-        Output("text/plain; rel=stdout", "1 + 2 = 3"),
-        Output("text/plain; rel=decl; lang=python", "restest = 3")
+        Output("text/plain; rel=stdout", "1 + 2 = 3")
       )
       displayed shouldBe empty
     }

--- a/polynote-kernel/src/test/scala/polynote/kernel/lang/scal/ScalaInterpreterSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/lang/scal/ScalaInterpreterSpec.scala
@@ -60,11 +60,11 @@ class ScalaInterpreterSpec extends FlatSpec with Matchers with KernelSpec {
         "kernel" -> polynote.runtime.Runtime,
         "x" -> 1,
         "y" -> 2,
-        "restest" -> 3
+        "Out" -> 3
       )
 
       displayed shouldBe empty
-      output should contain only Output("text/plain; rel=decl; lang=scala", "restest: Int = 3")
+      output shouldBe empty
     }
   }
 
@@ -84,14 +84,13 @@ class ScalaInterpreterSpec extends FlatSpec with Matchers with KernelSpec {
         "x" -> 1,
         "y" -> 2,
         "answer" -> 3,
-        "restest" -> 3
+        "Out" -> 3
       )
 
       displayed shouldBe empty
       output should contain theSameElementsAs Seq(
         Output("text/plain; rel=stdout", "println: 1 + 2 = 3"),
-        Output("text/plain; rel=stdout", "sys: 1 + 2 = 3"),
-        Output("text/plain; rel=decl; lang=scala", "restest: Int = 3")
+        Output("text/plain; rel=stdout", "sys: 1 + 2 = 3")
       )
     }
 

--- a/polynote-spark/src/main/scala/polynote/kernel/lang/sql/SparkSqlInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/lang/sql/SparkSqlInterpreter.scala
@@ -99,7 +99,7 @@ class SparkSqlInterpreter(val symbolTable: RuntimeSymbolTable) extends LanguageI
       _           <- symbolTable.drain()
       parseResult <- IO.fromEither(parser.parse(cell, code).fold(Left(_), Right(_), (errs, _) => Left(errs)))
       resultDF    <- registerTempViews(parseResult.tableIdentifiers).sequence.bracket(_ => IO(spark.sql(code)))(dropTempViews)
-      cellResult   = ResultValue.withIndex(kernelContext, cellIndex, global.typeOf[DataFrame], resultDF, cell)
+      cellResult   = ResultValue(kernelContext, "Out", global.typeOf[DataFrame], resultDF, cell)
     } yield Stream.emit(cellResult) ++ Stream.eval(outputDataFrame(resultDF))
 
     run.handleErrorWith(err => IO.pure(Stream.emit(RuntimeError(err))))


### PR DESCRIPTION
Introduces a bunch of things to make the UI cleaner in general.

- Get rid of `resCellX`. It's now replaced with `Out`.
- UI shows `Out:` next to the `Out` value, if there is one. Declared values are not shown in the output, but are highlighted in the symbol table.