### PR TITLE
Use Cell's index in the notebook as its ID

### DIFF
--- a/polynote-frontend/polynote/cell.js
+++ b/polynote-frontend/polynote/cell.js
@@ -97,7 +97,7 @@ export class Cell extends UIEventTarget {
                 this.cellOutputTools = div(['cell-output-tools'], []),
                 this.cellOutputDisplay = div(['cell-output-display'], [])
             ])
-        ]).withId(id);
+        ]).withId(`Cell${id}`);
 
         this.container.cell = this;
 

--- a/polynote-frontend/polynote/cell.js
+++ b/polynote-frontend/polynote/cell.js
@@ -85,8 +85,6 @@ export class Cell extends UIEventTarget {
         this.id = id;
         this.language = language;
 
-        this.cellIndex = id.match(/^Cell(\d+)$/)[1];
-
         this.container = div(['cell-container', language], [
             this.cellInput = div(['cell-input'], [
                 div(['cell-input-tools'], [

--- a/polynote-frontend/polynote/messages.js
+++ b/polynote-frontend/polynote/messages.js
@@ -386,7 +386,7 @@ export class InsertCell extends Message {
     }
 }
 
-InsertCell.codec = combined(shortStr, uint32, uint32, NotebookCell.codec, optional(int16)).to(InsertCell);
+InsertCell.codec = combined(shortStr, uint32, uint32, NotebookCell.codec, int16).to(InsertCell);
 
 export class ParamInfo {
     static unapply(inst) {

--- a/polynote-frontend/polynote/messages.js
+++ b/polynote-frontend/polynote/messages.js
@@ -6,6 +6,7 @@ import {
 } from './codec.js'
 
 import { Result, KernelErrorWithCause } from './result.js'
+import {int16} from "./codec";
 
 export class Message {
     static decode(data) {
@@ -84,7 +85,7 @@ export class NotebookCell {
     }
 }
 
-NotebookCell.codec = combined(tinyStr, tinyStr, str, arrayCodec(uint16, Result.codec), CellMetadata.codec).to(NotebookCell);
+NotebookCell.codec = combined(int16, tinyStr, str, arrayCodec(uint16, Result.codec), CellMetadata.codec).to(NotebookCell);
 
 export class RepositoryConfig {
 
@@ -190,7 +191,7 @@ export class RunCell extends Message {
     }
 }
 
-RunCell.codec = combined(shortStr, arrayCodec(uint16, tinyStr)).to(RunCell);
+RunCell.codec = combined(shortStr, arrayCodec(uint16, uint16)).to(RunCell);
 
 export class CellResult extends Message {
     static get msgTypeId() { return 4; }
@@ -208,7 +209,7 @@ export class CellResult extends Message {
     }
 }
 
-CellResult.codec = combined(shortStr, tinyStr, Result.codec).to(CellResult);
+CellResult.codec = combined(shortStr, int16, Result.codec).to(CellResult);
 
 
 export class ContentEdit {
@@ -366,7 +367,7 @@ export class UpdateCell extends Message {
     }
 }
 
-UpdateCell.codec = combined(shortStr, uint32, uint32, tinyStr, arrayCodec(uint16, ContentEdit.codec)).to(UpdateCell);
+UpdateCell.codec = combined(shortStr, uint32, uint32, int16, arrayCodec(uint16, ContentEdit.codec)).to(UpdateCell);
 
 export class InsertCell extends Message {
     static get msgTypeId() { return 6; }
@@ -386,7 +387,7 @@ export class InsertCell extends Message {
     }
 }
 
-InsertCell.codec = combined(shortStr, uint32, uint32, NotebookCell.codec, optional(tinyStr)).to(InsertCell);
+InsertCell.codec = combined(shortStr, uint32, uint32, NotebookCell.codec, optional(int16)).to(InsertCell);
 
 export class ParamInfo {
     static unapply(inst) {
@@ -438,7 +439,7 @@ export class CompletionsAt extends Message {
 }
 
 CompletionsAt.codec =
-    combined(shortStr, tinyStr, int32, arrayCodec(uint16, CompletionCandidate.codec)).to(CompletionsAt);
+    combined(shortStr, int16, int32, arrayCodec(uint16, CompletionCandidate.codec)).to(CompletionsAt);
 
 export class ParameterHint {
     static unapply(inst) {
@@ -502,7 +503,7 @@ export class ParametersAt extends Message {
     }
 }
 
-ParametersAt.codec = combined(shortStr, tinyStr, int32, optional(Signatures.codec)).to(ParametersAt);
+ParametersAt.codec = combined(shortStr, int16, int32, optional(Signatures.codec)).to(ParametersAt);
 
 export class KernelStatusUpdate {
    constructor() {
@@ -680,7 +681,7 @@ export class SetCellLanguage extends Message {
     }
 }
 
-SetCellLanguage.codec = combined(shortStr, uint32, uint32, tinyStr, tinyStr).to(SetCellLanguage);
+SetCellLanguage.codec = combined(shortStr, uint32, uint32, int16, tinyStr).to(SetCellLanguage);
 
 export class StartKernel extends Message {
     static get msgTypeId() { return 12; }
@@ -749,7 +750,7 @@ export class DeleteCell extends Message {
     }
 }
 
-DeleteCell.codec = combined(shortStr, uint32, uint32, tinyStr).to(DeleteCell);
+DeleteCell.codec = combined(shortStr, uint32, uint32, int16).to(DeleteCell);
 
 export class ServerHandshake extends Message {
     static get msgTypeId() { return 16; }

--- a/polynote-frontend/polynote/messages.js
+++ b/polynote-frontend/polynote/messages.js
@@ -2,11 +2,10 @@
 
 import {
     DataReader, DataWriter, Codec, combined, arrayCodec, discriminated, optional, mapCodec,
-    str, shortStr, tinyStr, uint8, uint16, int32, uint32, bool
+    str, shortStr, tinyStr, uint8, uint16, int16, int32, uint32, bool
 } from './codec.js'
 
 import { Result, KernelErrorWithCause } from './result.js'
-import {int16} from "./codec";
 
 export class Message {
     static decode(data) {
@@ -85,7 +84,7 @@ export class NotebookCell {
     }
 }
 
-NotebookCell.codec = combined(int16, tinyStr, str, arrayCodec(uint16, Result.codec), CellMetadata.codec).to(NotebookCell);
+NotebookCell.codec = combined(int16, tinyStr, str, arrayCodec(int16, Result.codec), CellMetadata.codec).to(NotebookCell);
 
 export class RepositoryConfig {
 

--- a/polynote-frontend/polynote/result.js
+++ b/polynote-frontend/polynote/result.js
@@ -6,6 +6,7 @@ import {
 } from './codec.js'
 
 import { ValueRepr, StringRepr, MIMERepr } from './value_repr.js'
+import {int16} from "./codec";
 
 export class Result {
     static decode(data) {
@@ -236,7 +237,7 @@ export class ResultValue extends Result {
     }
 }
 
-ResultValue.codec = combined(tinyStr, tinyStr, arrayCodec(uint8, ValueRepr.codec), tinyStr).to(ResultValue);
+ResultValue.codec = combined(tinyStr, tinyStr, arrayCodec(uint8, ValueRepr.codec), int16).to(ResultValue);
 
 Result.codecs = [
   Output,

--- a/polynote-frontend/polynote/ui.js
+++ b/polynote-frontend/polynote/ui.js
@@ -728,7 +728,7 @@ export class NotebookUI {
 
         this.cellUI.addEventListener('InsertCellAfter', evt => {
            const current = this.cellUI.cells[evt.detail.cellId] || this.cellUI.cells[this.cellUI.el.querySelector('.cell-container').id];
-           const nextId = "Cell" + this.cellUI.cellCount;
+           const nextId = this.cellUI.cellCount;
            const newCell = current.language === 'text' ? new TextCell(nextId, '', 'text') : new CodeCell(nextId, '', current.language);
            this.socket.send(new messages.InsertCell(path, this.globalVersion, this.localVersion++, new messages.NotebookCell(newCell.id, newCell.language, ''), current.id));
            this.cellUI.insertCell(newCell, current);

--- a/polynote-frontend/polynote/ui.js
+++ b/polynote-frontend/polynote/ui.js
@@ -927,7 +927,6 @@ export class NotebookUI {
         });
 
         socket.addMessageListener(messages.CellResult, (path, id, result) => {
-            //console.log(result);
             if (path === this.path) {
                 const cell = this.cellUI.cells[id];
                 if (cell instanceof CodeCell) {

--- a/polynote-kernel/src/main/scala/polynote/kernel/KernelAPI.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/KernelAPI.scala
@@ -4,7 +4,7 @@ import cats.effect.concurrent.Ref
 import fs2.Stream
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
-import polynote.messages.{CellResult, ShortString, TinyList, TinyMap, TinyString}
+import polynote.messages.{CellID, CellResult, ShortString, TinyList, TinyMap, TinyString}
 import scodec.codecs.{Discriminated, Discriminator, byte}
 import scodec.{Attempt, Codec, Err}
 
@@ -22,15 +22,15 @@ trait KernelAPI[F[_]] {
 
   def shutdown(): F[Unit]
 
-  def startInterpreterFor(id: Short): F[Stream[F, Result]]
+  def startInterpreterFor(id: CellID): F[Stream[F, Result]]
 
-  def runCell(id: Short): F[Stream[F, Result]]
+  def runCell(id: CellID): F[Stream[F, Result]]
 
-  def runCells(ids: List[Short]): F[Stream[F, CellResult]]
+  def runCells(ids: List[CellID]): F[Stream[F, CellResult]]
 
-  def completionsAt(id: Short, pos: Int): F[List[Completion]]
+  def completionsAt(id: CellID, pos: Int): F[List[Completion]]
 
-  def parametersAt(id: Short, pos: Int): F[Option[Signatures]]
+  def parametersAt(id: CellID, pos: Int): F[Option[Signatures]]
 
   def currentSymbols(): F[List[ResultValue]]
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/KernelAPI.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/KernelAPI.scala
@@ -22,15 +22,15 @@ trait KernelAPI[F[_]] {
 
   def shutdown(): F[Unit]
 
-  def startInterpreterFor(id: String): F[Stream[F, Result]]
+  def startInterpreterFor(id: Short): F[Stream[F, Result]]
 
-  def runCell(id: String): F[Stream[F, Result]]
+  def runCell(id: Short): F[Stream[F, Result]]
 
-  def runCells(ids: List[String]): F[Stream[F, CellResult]]
+  def runCells(ids: List[Short]): F[Stream[F, CellResult]]
 
-  def completionsAt(id: String, pos: Int): F[List[Completion]]
+  def completionsAt(id: Short, pos: Int): F[List[Completion]]
 
-  def parametersAt(cell: String, offset: Int): F[Option[Signatures]]
+  def parametersAt(id: Short, pos: Int): F[Option[Signatures]]
 
   def currentSymbols(): F[List[ResultValue]]
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/Result.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/Result.scala
@@ -11,7 +11,7 @@ import shapeless.cachedImplicit
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import polynote.kernel.util.{KernelContext, SymbolDecl}
-import polynote.messages.{TinyList, TinyString, tinyListCodec, tinyStringCodec, truncateTinyString, iorCodec}
+import polynote.messages.{CellID, TinyList, TinyString, iorCodec, tinyListCodec, tinyStringCodec, truncateTinyString}
 import scodec.bits.BitVector
 
 import scala.collection.mutable.ListBuffer
@@ -143,7 +143,7 @@ final case class ResultValue(
   name: TinyString,
   typeName: TinyString,
   reprs: TinyList[ValueRepr],
-  sourceCell: Short,
+  sourceCell: CellID,
   value: Any,
   scalaType: Universe#Type
 ) extends Result {
@@ -160,12 +160,12 @@ object ResultValue extends ResultCompanion[ResultValue](4) {
     globalType -> ctx.formatType(globalType)
   }
 
-  def apply(ctx: KernelContext, name: String, typ: Universe#Type, value: Any, sourceCell: Short): ResultValue = {
+  def apply(ctx: KernelContext, name: String, typ: Universe#Type, value: Any, sourceCell: CellID): ResultValue = {
     val (globalType, typeStr) = toGlobalType(ctx, typ)
     ResultValue(name, typeStr, ctx.reprsOf(value, globalType), sourceCell, value, typ)
   }
 
-  def apply(ctx: KernelContext, name: String, value: Any, sourceCell: Short): ResultValue =
+  def apply(ctx: KernelContext, name: String, value: Any, sourceCell: CellID): ResultValue =
     apply(ctx, name, ctx.inferType(value), value, sourceCell)
 
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/Result.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/Result.scala
@@ -143,7 +143,7 @@ final case class ResultValue(
   name: TinyString,
   typeName: TinyString,
   reprs: TinyList[ValueRepr],
-  sourceCell: TinyString,
+  sourceCell: Short,
   value: Any,
   scalaType: Universe#Type
 ) extends Result {
@@ -160,12 +160,12 @@ object ResultValue extends ResultCompanion[ResultValue](4) {
     globalType -> ctx.formatType(globalType)
   }
 
-  def apply(ctx: KernelContext, name: String, typ: Universe#Type, value: Any, sourceCell: String): ResultValue = {
+  def apply(ctx: KernelContext, name: String, typ: Universe#Type, value: Any, sourceCell: Short): ResultValue = {
     val (globalType, typeStr) = toGlobalType(ctx, typ)
     ResultValue(name, typeStr, ctx.reprsOf(value, globalType), sourceCell, value, typ)
   }
 
-  def apply(ctx: KernelContext, name: String, value: Any, sourceCell: String): ResultValue =
+  def apply(ctx: KernelContext, name: String, value: Any, sourceCell: Short): ResultValue =
     apply(ctx, name, ctx.inferType(value), value, sourceCell)
 
 
@@ -181,7 +181,7 @@ object ResultValue extends ResultCompanion[ResultValue](4) {
       but it seems prudent to raise an alarm if we're trying to decode a ResultValue, because we shouldn't be. Maybe
       at some point if there is a client-side interpreter (i.e. JavaScript up in your browser) this would be a thing?
    */
-  implicit val codec: Codec[ResultValue] = (tinyStringCodec ~ tinyStringCodec ~ tinyListCodec[ValueRepr] ~ tinyStringCodec).xmap(
+  implicit val codec: Codec[ResultValue] = (tinyStringCodec ~ tinyStringCodec ~ tinyListCodec[ValueRepr] ~ short16).xmap(
     _ => throw new UnsupportedOperationException(
       s"Shouldn't be decoding a ${classOf[ResultValue].getSimpleName} on the server!"
       // the reflection is so this message can participate in refactoring of ResultValue's name, which is likely.

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/LanguageInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/LanguageInterpreter.scala
@@ -31,9 +31,9 @@ trait LanguageInterpreter[F[_]] {
     *         resulted from running the code.
     */
   def runCode(
-    cell: String,
+    cell: Short,
     visibleSymbols: Seq[Decl],
-    previousCells: Seq[String],
+    previousCells: Seq[Short],
     code: String
   ): F[Stream[F, Result]]
 
@@ -42,14 +42,14 @@ trait LanguageInterpreter[F[_]] {
     *
     * @param pos The position (character offset) within the code string at which completions are requested
     */
-  def completionsAt(cell: String, visibleSymbols: Seq[Decl], previousCells: Seq[String], code: String, pos: Int): F[List[Completion]]
+  def completionsAt(cell: Short, visibleSymbols: Seq[Decl], previousCells: Seq[Short], code: String, pos: Int): F[List[Completion]]
 
   /**
     * Ask for parameter signatures (if applicable) at the given position in the given code string
     *
     * @param pos The position (character offset) within the code string at which parameter hints are requested
     */
-  def parametersAt(cell: String, visibleSymbols: Seq[Decl], previousCells: Seq[String], code: String, pos: Int): F[Option[Signatures]]
+  def parametersAt(cell: Short, visibleSymbols: Seq[Decl], previousCells: Seq[Short], code: String, pos: Int): F[Option[Signatures]]
 
   /**
     * Initialize the kernel (if necessary)

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/LanguageInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/LanguageInterpreter.scala
@@ -6,6 +6,7 @@ import fs2.Stream
 import fs2.concurrent.{Enqueue, Queue}
 import polynote.kernel._
 import polynote.kernel.util.{Publish, RuntimeSymbolTable, SymbolDecl}
+import polynote.messages.CellID
 
 /**
   * The LanguageInterpreter runs code in a given language.
@@ -31,9 +32,9 @@ trait LanguageInterpreter[F[_]] {
     *         resulted from running the code.
     */
   def runCode(
-    cell: Short,
+    cell: CellID,
     visibleSymbols: Seq[Decl],
-    previousCells: Seq[Short],
+    previousCells: Seq[CellID],
     code: String
   ): F[Stream[F, Result]]
 
@@ -42,14 +43,14 @@ trait LanguageInterpreter[F[_]] {
     *
     * @param pos The position (character offset) within the code string at which completions are requested
     */
-  def completionsAt(cell: Short, visibleSymbols: Seq[Decl], previousCells: Seq[Short], code: String, pos: Int): F[List[Completion]]
+  def completionsAt(cell: CellID, visibleSymbols: Seq[Decl], previousCells: Seq[CellID], code: String, pos: Int): F[List[Completion]]
 
   /**
     * Ask for parameter signatures (if applicable) at the given position in the given code string
     *
     * @param pos The position (character offset) within the code string at which parameter hints are requested
     */
-  def parametersAt(cell: Short, visibleSymbols: Seq[Decl], previousCells: Seq[Short], code: String, pos: Int): F[Option[Signatures]]
+  def parametersAt(cell: CellID, visibleSymbols: Seq[Decl], previousCells: Seq[CellID], code: String, pos: Int): F[Option[Signatures]]
 
   /**
     * Initialize the kernel (if necessary)

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
@@ -146,7 +146,8 @@ class PythonInterpreter(val symbolTable: RuntimeSymbolTable) extends LanguageInt
     code: String
   ): IO[Stream[IO, Result]] = if (code.trim().isEmpty) IO.pure(Stream.empty) else {
     val run = new global.Run()
-    global.newCompilationUnit("", s"Cell$cellId")
+    val cellName = s"Cell$cellId"
+    global.newCompilationUnit("", cellName)
 
     val shiftEffect = IO.ioConcurrentEffect(shift) // TODO: we can also create an implicit shift instead of doing this, which is better?
     Queue.unbounded[IO, Option[Result]](shiftEffect).flatMap { maybeResultQ =>
@@ -165,7 +166,7 @@ class PythonInterpreter(val symbolTable: RuntimeSymbolTable) extends LanguageInt
         jep.eval("sys.stdout = __polynote_displayhook__\n")
         jep.eval("__polynote_locals__ = {}\n")
         jep.set("__polynote_code__", code)
-        jep.set("__polynote_cell__", cellId)
+        jep.set("__polynote_cell__", cellName)
 
         // all of this parsing is just so if the last statement is an expression, we can print the value like the repl does
         // TODO: should probably just use ipython to evaluate it instead

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
@@ -46,7 +46,7 @@ class ScalaInterpreter(
 
   override def shutdown(): IO[Unit] = shutdownSignal.complete
 
-  protected val previousSources: mutable.HashMap[String, ScalaSource[this.type]] = new mutable.HashMap()
+  protected val previousSources: mutable.HashMap[Short, ScalaSource[this.type]] = new mutable.HashMap()
 
   protected lazy val notebookPackageName = global.TermName("$notebook")
   def notebookPackage = global.Ident(notebookPackageName)
@@ -60,9 +60,9 @@ class ScalaInterpreter(
   override def init(): IO[Unit] = IO.unit // pass for now
 
   override def runCode(
-    cell: String,
+    cell: Short,
     visibleSymbols: Seq[Decl],
-    previousCells: Seq[String],
+    previousCells: Seq[Short],
     code: String
   ): IO[Stream[IO, Result]] = {
     val originalOut = System.out
@@ -207,9 +207,9 @@ class ScalaInterpreter(
   }
 
   override def completionsAt(
-    cell: String,
+    cell: Short,
     visibleSymbols: Seq[Decl],
-    previousCells: Seq[String],
+    previousCells: Seq[Short],
     code: String,
     pos: Int
   ): IO[List[Completion]] =
@@ -233,9 +233,9 @@ class ScalaInterpreter(
     }.handleErrorWith(err => IO(logger.error(err)("Completions error")).as(Nil))
 
   override def parametersAt(
-    cell: String,
+    cell: Short,
     visibleSymbols: Seq[Decl],
-    previousCells: Seq[String],
+    previousCells: Seq[Short],
     code: String,
     pos: Int
   ): IO[Option[Signatures]] =

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
@@ -15,7 +15,7 @@ import polynote.kernel.PolyKernel.EnqueueSome
 import polynote.kernel._
 import polynote.kernel.lang.LanguageInterpreter
 import polynote.kernel.util._
-import polynote.messages.{CellResult, ShortList, ShortString, TinyList, TinyString}
+import polynote.messages.{CellID, CellResult, ShortList, ShortString, TinyList, TinyString}
 
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
@@ -46,7 +46,7 @@ class ScalaInterpreter(
 
   override def shutdown(): IO[Unit] = shutdownSignal.complete
 
-  protected val previousSources: mutable.HashMap[Short, ScalaSource[this.type]] = new mutable.HashMap()
+  protected val previousSources: mutable.HashMap[CellID, ScalaSource[this.type]] = new mutable.HashMap()
 
   protected lazy val notebookPackageName = global.TermName("$notebook")
   def notebookPackage = global.Ident(notebookPackageName)
@@ -60,9 +60,9 @@ class ScalaInterpreter(
   override def init(): IO[Unit] = IO.unit // pass for now
 
   override def runCode(
-    cell: Short,
+    cell: CellID,
     visibleSymbols: Seq[Decl],
-    previousCells: Seq[Short],
+    previousCells: Seq[CellID],
     code: String
   ): IO[Stream[IO, Result]] = {
     val originalOut = System.out
@@ -207,9 +207,9 @@ class ScalaInterpreter(
   }
 
   override def completionsAt(
-    cell: Short,
+    cell: CellID,
     visibleSymbols: Seq[Decl],
-    previousCells: Seq[Short],
+    previousCells: Seq[CellID],
     code: String,
     pos: Int
   ): IO[List[Completion]] =
@@ -233,9 +233,9 @@ class ScalaInterpreter(
     }.handleErrorWith(err => IO(logger.error(err)("Completions error")).as(Nil))
 
   override def parametersAt(
-    cell: Short,
+    cell: CellID,
     visibleSymbols: Seq[Decl],
-    previousCells: Seq[Short],
+    previousCells: Seq[CellID],
     code: String,
     pos: Int
   ): IO[Option[Signatures]] =

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaSource.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaSource.scala
@@ -4,6 +4,7 @@ import cats.data.Ior
 import cats.syntax.either._
 import polynote.kernel.EmptyCell
 import polynote.kernel.util.KernelReporter
+import polynote.messages.CellID
 
 import scala.annotation.tailrec
 import scala.reflect.internal.util.{ListOfNil, Position, RangePosition, SourceFile}
@@ -15,7 +16,7 @@ import scala.reflect.internal.util.{ListOfNil, Position, RangePosition, SourceFi
   *       unwound?
   */
 class ScalaSource[Interpreter <: ScalaInterpreter](val interpreter: Interpreter)(
-  cellId: Short,
+  id: CellID,
   availableSymbols: Set[Interpreter#Decl],
   previousSources: List[ScalaSource[Interpreter]],
   code: String
@@ -71,7 +72,7 @@ class ScalaSource[Interpreter <: ScalaInterpreter](val interpreter: Interpreter)
     transformer.transform(tree)
   }
 
-  private val cellName = s"Cell$cellId"
+  private val cellName = s"Cell$id"
   private lazy val unitParser = global.newUnitParser(code, cellName)
 
   // the parsed trees, but only successful if there weren't any parse errors

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaSource.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaSource.scala
@@ -15,7 +15,7 @@ import scala.reflect.internal.util.{ListOfNil, Position, RangePosition, SourceFi
   *       unwound?
   */
 class ScalaSource[Interpreter <: ScalaInterpreter](val interpreter: Interpreter)(
-  id: String,
+  cellId: Short,
   availableSymbols: Set[Interpreter#Decl],
   previousSources: List[ScalaSource[Interpreter]],
   code: String
@@ -71,7 +71,8 @@ class ScalaSource[Interpreter <: ScalaInterpreter](val interpreter: Interpreter)
     transformer.transform(tree)
   }
 
-  private lazy val unitParser = global.newUnitParser(code, id)
+  private val cellName = s"Cell$cellId"
+  private lazy val unitParser = global.newUnitParser(code, cellName)
 
   // the parsed trees, but only successful if there weren't any parse errors
   lazy val parsed: Ior[Throwable, List[Tree]] = reporter.attemptIor(unitParser.parseStats())
@@ -93,7 +94,7 @@ class ScalaSource[Interpreter <: ScalaInterpreter](val interpreter: Interpreter)
 
   private lazy val executionId = global.currentRunId
 
-  lazy val moduleName: global.TermName = global.TermName(s"Eval$$$id$$$executionId")
+  lazy val moduleName: global.TermName = global.TermName(s"Eval$$$cellName$$$executionId")
 
   private lazy val results = parsedTrees.flatMap {
     trees => Either.catchNonFatal {
@@ -195,7 +196,7 @@ class ScalaSource[Interpreter <: ScalaInterpreter](val interpreter: Interpreter)
 
   private lazy val compileUnit: Either[Throwable, global.CompilationUnit] = wrapped.right.map {
     tree =>
-      val sourceFile = CellSourceFile(id)
+      val sourceFile = CellSourceFile(cellName)
       val unit = new global.RichCompilationUnit(sourceFile) //new global.CompilationUnit(CellSourceFile(id))
       unit.body = tree
       unit.status = global.JustParsed

--- a/polynote-kernel/src/main/scala/polynote/kernel/util/RuntimeSymbolTable.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/RuntimeSymbolTable.scala
@@ -7,6 +7,7 @@ import fs2.Stream
 import fs2.concurrent.{SignallingRef, Topic}
 import polynote.kernel.{KernelStatusUpdate, ResultValue}
 import polynote.kernel.lang.LanguageInterpreter
+import polynote.messages.CellID
 
 import scala.collection.mutable
 import scala.collection.JavaConverters._
@@ -24,7 +25,7 @@ final class RuntimeSymbolTable(
   private val currentSymbolTable: ConcurrentHashMap[TermName, RuntimeValue] = new ConcurrentHashMap()
   private val disposed = ReadySignal()
 
-  private val cellIds: mutable.TreeSet[Short] = new mutable.TreeSet()
+  private val cellIds: mutable.TreeSet[CellID] = new mutable.TreeSet()
 
   private val newSymbols: Topic[IO, RuntimeValue] =
     Topic[IO, RuntimeValue]{
@@ -62,7 +63,7 @@ final class RuntimeSymbolTable(
     cellIds.add(value.sourceCellId)
   }
 
-  def publish(source: LanguageInterpreter[IO], sourceCellId: Short)(name: String, value: Any, staticType: Option[global.Type]): IO[Unit] = {
+  def publish(source: LanguageInterpreter[IO], sourceCellId: CellID)(name: String, value: Any, staticType: Option[global.Type]): IO[Unit] = {
     val rv = RuntimeValue(name, value, staticType.getOrElse(kernelContext.inferType(value)), Some(source), sourceCellId)
     for {
       _    <- IO(putValue(rv))
@@ -96,7 +97,7 @@ final class RuntimeSymbolTable(
     value: Any,
     scalaTypeHolder: global.Type,
     source: Option[LanguageInterpreter[IO]],
-    sourceCellId: Short
+    sourceCellId: CellID
   ) extends SymbolDecl[IO] {
 
     override def scalaType(g: Global): g.Type = if (g eq global) {
@@ -112,7 +113,7 @@ final class RuntimeSymbolTable(
   }
 
   object RuntimeValue {
-    def apply(name: String, value: Any, source: Option[LanguageInterpreter[IO]], sourceCell: Short): RuntimeValue = RuntimeValue(
+    def apply(name: String, value: Any, source: Option[LanguageInterpreter[IO]], sourceCell: CellID): RuntimeValue = RuntimeValue(
       name, value, kernelContext.inferType(value), source, sourceCell
     )
 
@@ -137,7 +138,7 @@ final class RuntimeSymbolTable(
 trait SymbolDecl[F[_]] {
   def name: String
   def source: Option[LanguageInterpreter[F]]
-  def sourceCellId: Short
+  def sourceCellId: CellID
   def scalaType(g: Global): g.Type
   def getValue: Option[Any]
 }

--- a/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
+++ b/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
@@ -59,7 +59,7 @@ final case class CellMetadata(
 )
 
 final case class NotebookCell(
-  id: Short,
+  id: CellID,
   language: TinyString,
   content: Rope,
   results: ShortList[Result] = ShortList(Nil),
@@ -69,7 +69,7 @@ final case class NotebookCell(
 }
 
 object NotebookCell {
-  def apply(id: Short, language: TinyString, content: String): NotebookCell = NotebookCell(id, language, Rope(content))
+  def apply(id: CellID, language: TinyString, content: String): NotebookCell = NotebookCell(id, language, Rope(content))
 }
 
 final case class NotebookConfig(
@@ -87,19 +87,21 @@ final case class Notebook(path: ShortString, cells: ShortList[NotebookCell], con
     cells = ShortList(cells.map(fn))
   )
 
-  def updateCell(id: Short)(fn: NotebookCell => NotebookCell): Notebook = map {
+  def updateCell(id: CellID)(fn: NotebookCell => NotebookCell): Notebook = map {
     case cell if cell.id == id => fn(cell)
     case cell => cell
   }
 
-  def editCell(id: Short, edits: ContentEdits): Notebook = updateCell(id) {
+  def editCell(id: CellID, edits: ContentEdits): Notebook = updateCell(id) {
     cell => cell.updateContent(_.withEdits(edits))
   }
 
   def addCell(cell: NotebookCell): Notebook = copy(cells = ShortList(cells :+ cell))
 
-  def insertCell(cell: NotebookCell, after: Option[Short]): Notebook = {
-    val insertIndex = after.fold(0)(id => cells.indexWhere(_.id == id)) match {
+  def insertCell(cell: NotebookCell, after: Short): Notebook = {
+    require(!cells.exists(_.id == cell.id), s"Cell ids must be unique, a cell with id ${cell.id} already exists")
+
+    val insertIndex = cells.indexWhere(_.id == after) match {
       case -1 => 0
       case n => n
     }
@@ -109,25 +111,25 @@ final case class Notebook(path: ShortString, cells: ShortList[NotebookCell], con
         cells.take(insertIndex + 1) ++ (cell :: cells.drop(insertIndex + 1))))
   }
 
-  def deleteCell(id: Short): Notebook = copy(cells = ShortList(cells.collect {
+  def deleteCell(id: CellID): Notebook = copy(cells = ShortList(cells.collect {
     case cell if cell.id != id => cell
   }))
 
-  def setResults(id: Short, results: List[Result]): Notebook = updateCell(id) {
+  def setResults(id: CellID, results: List[Result]): Notebook = updateCell(id) {
     cell => cell.copy(results = ShortList(results))
   }
 
-  def getCell(id: Short): Option[NotebookCell] = cells.find(_.id == id)
+  def getCell(id: CellID): Option[NotebookCell] = cells.find(_.id == id)
 
-  def cell(id: Short): NotebookCell = getCell(id).getOrElse(throw new NoSuchElementException(s"Cell $id does not exist"))
+  def cell(id: CellID): NotebookCell = getCell(id).getOrElse(throw new NoSuchElementException(s"Cell $id does not exist"))
 }
 
 object Notebook extends MessageCompanion[Notebook](2)
 
-final case class RunCell(notebook: ShortString, cellIds: ShortList[Short]) extends Message
+final case class RunCell(notebook: ShortString, ids: ShortList[CellID]) extends Message
 object RunCell extends MessageCompanion[RunCell](3)
 
-final case class CellResult(notebook: ShortString, cellId: Short, result: Result) extends Message
+final case class CellResult(notebook: ShortString, id: CellID, result: Result) extends Message
 object CellResult extends MessageCompanion[CellResult](4)
 
 sealed trait NotebookUpdate extends Message {
@@ -147,7 +149,7 @@ sealed trait NotebookUpdate extends Message {
   def rebase(prev: NotebookUpdate): NotebookUpdate = (this, prev) match {
     case (i@InsertCell(_, _, _, cell1, after1), InsertCell(_, _, _, cell2, after2)) if after1 == after2 =>
       // we both tried to insert a cell after the same cell. Transform the first update so it inserts after the cell created by the second update.
-      i.copy(after = Some(cell2.id))
+      i.copy(after = cell2.id)
 
     case (u@UpdateCell(_, _, _, id1, edits1), UpdateCell(_, _, _, id2, edits2)) if id1 == id2 =>
       // we both tried to edit the same cell. Transform first edits so they apply to the document state as it exists after the second edits are already applied.
@@ -167,16 +169,16 @@ object NotebookUpdate {
   }
 }
 
-final case class UpdateCell(notebook: ShortString, globalVersion: Int, localVersion: Int, cellId: Short, edits: ContentEdits) extends Message with NotebookUpdate
+final case class UpdateCell(notebook: ShortString, globalVersion: Int, localVersion: Int, id: CellID, edits: ContentEdits) extends Message with NotebookUpdate
 object UpdateCell extends MessageCompanion[UpdateCell](5)
 
-final case class InsertCell(notebook: ShortString, globalVersion: Int, localVersion: Int, cell: NotebookCell, after: Option[Short]) extends Message with NotebookUpdate
+final case class InsertCell(notebook: ShortString, globalVersion: Int, localVersion: Int, cell: NotebookCell, after: CellID) extends Message with NotebookUpdate
 object InsertCell extends MessageCompanion[InsertCell](6)
 
-final case class CompletionsAt(notebook: ShortString, cellId: Short, pos: Int, completions: ShortList[Completion]) extends Message
+final case class CompletionsAt(notebook: ShortString, id: CellID, pos: Int, completions: ShortList[Completion]) extends Message
 object CompletionsAt extends MessageCompanion[CompletionsAt](7)
 
-final case class ParametersAt(notebook: ShortString, cellId: Short, pos: Int, signatures: Option[Signatures]) extends Message
+final case class ParametersAt(notebook: ShortString, id: CellID, pos: Int, signatures: Option[Signatures]) extends Message
 object ParametersAt extends MessageCompanion[ParametersAt](8)
 
 final case class KernelStatus(notebook: ShortString, update: KernelStatusUpdate) extends Message
@@ -185,7 +187,7 @@ object KernelStatus extends MessageCompanion[KernelStatus](9)
 final case class UpdateConfig(notebook: ShortString, globalVersion: Int, localVersion: Int, config: NotebookConfig) extends Message with NotebookUpdate
 object UpdateConfig extends MessageCompanion[UpdateConfig](10)
 
-final case class SetCellLanguage(notebook: ShortString, globalVersion: Int, localVersion: Int, cellId: Short, language: TinyString) extends Message with NotebookUpdate
+final case class SetCellLanguage(notebook: ShortString, globalVersion: Int, localVersion: Int, id: CellID, language: TinyString) extends Message with NotebookUpdate
 object SetCellLanguage extends MessageCompanion[SetCellLanguage](11)
 
 final case class StartKernel(notebook: ShortString, level: Byte) extends Message
@@ -203,7 +205,7 @@ object ListNotebooks extends MessageCompanion[ListNotebooks](13)
 final case class CreateNotebook(path: ShortString) extends Message
 object CreateNotebook extends MessageCompanion[CreateNotebook](14)
 
-final case class DeleteCell(notebook: ShortString, globalVersion: Int, localVersion: Int, cellId: Short) extends Message with NotebookUpdate
+final case class DeleteCell(notebook: ShortString, globalVersion: Int, localVersion: Int, id: CellID) extends Message with NotebookUpdate
 object DeleteCell extends MessageCompanion[DeleteCell](15)
 
 final case class ServerHandshake(

--- a/polynote-kernel/src/main/scala/polynote/messages/package.scala
+++ b/polynote-kernel/src/main/scala/polynote/messages/package.scala
@@ -98,4 +98,9 @@ package object messages {
     .|(0) { case Ior.Left(a) => a } (Ior.left) (codecA)
     .|(1) { case Ior.Right(b) => b } (Ior.right) (codecB)
     .|(2) { case Ior.Both(a, b) => (a, b) } ((Ior.both[A, B] _).tupled) (codecA ~ codecB)
+
+  // alias for Cell ID type so we can more easily change it (if needed)
+  type CellID = Short
+
+  implicit def int2cellId(i: Int): CellID = i.toShort
 }

--- a/polynote-kernel/src/test/scala/polynote/kernel/lang/KernelSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/lang/KernelSpec.scala
@@ -63,7 +63,7 @@ trait KernelSpec {
         // publishes to symbol table as a side-effect
         // TODO: ideally we wouldn't need to run predef specially
         symsF   <- symbolTable.subscribe()(_ => IO.unit).map(_._1).interruptWhen(done()).compile.toVector.start
-        results <- interp.runCode("test", symbolTable.currentTerms.map(_.asInstanceOf[interp.Decl]), Nil, code)
+        results <- interp.runCode(0, symbolTable.currentTerms.map(_.asInstanceOf[interp.Decl]), Nil, code)
         output  <- results.evalMap {
             case v: ResultValue =>
               symbolTable.publishAll(symbolTable.RuntimeValue.fromResultValue(v, interp).toList).map { _ =>

--- a/polynote-kernel/src/test/scala/polynote/kernel/lang/scal/ScalaInterpreterSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/lang/scal/ScalaInterpreterSpec.scala
@@ -40,7 +40,7 @@ class ScalaInterpreterSpec extends FlatSpec with Matchers with KernelSpec {
           "hm" -> Map(1 -> "foo", "foo" -> 100, "hey!" ->  List(100, List(1, "foo", Map("sup?" -> "nm"), false))),
           "humm" -> Map(1 -> "foo", "foo" -> 100, "hey!" ->  List(100, List(1, "foo", Map("sup?" -> "nm"), false))))
       )
-      vars("z").toString should (include("$notebook.Eval$test$") and include("$MyNewClass"))
+      vars("z").toString should (include("$notebook.Eval") and include("$MyNewClass"))
 
 
       displayed shouldBe empty

--- a/polynote-kernel/src/test/scala/polynote/test/Generators.scala
+++ b/polynote-kernel/src/test/scala/polynote/test/Generators.scala
@@ -3,7 +3,7 @@ package polynote.test
 import org.scalacheck.{Arbitrary, Gen}
 import Arbitrary.arbitrary
 import polynote.data.Rope
-import polynote.messages.{ContentEdit, ContentEdits, Delete, Insert, NotebookCell, TinyString, ShortList}
+import polynote.messages.{CellID, ContentEdit, ContentEdits, Delete, Insert, NotebookCell, ShortList, TinyString}
 
 import scala.collection.immutable.Queue
 
@@ -48,10 +48,10 @@ object Generators {
   // applying a bunch of edits to it
   implicit val arbRope: Arbitrary[Rope] = Arbitrary(genEdits.map(_._3))
 
-  def genCell(cellId: Short): Gen[NotebookCell] = for {
+  def genCell(id: CellID): Gen[NotebookCell] = for {
     lang <- Gen.oneOf[TinyString]("text", "scala", "python")
     content <- genRope
     // TODO: also generate results & metadata
-  } yield NotebookCell(cellId, lang, content)
+  } yield NotebookCell(id, lang, content)
 
 }

--- a/polynote-kernel/src/test/scala/polynote/test/Generators.scala
+++ b/polynote-kernel/src/test/scala/polynote/test/Generators.scala
@@ -48,10 +48,10 @@ object Generators {
   // applying a bunch of edits to it
   implicit val arbRope: Arbitrary[Rope] = Arbitrary(genEdits.map(_._3))
 
-  def genCell(id: String): Gen[NotebookCell] = for {
+  def genCell(cellId: Short): Gen[NotebookCell] = for {
     lang <- Gen.oneOf[TinyString]("text", "scala", "python")
     content <- genRope
     // TODO: also generate results & metadata
-  } yield NotebookCell(id, lang, content)
+  } yield NotebookCell(cellId, lang, content)
 
 }

--- a/polynote-server/src/main/scala/polynote/server/repository/MarkdownNotebookRepository.scala
+++ b/polynote-server/src/main/scala/polynote/server/repository/MarkdownNotebookRepository.scala
@@ -36,10 +36,10 @@ class MarkdownNotebookRepository(
   override protected val defaultExtension: String = "md"
 
   private def textCell(content: String, i: Int) =
-    NotebookCell(TinyString(s"Cell$i"), TinyString("text"), Rope(content), ShortList(Nil))
+    NotebookCell(i.toShort, TinyString("text"), Rope(content), ShortList(Nil))
 
   private def codeCell(node: FencedCodeBlock, i: Int) =
-    NotebookCell(TinyString(s"Cell$i"), TinyString(node.getInfo.normalizeEOL()), Rope(node.getContentChars.normalizeEOL()), ShortList(Nil))
+    NotebookCell(i.toShort, TinyString(node.getInfo.normalizeEOL()), Rope(node.getContentChars.normalizeEOL()), ShortList(Nil))
 
   private def collectCells(path: String, document: Document): Notebook =
     document.getChildren.iterator().asScala.foldLeft((0, 0, Notebook(ShortString(path), ShortList(Nil), None))) {
@@ -66,7 +66,7 @@ class MarkdownNotebookRepository(
           val parsedChildren = children.collect {
             case child: HtmlBlock => scala.xml.XML.loadString(child.getContentChars.normalizeEOL())
           }
-          val parsedResults: ShortList[Result] = ShortList(parsedChildren.flatMap(htmlToResult(_, nb.cells.last.id)))
+          val parsedResults: ShortList[Result] = ShortList(parsedChildren.flatMap(htmlToResult(_, nb.cells.last.id.toString)))
           (node.getEndOffset, node.getEndOffset, nb.copy(cells = ShortList(nb.cells.dropRight(1) :+ nb.cells.last.copy(results = parsedResults))))
 
         case other =>

--- a/polynote-server/src/main/scala/polynote/server/repository/MarkdownNotebookRepository.scala
+++ b/polynote-server/src/main/scala/polynote/server/repository/MarkdownNotebookRepository.scala
@@ -8,7 +8,7 @@ import cats.syntax.either._
 import com.vladsch.flexmark.ast._
 import com.vladsch.flexmark.ext.yaml.front.matter.{YamlFrontMatterBlock, YamlFrontMatterExtension}
 import com.vladsch.flexmark.parser.Parser
-import polynote.messages.{Notebook, NotebookCell, NotebookConfig, ShortList, ShortString, TinyString}
+import polynote.messages._
 import io.circe.syntax._
 import io.circe.yaml.Printer
 import polynote.data.Rope
@@ -36,10 +36,10 @@ class MarkdownNotebookRepository(
   override protected val defaultExtension: String = "md"
 
   private def textCell(content: String, i: Int) =
-    NotebookCell(i.toShort, TinyString("text"), Rope(content), ShortList(Nil))
+    NotebookCell(i, TinyString("text"), Rope(content), ShortList(Nil))
 
   private def codeCell(node: FencedCodeBlock, i: Int) =
-    NotebookCell(i.toShort, TinyString(node.getInfo.normalizeEOL()), Rope(node.getContentChars.normalizeEOL()), ShortList(Nil))
+    NotebookCell(i, TinyString(node.getInfo.normalizeEOL()), Rope(node.getContentChars.normalizeEOL()), ShortList(Nil))
 
   private def collectCells(path: String, document: Document): Notebook =
     document.getChildren.iterator().asScala.foldLeft((0, 0, Notebook(ShortString(path), ShortList(Nil), None))) {

--- a/polynote-server/src/main/scala/polynote/server/repository/NotebookRepository.scala
+++ b/polynote-server/src/main/scala/polynote/server/repository/NotebookRepository.scala
@@ -6,7 +6,7 @@ import java.nio.file.{FileAlreadyExistsException, FileVisitOption, Files, Path}
 import scala.collection.JavaConverters._
 import cats.effect.{ContextShift, IO}
 import polynote.config.DependencyConfigs
-import polynote.messages.{Notebook, NotebookCell, NotebookConfig, ShortList, ShortString}
+import polynote.messages._
 import polynote.server.ServerConfig
 
 import scala.concurrent.ExecutionContext
@@ -75,7 +75,7 @@ trait FileBasedRepository extends NotebookRepository[IO] {
   def emptyNotebook(path: String, title: String): Notebook = Notebook(
     ShortString(path),
     ShortList(
-      NotebookCell(0.toShort, "text", s"# $title\n\nThis is a text cell. Start editing!") :: Nil
+      NotebookCell(0, "text", s"# $title\n\nThis is a text cell. Start editing!") :: Nil
     ),
     Some(NotebookConfig(Option(serverConfig.dependencies.asInstanceOf[DependencyConfigs]), Option(serverConfig.repositories)))
   )

--- a/polynote-server/src/main/scala/polynote/server/repository/NotebookRepository.scala
+++ b/polynote-server/src/main/scala/polynote/server/repository/NotebookRepository.scala
@@ -75,7 +75,7 @@ trait FileBasedRepository extends NotebookRepository[IO] {
   def emptyNotebook(path: String, title: String): Notebook = Notebook(
     ShortString(path),
     ShortList(
-      NotebookCell("Cell0", "text", s"# $title\n\nThis is a text cell. Start editing!") :: Nil
+      NotebookCell(0.toShort, "text", s"# $title\n\nThis is a text cell. Start editing!") :: Nil
     ),
     Some(NotebookConfig(Option(serverConfig.dependencies.asInstanceOf[DependencyConfigs]), Option(serverConfig.repositories)))
   )

--- a/polynote-spark/src/main/scala/polynote/kernel/lang/sql/Parser.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/lang/sql/Parser.scala
@@ -10,7 +10,7 @@ import scala.collection.mutable.ListBuffer
 
 class Parser {
 
-  def parse(id: String, sql: String): Ior[CompileErrors, Parser.Result] = {
+  def parse(cellId: Short, sql: String): Ior[CompileErrors, Parser.Result] = {
      val lexer = new SqlBaseLexer(new org.antlr.v4.runtime.ANTLRInputStream(sql) {
        override def LA(i: Int): Int = {
          val la = super.LA(i)
@@ -25,7 +25,7 @@ class Parser {
 
     parser.addErrorListener(new BaseErrorListener {
       override def syntaxError(recognizer: Recognizer[_, _], offendingSymbol: AnyRef, line: Int, charPositionInLine: Int, msg: String, e: RecognitionException): Unit = {
-        errors += report(id, msg, e)
+        errors += report(cellId, msg, e)
       }
     })
 
@@ -49,15 +49,15 @@ class Parser {
       }
     } catch {
       case err: RecognitionException =>
-        errors += report(id, err.getMessage, err)
+        errors += report(cellId, err.getMessage, err)
         Ior.left(CompileErrors(errors.toList))
     }
 
   }
 
-  private def report(id: String, msg: String, err: RecognitionException): KernelReport = {
+  private def report(cellId: Short, msg: String, err: RecognitionException): KernelReport = {
     val token = err.getOffendingToken
-    val pos = Pos(id, token.getStartIndex, token.getStopIndex, token.getStartIndex)
+    val pos = Pos(s"Cell$cellId", token.getStartIndex, token.getStopIndex, token.getStartIndex)
     KernelReport(pos, msg, KernelReport.Error)
   }
 }

--- a/polynote-spark/src/main/scala/polynote/kernel/lang/sql/SparkSqlInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/lang/sql/SparkSqlInterpreter.scala
@@ -88,27 +88,27 @@ class SparkSqlInterpreter(val symbolTable: RuntimeSymbolTable) extends LanguageI
   }.handleErrorWith(err => IO.pure(RuntimeError(err)))
 
   override def runCode(
-    cell: String,
+    cellId: Short,
     visibleSymbols: Seq[Decl],
-    previousCells: Seq[String],
+    previousCellIds: Seq[Short],
     code: String
   ): IO[fs2.Stream[IO, Result]] = {
     val compilerRun = new global.Run
-    val cellIndex = previousCells.size
+    val cellIndex = previousCellIds.size
     val run = for {
       _           <- symbolTable.drain()
-      parseResult <- IO.fromEither(parser.parse(cell, code).fold(Left(_), Right(_), (errs, _) => Left(errs)))
+      parseResult <- IO.fromEither(parser.parse(cellId, code).fold(Left(_), Right(_), (errs, _) => Left(errs)))
       resultDF    <- registerTempViews(parseResult.tableIdentifiers).sequence.bracket(_ => IO(spark.sql(code)))(dropTempViews)
-      cellResult   = ResultValue(kernelContext, "Out", global.typeOf[DataFrame], resultDF, cell)
+      cellResult   = ResultValue(kernelContext, "Out", global.typeOf[DataFrame], resultDF, cellId)
     } yield Stream.emit(cellResult) ++ Stream.eval(outputDataFrame(resultDF))
 
     run.handleErrorWith(err => IO.pure(Stream.emit(RuntimeError(err))))
   }
 
   override def completionsAt(
-    cell: String,
+    cellIds: Short,
     visibleSymbols: Seq[Decl],
-    previousCells: Seq[String],
+    previousCellIds: Seq[Short],
     code: String,
     pos: Int
   ): IO[List[Completion]] = {
@@ -119,11 +119,11 @@ class SparkSqlInterpreter(val symbolTable: RuntimeSymbolTable) extends LanguageI
     }
 
     for {
-      parseResult <- IO.fromEither(parser.parse(cell, code).toEither)
+      parseResult <- IO.fromEither(parser.parse(cellIds, code).toEither)
     } yield completeAtPos(parseResult.statement)
   }
 
-  override def parametersAt(cell: String, visibleSymbols: Seq[Decl], previousCells: Seq[String], code: String, pos: Int): IO[Option[Signatures]] =
+  override def parametersAt(cellId: Short, visibleSymbols: Seq[Decl], previousCellIds: Seq[Short], code: String, pos: Int): IO[Option[Signatures]] =
     IO(None) // TODO: could we generate parameter hints for spark's builtin functions?
 
   override def init(): IO[Unit] = IO.unit


### PR DESCRIPTION
Cell ID is now a short and we no longer read execution count. This is possible now due to the changes in #76 which eliminates our need to persist cell IDs in the order they were created. 

Addresses #70 as it was due to id space collisions when reading execution count. 