### PR TITLE
avoid bracketing when resource acquisition can fail

### DIFF
--- a/polynote-server/src/main/scala/polynote/server/ServerConfig.scala
+++ b/polynote-server/src/main/scala/polynote/server/ServerConfig.scala
@@ -42,9 +42,8 @@ object ServerConfig {
   def load(file: File): IO[ServerConfig] = {
 
     IO(new FileReader(file)).flatMap { reader =>
-      val parsed = IO.fromEither(yaml.parser.parse(reader).flatMap(_.as[ServerConfig]))
-      reader.close()
-      parsed
+      IO.fromEither(yaml.parser.parse(reader).flatMap(_.as[ServerConfig]))
+        .guarantee(IO(reader.close()))
     } handleErrorWith {
       case err: MatchError =>
         IO.pure(ServerConfig()) // TODO: Handles an upstream issue with circe-yaml, on an empty config file https://github.com/circe/circe-yaml/issues/50

--- a/polynote-server/src/main/scala/polynote/server/ServerConfig.scala
+++ b/polynote-server/src/main/scala/polynote/server/ServerConfig.scala
@@ -39,14 +39,20 @@ object ServerConfig {
 
   def parse(content: String): Either[Throwable, ServerConfig] = yaml.parser.parse(content).flatMap(_.as[ServerConfig])
 
-  def load(file: File): IO[ServerConfig] = IO(new FileReader(file)).bracket {
-    reader => IO.fromEither(yaml.parser.parse(reader).flatMap(_.as[ServerConfig]))
-  }(reader => IO(reader.close())).handleErrorWith {
-    case err: MatchError =>
-      IO.pure(ServerConfig()) // TODO: Handles an upstream issue with circe-yaml, on an empty config file https://github.com/circe/circe-yaml/issues/50
-    case err: FileNotFoundException =>
-      IO(logger.warn(s"Configuration file $file not found; using default configuration")).as(new ServerConfig())
-    case err: Throwable => IO.raiseError(err)
+  def load(file: File): IO[ServerConfig] = {
+
+    IO(new FileReader(file)).flatMap { reader =>
+      val parsed = IO.fromEither(yaml.parser.parse(reader).flatMap(_.as[ServerConfig]))
+      reader.close()
+      parsed
+    } handleErrorWith {
+      case err: MatchError =>
+        IO.pure(ServerConfig()) // TODO: Handles an upstream issue with circe-yaml, on an empty config file https://github.com/circe/circe-yaml/issues/50
+      case err: FileNotFoundException =>
+        IO(logger.warn(s"Configuration file $file not found; using default configuration")).as(new ServerConfig())
+      case err: Throwable => IO.raiseError(err)
+    }
+
   }
 
 }


### PR DESCRIPTION
I don't fully understand why but it looks like `acquire.bracket(use)(release)` doesn't properly handle failures in `acquire`. It looks like there's some signal or something that isn't being properly cleaned up in this case, leaving some thread up which causes the JVM to hang when you send a SIGINT (ctrl-c) to Polynote.

This PR solves it but it's probably not idiomatic. 

Here's a thread dump showing the waiting main thread after I'd sent a SIGINT to it: 
```
"main" #1 prio=5 os_prio=0 tid=0x00007f8438029800 nid=0x5bd3 waiting on condition [0x00007f8441edd000]
   java.lang.Thread.State: WAITING (parking)
        at sun.misc.Unsafe.park(Native Method)
        - parking to wait for  <0x00000006800233d0> (a cats.effect.internals.IOPlatform$OneShotLatch)
        at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:836)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedInterruptibly(AbstractQueuedSynchronizer.java:997)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1304)
        at cats.effect.internals.IOPlatform$$anonfun$unsafeResync$1.apply$mcV$sp(IOPlatform.scala:50)
        at cats.effect.internals.IOPlatform$$anonfun$unsafeResync$1.apply(IOPlatform.scala:50)
        at cats.effect.internals.IOPlatform$$anonfun$unsafeResync$1.apply(IOPlatform.scala:50)
        at scala.concurrent.BlockContext$DefaultBlockContext$.blockOn(BlockContext.scala:53)
        at scala.concurrent.package$.blocking(package.scala:123)
        at cats.effect.internals.IOPlatform$.unsafeResync(IOPlatform.scala:50)
        at cats.effect.IO.unsafeRunTimed(IO.scala:325)
        at cats.effect.IO.unsafeRunSync(IO.scala:240)
        at cats.effect.internals.IOAppPlatform$.main(IOAppPlatform.scala:24)
        at cats.effect.IOApp$class.main(IOApp.scala:67)
        at polynote.server.SparkServer$.main(SparkServer.scala:13)
        at polynote.server.SparkServer.main(SparkServer.scala)

```