### PR TITLE
make sure to close filesystem

### DIFF
--- a/polynote-spark/src/main/scala/polynote/kernel/SparkPolyKernel.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/SparkPolyKernel.scala
@@ -54,6 +54,7 @@ class SparkPolyKernel(
         val inPath = jarFS.getPath(polynoteRuntimeJar)
         val runtimeJar = new File(tmp.toFile, polynoteRuntimeJar).toPath
         Files.copy(inPath, runtimeJar, StandardCopyOption.REPLACE_EXISTING)
+        jarFS.close()
         runtimeJar
 
       case "file" =>


### PR DESCRIPTION
This was causing @faisalzs 's 
```
java.nio.file.FileSystemAlreadyExistsException
	at com.sun.nio.zipfs.ZipFileSystemProvider.newFileSystem(ZipFileSystemProvider.java:113)
	at java.nio.file.FileSystems.newFileSystem(FileSystems.java:326)
	at java.nio.file.FileSystems.newFileSystem(FileSystems.java:276)
	at polynote.kernel.SparkPolyKernel.runtimeJar(SparkPolyKernel.scala:50)
	at polynote.kernel.SparkPolyKernel.dependencyJars$lzycompute(SparkPolyKernel.scala:76)
	at polynote.kernel.SparkPolyKernel.dependencyJars(SparkPolyKernel.scala:64)
	at polynote.kernel.SparkPolyKernel.polynote$kernel$SparkPolyKernel$$session$lzycompute(SparkPolyKernel.scala:101)
	at polynote.kernel.SparkPolyKernel.polynote$kernel$SparkPolyKernel$$session(SparkPolyKernel.scala:95)
	at polynote.kernel.SparkPolyKernel$$anonfun$2$$anonfun$apply$5$$anonfun$apply$6.apply(SparkPolyKernel.scala:135)
	at polynote.kernel.SparkPolyKernel$$anonfun$2$$anonfun$apply$5$$anonfun$apply$6.apply(SparkPolyKernel.scala:135)

```