### PR TITLE
Collapsed exceptions

### DIFF
--- a/polynote-frontend/polynote/tags.js
+++ b/polynote-frontend/polynote/tags.js
@@ -262,3 +262,11 @@ export function table(classes, contentSpec) {
 
     return table;
 }
+
+export function details(classes, summary, content) {
+    const el = tag('details', classes, {}, [
+        tag('summary', [], {}, summary)
+    ]);
+    appendContent(el, content);
+    return el;
+}

--- a/polynote-frontend/polynote/ui.js
+++ b/polynote-frontend/polynote/ui.js
@@ -1341,7 +1341,7 @@ export class MainUI extends EventTarget {
         });
 
         this.tabUI.addEventListener('TabActivated', evt => {
-            const tab = evt.detail.tab
+            const tab = evt.detail.tab;
             if (tab.type === 'notebook') {
                 window.history.pushState({notebook: tab.name}, `${tab.name.split(/\//g).pop()} | Polynote`, `/notebook/${tab.name}`);
                 this.currentNotebookPath = tab.name;

--- a/polynote-kernel/src/main/scala/polynote/kernel/PolyKernel.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/PolyKernel.scala
@@ -170,12 +170,10 @@ class PolyKernel private[kernel] (
                     case result =>
                       IO.pure(result)
                   }
-                }.handleErrorWith {
-                  case errs@CompileErrors(_) => IO.pure(Stream.emit(errs))
-                  case err@RuntimeError(_) => IO.pure(Stream.emit(err))
-                  case err => IO.pure(Stream.emit(RuntimeError(err)))
                 }
-            }.map(_.getOrElse(Stream.empty)).handleErrorWith(err => IO.pure(Stream.emit(RuntimeError(err)))).map {
+            }.map {
+              _.getOrElse(Stream.empty)
+            }.handleErrorWith(ErrorResult.toStream).map {
               _ ++ Stream.eval(oq.enqueue1(None)).drain ++ Stream.eval(symbolTable.drain()).drain
             }
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
@@ -86,15 +86,15 @@ class ScalaInterpreter(
               runtimeSym =>
                 kernelContext.runInterruptible {
                   val moduleMirror = try runtimeMirror.reflectModule(runtimeSym.asModule) catch {
-                    case err: ExceptionInInitializerError => throw new RuntimeError(err.getCause)
+                    case err: ExceptionInInitializerError => throw RuntimeError(err.getCause)
                     case err: Throwable =>
-                      throw new RuntimeError(err) // could be linkage errors which won't get handled by IO#handleErrorWith
+                      throw RuntimeError(err) // could be linkage errors which won't get handled by IO#handleErrorWith
                   }
 
                   val instMirror = try runtimeMirror.reflect(moduleMirror.instance) catch {
-                    case err: ExceptionInInitializerError => throw new RuntimeError(err.getCause)
+                    case err: ExceptionInInitializerError => throw RuntimeError(err.getCause)
                     case err: Throwable =>
-                      throw new RuntimeError(err)
+                      throw RuntimeError(err)
                   }
 
                   val runtimeType = instMirror.symbol.info
@@ -188,7 +188,7 @@ class ScalaInterpreter(
                 for {
                   pub   <- outputs.through(resultQ.enqueue).compile.drain.start
                   fiber <- runWithCapturedStdout.start
-                } yield fiber.join.uncancelable.handleErrorWith(err => IO.pure(List(RuntimeError(err))))
+                } yield fiber.join.uncancelable.handleErrorWith(err => IO.pure(List(ErrorResult(err))))
             }
 
             eval.map {

--- a/polynote-server/src/main/scala/polynote/server/SharedNotebook.scala
+++ b/polynote-server/src/main/scala/polynote/server/SharedNotebook.scala
@@ -304,11 +304,7 @@ class IOSharedNotebook(
                           case (ver, nb) => ver -> nb.setResults(id, buf.toList)
                         }
                       }
-                  }.handleErrorWith {
-                    case errs@CompileErrors(_) => IO.pure(Stream.emit(errs))
-                    case err@RuntimeError(_) => IO.pure(Stream.emit(err))
-                    case err => IO.pure(Stream.emit(RuntimeError(err)))
-                  }
+                  }.handleErrorWith(ErrorResult.toStream)
                 }
             }
         }

--- a/polynote-server/src/main/scala/polynote/server/SocketSession.scala
+++ b/polynote-server/src/main/scala/polynote/server/SocketSession.scala
@@ -86,10 +86,7 @@ class SocketSession(
           Stream(oq.dequeue.interruptWhen(closeSignal()), responses.parJoinUnbounded).parJoinUnbounded
             .handleErrorWith {
               err =>
-                val re = err match {
-                  case RuntimeError(e) => e
-                  case e => RuntimeError(e)
-                }
+                val re = ErrorResult(err)
                 Stream.eval(logError(re).map(_ => Error(0, re)))
             }
             //.evalTap(logMessage)

--- a/polynote-spark/src/main/scala/polynote/kernel/lang/sql/SparkSqlInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/lang/sql/SparkSqlInterpreter.scala
@@ -86,7 +86,7 @@ class SparkSqlInterpreter(val symbolTable: RuntimeSymbolTable) extends LanguageI
            |</table>""".stripMargin
       )
     }
-  }.handleErrorWith(err => IO.pure(RuntimeError(err)))
+  }.handleErrorWith(ErrorResult.applyIO)
 
   override def runCode(
     cell: CellID,
@@ -103,7 +103,7 @@ class SparkSqlInterpreter(val symbolTable: RuntimeSymbolTable) extends LanguageI
       cellResult   = ResultValue(kernelContext, "Out", global.typeOf[DataFrame], resultDF, cell)
     } yield Stream.emit(cellResult) ++ Stream.eval(outputDataFrame(resultDF))
 
-    run.handleErrorWith(err => IO.pure(Stream.emit(RuntimeError(err))))
+    run.handleErrorWith(ErrorResult.toStream)
   }
 
   override def completionsAt(


### PR DESCRIPTION
Runtime exceptions now display with a collapsed/expandable stack trace. They also include the causes (up to 4 levels) which are similarly collapsed by default.

Also added a new constructors for handling errors into message-able errors (without over-wrapping them into `RuntimeError`).

Fixes #94 