### PR TITLE
Handle other remote updates in the UI

### DIFF
--- a/polynote-frontend/polynote/comms.js
+++ b/polynote-frontend/polynote/comms.js
@@ -73,7 +73,7 @@ export class SocketSession extends EventTarget {
 
                 for (var handler of this.messageListeners) {
                     if (msg instanceof handler[0]) {
-                        const result = handler[1].apply(null, msg.constructor.unapply(msg));
+                        const result = handler[1].apply(null, handler[0].unapply(msg));
                         if (handler[2] && result === false) {
                             this.removeMessageListener(handler);
                         }

--- a/polynote-frontend/polynote/match.js
+++ b/polynote-frontend/polynote/match.js
@@ -1,0 +1,41 @@
+"use strict";
+
+export default function match(obj) {
+    return new Matcher(obj);
+}
+
+export class MatchError {
+    constructor(obj) {
+        this.obj = obj;
+        Object.freeze(this);
+    }
+}
+
+export class Matcher {
+    constructor(obj) {
+        this.obj = obj;
+    }
+
+    when(type, fn) {
+        if (this.result === undefined && this.obj instanceof type) {
+            this.result = fn(...type.unapply(this.obj)) || null;
+        }
+        return this;
+    }
+
+    otherwise(value) {
+        if (this.result !== undefined) {
+            return this.result;
+        } else {
+            return value;
+        }
+    }
+
+    get otherwiseThrow() {
+        if (this.result !== undefined) {
+            return this.result;
+        } else {
+            throw new MatchError(this.obj);
+        }
+    }
+}

--- a/polynote-frontend/polynote/toolbar.js
+++ b/polynote-frontend/polynote/toolbar.js
@@ -57,7 +57,7 @@ class NotebookToolbarUI extends UIEventTarget {
         this.el = toolbarElem("notebook", [
             [
                 iconButton(["run-cell", "run-all"], "Run all cells", "", "Run all")
-                    .click(() => this.dispatchEvent(new ToolbarEvent(("RunAll")))),
+                    .click(() => this.dispatchEvent(new ToolbarEvent("RunAll"))),
                 iconButton(["branch"], "Create branch", "", "Branch").disable(),
                 iconButton(["publish"], "Publish", "", "Publish").disable(),
             ], [
@@ -82,6 +82,8 @@ class CellToolbarUI extends UIEventTarget {
                     .click(() => this.dispatchEvent(new ToolbarEvent(("InsertBelow")))),
                 iconButton(["delete-cell"], "Delete current cell", "", "Delete")
                     .click(() => this.dispatchEvent(new ToolbarEvent(("DeleteCell")))),
+                iconButton(['undo'], 'Undo', '', 'Undo')
+                    .click(() => this.dispatchEvent(new ToolbarEvent('Undo'))),
             ]
         ]);
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
@@ -195,7 +195,7 @@ class ScalaInterpreter(
               ioValues =>
                 Stream(
                   maybeResultQ.dequeue.unNoneTerminate,
-                  Stream.eval(ioValues).flatMap(Stream.emits).onFinalize(maybeResultQ.enqueue1(None))
+                  Stream.eval(ioValues).flatMap(Stream.emits) ++ Stream.eval(maybeResultQ.enqueue1(None)).drain
                 ).parJoinUnbounded
             }
         }


### PR DESCRIPTION
Currently only remote cell edits are actually handled in the UI. This commit handles the rest of the types of edit.

Also added this `match` thing that is a slightly prettier way to typecase stuff. I dunno.