### PR TITLE
Fix bugs

### DIFF
--- a/polynote-frontend/polynote/cell.js
+++ b/polynote-frontend/polynote/cell.js
@@ -396,11 +396,11 @@ export class CodeCell extends Cell {
             if (result.name !== "Out") {
                 // don't display this; it's a named declaration
                 // TODO: have a way to display these if desired
-            } else if (!this.resultEl || !this.resultEl.reprs || !this.resultEl.reprs.length || this.resultEl.reprs.length < result.reprs.length) {
+            } else if (!this.resultEl || !this.resultEl.parentNode || !this.resultEl.reprs || !this.resultEl.reprs.length || this.resultEl.reprs.length < result.reprs.length) {
                 if (this.resultEl && this.resultEl.parentNode) {
                     this.resultEl.parentNode.removeChild(this.resultEl);
-                    this.resultEl = null;
                 }
+                this.resultEl = null;
                 const [mime, content] = result.displayRepr;
                 const outLabel = result.reprs.length <= 1
                     ? div(['out-ident'], `Out:`)

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
@@ -184,7 +184,7 @@ class ScalaInterpreter(
                 for {
                   pub   <- outputs.through(resultQ.enqueue).compile.drain.start
                   fiber <- runWithCapturedStdout.start
-                } yield fiber.join.uncancelable.handleErrorWith(err => IO.pure(List(ErrorResult(err))))
+                } yield fiber.join.uncancelable.handleErrorWith(err => IO.pure(List(ErrorResult(err)))) <* pub.join
             }
 
             eval.map {

--- a/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
+++ b/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
@@ -257,5 +257,5 @@ object ModifyStream extends MessageCompanion[ModifyStream](19) {
   implicit val codec: Codec[ModifyStream] = shapeless.cachedImplicit
 }
 
-final case class ReleaseHandle(path: String, handleType: HandleType, handle: Int) extends Message
+final case class ReleaseHandle(path: ShortString, handleType: HandleType, handle: Int) extends Message
 object ReleaseHandle extends MessageCompanion[ReleaseHandle](20)

--- a/polynote-kernel/src/test/scala/polynote/kernel/lang/scal/ScalaInterpreterSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/lang/scal/ScalaInterpreterSpec.scala
@@ -89,8 +89,8 @@ class ScalaInterpreterSpec extends FlatSpec with Matchers with KernelSpec {
 
       displayed shouldBe empty
       output should contain theSameElementsAs Seq(
-        Output("text/plain; rel=stdout", "println: 1 + 2 = 3"),
-        Output("text/plain; rel=stdout", "sys: 1 + 2 = 3")
+        Output("text/plain; rel=stdout", "println: 1 + 2 = 3\n"),
+        Output("text/plain; rel=stdout", "sys: 1 + 2 = 3\n")
       )
     }
 
@@ -105,7 +105,7 @@ class ScalaInterpreterSpec extends FlatSpec with Matchers with KernelSpec {
       vars.toSeq should contain only "kernel" -> polynote.runtime.Runtime
 
       displayed shouldBe empty
-      output should contain only Output("text/plain; rel=stdout", "Do you like muffins?")
+      output should contain only Output("text/plain; rel=stdout", "Do you like muffins?\n")
     }
   }
 }

--- a/polynote-runtime/src/main/scala/polynote/runtime/ScalaCell.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/ScalaCell.scala
@@ -1,9 +1,0 @@
-package polynote.runtime
-
-class ScalaCell extends AnyRef with Serializable {
-
-  // this prevents typecheck errors, but if cells do get serialized/deserialized in the same JVM could lead to weirdness.
-  // TODO: figure out the cause of the type error
-  protected def readResolve(): Object = this
-
-}

--- a/polynote-spark/src/main/scala/polynote/kernel/SparkPolyKernel.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/SparkPolyKernel.scala
@@ -96,7 +96,7 @@ class SparkPolyKernel(
 
   private lazy val session: SparkSession = {
     val nbConfig = getNotebook().unsafeRunSync().config
-    val conf = new SparkConf(loadDefaults = true)
+    val conf = org.apache.spark.repl.Main.conf
 
     nbConfig.flatMap(_.sparkConfig).getOrElse(config.spark).foreach {
       case (k, v) => conf.set(k, v)
@@ -108,15 +108,14 @@ class SparkPolyKernel(
     }
     conf.setJars(dependencyJars.map(_.toString))
     conf.set("spark.repl.class.outputDir", outputPath.toString)
+    conf.setAppName("Polynote session")
 
     // TODO: experimental
     //    conf.set("spark.driver.userClassPathFirst", "true")
     //    conf.set("spark.executor.userClassPathFirst", "true")
     // TODO: experimental
 
-    val sess = SparkSession.builder().config(conf)
-      .appName("PolyNote session")
-      .getOrCreate()
+    val sess = org.apache.spark.repl.Main.createSparkSession()
 
     // for some reason the jars aren't totally working...
 

--- a/polynote-spark/src/main/scala/polynote/kernel/SparkPolyKernel.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/SparkPolyKernel.scala
@@ -169,7 +169,7 @@ object SparkPolyKernel {
       nb => new File(nb.path).getName
     }.unsafeRunSync()
 
-    val outputPath = Files.createTempDirectory(notebookFilename)
+    val outputPath = org.apache.spark.repl.Main.outputDir.toPath
     outputPath.toFile.deleteOnExit()
 
     val outputDir = new PlainDirectory(new Directory(outputPath.toFile))

--- a/polynote-spark/src/main/scala/polynote/kernel/lang/scal/ScalaSparkInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/lang/scal/ScalaSparkInterpreter.scala
@@ -16,7 +16,12 @@ class ScalaSparkInterpreter(st: RuntimeSymbolTable) extends ScalaInterpreter(st)
   override def predefCode: Option[String] = Some {
     s"""${super.predefCode.getOrElse("")}
        |import org.apache.spark.sql.SparkSession
-       |final val spark: SparkSession = SparkSession.builder().getOrCreate()
+       |@transient val spark: SparkSession = if (org.apache.spark.repl.Main.sparkSession != null) {
+       |            org.apache.spark.repl.Main.sparkSession
+       |          } else {
+       |            org.apache.spark.repl.Main.createSparkSession()
+       |          }
+       |import org.apache.spark.sql.{DataFrame, Dataset}
        |import this.spark.implicits._
        |import org.apache.spark.sql.functions._
      """.stripMargin


### PR DESCRIPTION
This commit fixes an issue wherein any cell that referred to `spark` and also contained a closure which referenced a member of the same cell would fail to initialize on the executor side.

The reason for this is that we were simply wrapping the cell's code in an `object`, and therefore regardless of serialization, the code would be run as a static initializer for the class (so whenever the class was loaded anywhere).

This is why the Scala REPL provides "class-based" wrapping, which Spark uses. Instead, we wrap the code in a class, and instantiate that class inside of an object. Then, the code is not run as a static initializer but in the class's constructor – which won't be run after deserialization.

So `ScalaSource` has been changed to wrap in a similar way – except we also do a little more (hopefully) smart stuff. We move class definitions to the object, so they won't be inner classes (which cause a lot of problems). And we make `lazy val` and def forwarders in the object which delegate to the instance, to simplify importing later on. This fixes the Spark issue with a minimum of other changes (since the declarations are all available on the object just as they were before).

Also fixes some misc JS bugs.