### PR TITLE
Fix web font

### DIFF
--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -2,28 +2,28 @@
   font-family: Hasklig;
   font-weight: 400;
   font-style: normal;
-  src: url(fonts/Hasklig-Regular.otf) format("otf");
+  src: url(/style/fonts/Hasklig-Regular.otf) format("opentype");
 }
 
 @font-face {
   font-family: Hasklig;
   font-weight: 400;
   font-style: italic;
-  src: url(fonts/Hasklig-It.otf) format("otf");
+  src: url(/style/fonts/Hasklig-It.otf) format("opentype");
 }
 
 @font-face {
   font-family: Hasklig;
   font-weight: 700;
   font-style: normal;
-  src: url(fonts/Hasklig-Bold.otf) format("otf");
+  src: url(/style/fonts/Hasklig-Bold.otf) format("opentype");
 }
 
 @font-face {
   font-family: Hasklig;
   font-weight: 800;
   font-style: italic;
-  src: url(fonts/Hasklig-BoldIt.otf) format("otf");
+  src: url(/style/fonts/Hasklig-BoldIt.otf) format("opentype");
 }
 
 @ui-background: rgb(245, 245, 245);


### PR DESCRIPTION
Fixes the Hasklig webfont. It turns out Menlo has terrible ligatures, so we should probably either

1) Remove Menlo from the list,
2) Disable ligatures,
3) Make ligatures configurable, or
4) Somehow detect which font is being used and selectively enable ligatures.

I really like the ligatures and I'd be sad to see them go. But, I'm not married to it. Once the Hasklig webfont works, happy to hear from others whether it's nicer than Menlo for them.