### PR TITLE
Whitelist log4j

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/util/KernelContext.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/KernelContext.scala
@@ -162,7 +162,7 @@ object KernelContext {
       */
     val dependencyClassLoader: URLClassLoader =
     new LimitedSharingClassLoader(
-      "^(scala|javax?|jdk|sun|com.sun|com.oracle|polynote|org.w3c|org.xml|org.omg|org.ietf|org.jcp|org.apache.spark|org.apache.hadoop|org.codehaus|org.slf4j)\\.",
+      "^(scala|javax?|jdk|sun|com.sun|com.oracle|polynote|org.w3c|org.xml|org.omg|org.ietf|org.jcp|org.apache.spark|org.apache.hadoop|org.codehaus|org.slf4j|org.log4j)\\.",
       dependencyClassPath,
       parentClassLoader)
 


### PR DESCRIPTION
Share log4j so that it doesn't get re-initialized by notebook code (this can cause exceptions when a non-URL `log4j.configuration` is specified – see https://github.com/Netflix/blitz4j/issues/13)