### PR TITLE
Use production webpack to generate the distribution

### DIFF
--- a/polynote-frontend/package.json
+++ b/polynote-frontend/package.json
@@ -22,6 +22,7 @@
   },
   "scripts": {
     "build": "webpack --config webpack.config.js",
+    "dist": "webpack --config webpack.config.js --mode production",
     "watch": "webpack --config webpack.config.js --watch"
   }
 }

--- a/scripts/make-distribution.sh
+++ b/scripts/make-distribution.sh
@@ -11,7 +11,7 @@ pushd ${DIR}/../
     root=`pwd`
     pushd polynote-frontend
         npm install
-        npm run build
+        npm run dist
     popd
 
     sbt 'project polynote-spark' 'set test in assembly := {}' 'assembly'


### PR DESCRIPTION
This will cut down the assembly size (and JS load) considerably. Maybe we can have an alternate mechanism for developer-mode deployment (i.e. keep giant debuggable JS files)