### PR TITLE
Some fixes for PythonInterpreter

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
@@ -9,7 +9,7 @@ import cats.effect.{ContextShift, IO}
 import fs2.Stream
 import fs2.concurrent.{Enqueue, Queue}
 import jep.python.{PyCallable, PyObject}
-import jep.{Jep, JepConfig}
+import jep.{Jep, JepConfig, NamingConventionClassEnquirer}
 import polynote.kernel.PolyKernel.EnqueueSome
 import polynote.kernel._
 import polynote.kernel.util.{Publish, ReadySignal, RuntimeSymbolTable}
@@ -103,41 +103,21 @@ class PythonInterpreter(val symbolTable: RuntimeSymbolTable) extends LanguageInt
 
   def withJep[T](t: => T): IO[T] = shift.evalOn(executionContext)(IO.delay(t))
 
-  private val jep = jepExecutor.submit {
+  protected val jep: Jep = jepExecutor.submit {
     new Callable[Jep] {
       def call(): Jep = {
-        val jep = new Jep(new JepConfig().addSharedModules("numpy").setInteractive(false))
-//        jep.eval(
-//          """def __polynote_export_value__(d, k):
-//            |  globals().update({ "__polynote_exported__": d[k] })
-//          """.stripMargin)
+        val jep = new Jep(
+          new JepConfig()
+            .addSharedModules("numpy")
+            .setInteractive(false)
+            .setClassLoader(kernelContext.classLoader)
+            .setClassEnquirer(new NamingConventionClassEnquirer(true)))
         jep
       }
     }
   }.get()
 
   private val shutdownSignal = ReadySignal()(listenerShift)
-
-  // TODO: This is kind of a slow way to do this conversion, as it will result in a lot of JNI calls, but it is
-  //       necessary to work around https://github.com/ninia/jep/issues/43 until that gets resolved. We don't want
-  //       anything being converted to String except Strings. It's further complicated by the lack of being able to
-  //       force PyObject return for invoke(), so there is some python-side stuff that we have to do.
-  private def convertPythonValue(jep: Jep, value: PyObject): Any = {
-
-    def convertPythonDict(dict: PyObject): Map[String, Any] = {
-      val keys = jep.invoke("__builtins__.dict.keys", dict).asInstanceOf[java.util.List[String]].asScala.toSeq
-      keys.map {
-        key =>
-          jep.invoke("__polynote_export_value__", dict, key)
-          key -> convertPythonValue(jep, jep.getValue("__polynote_exported__", classOf[PyObject]))
-      }.toMap
-    }
-
-    val typStr = jep.invoke("__builtins__.type", value).asInstanceOf[PyCallable].getAttr("__name__").asInstanceOf[String]
-    typStr match {
-      case "dict" =>
-    }
-  }
 
   override def runCode(
     cell: CellID,
@@ -216,34 +196,41 @@ class PythonInterpreter(val symbolTable: RuntimeSymbolTable) extends LanguageInt
   }
 
   def getPyResults(decls: Seq[String], sourceCellId: CellID): Map[String, ResultValue] = {
-    decls.map {
-      name => name -> {
-        getPyResult(name) match {
+    decls.flatMap {
+      name =>
+        getPyResult(name).map {
           case (value, Some(typ)) =>
             ResultValue(kernelContext, name, typ, value, sourceCellId)
           case (value, _) =>
             ResultValue(kernelContext, name, value, sourceCellId)
+        }.map {
+          value => name -> value
         }
-      }
     }.toMap
   }
 
-  def getPyResult(accessor: String): (Any, Option[global.Type]) = {
+  // TODO: This is kind of a slow way to do this conversion, as it will result in a lot of JNI calls, but it is
+  //       necessary to work around https://github.com/ninia/jep/issues/43 until that gets resolved. We don't want
+  //       anything being converted to String except Strings.
+  def getPyResult(accessor: String): Option[(Any, Option[global.Type])] = {
     val resultType = jep.getValue(s"type($accessor).__name__", classOf[String])
     import global.{typeOf, weakTypeOf}
     resultType match {
-      case "int" => jep.getValue(accessor, classOf[java.lang.Number]).longValue() -> Some(typeOf[Long])
-      case "float" => jep.getValue(accessor, classOf[java.lang.Number]).doubleValue() -> Some(typeOf[Double])
-      case "str" => jep.getValue(accessor, classOf[String]) -> Some(typeOf[String])
-      case "bool" => jep.getValue(accessor, classOf[java.lang.Boolean]).booleanValue() -> Some(typeOf[Boolean])
+      case "int" => Option(jep.getValue(accessor, classOf[java.lang.Number]).longValue() -> Some(typeOf[Long]))
+      case "float" => Option(jep.getValue(accessor, classOf[java.lang.Number]).doubleValue() -> Some(typeOf[Double]))
+      case "str" => Option(jep.getValue(accessor, classOf[String]) -> Some(typeOf[String]))
+      case "bool" => Option(jep.getValue(accessor, classOf[java.lang.Boolean]).booleanValue() -> Some(typeOf[Boolean]))
       case "tuple" => getPyResult(s"list($accessor)")
-      case "dict" =>
-        val keys = getPyResult(s"list($accessor.keys())")._1.asInstanceOf[List[Any]]
-        val values = getPyResult(s"list($accessor.values())")._1.asInstanceOf[List[Any]]
-        keys.zip(values).toMap -> Some(typeOf[Map[Any, Any]])
+      case "dict" => for {
+        keys <- getPyResult(s"list($accessor.keys())")
+        values <- getPyResult(s"list($accessor.values())")
+      } yield {
+        keys._1.asInstanceOf[List[Any]].zip(values._1.asInstanceOf[List[Any]]).toMap -> Some(typeOf[Map[Any, Any]])
+      }
       case "list" =>
+        // TODO: this in particular is pretty inefficient... it does a JNI call for every element of the list.
         val numElements = jep.getValue(s"len($accessor)", classOf[java.lang.Number]).longValue()
-        val (elems, types) = (0L until numElements).map(n => getPyResult(s"$accessor[$n]")).toList.unzip
+        val (elems, types) = (0L until numElements).flatMap(n => getPyResult(s"$accessor[$n]")).toList.unzip
 
         val listType = global.ask {
           () =>
@@ -256,11 +243,14 @@ class PythonInterpreter(val symbolTable: RuntimeSymbolTable) extends LanguageInt
             global.appliedType(typeOf[List[Any]].typeConstructor, lubType)
         }
 
-        elems -> Some(listType)
+        Option(elems -> Some(listType))
       case "PyJObject" =>
-        jep.getValue(accessor) -> Some(typeOf[AnyRef])
+        Option(jep.getValue(accessor) -> Some(typeOf[AnyRef]))
+      case "module" | "type" => None
+      case "function" | "builtin_function_or_method" => Option(jep.getValue(accessor, classOf[PyCallable]) -> Some(typeOf[PyCallable]))
+
       case _ =>
-        jep.getValue(accessor, classOf[PyObject]) -> Some(typeOf[PyObject])
+        Option(jep.getValue(accessor, classOf[PyObject]) -> Some(typeOf[PyObject]))
     }
   }
 

--- a/polynote-kernel/src/test/scala/polynote/kernel/lang/python/PythonInterpreterSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/lang/python/PythonInterpreterSpec.scala
@@ -153,6 +153,9 @@ class PythonInterpreterSpec extends FlatSpec with Matchers with KernelSpec {
         foo.bar(1, 2, 3) shouldEqual 6
         foo.bar(1, bb = 2, cc = 3) shouldEqual 6
         foo.bar(aa = 1, bb = 2, cc = 3) shouldEqual 6
+
+        foo.wizzle = "wizzlewozzleweasel"
+        foo.wizzle[String] shouldEqual "wizzlewozzleweasel"
     }
   }
 

--- a/polynote-runtime/src/main/scala/polynote/runtime/python/PythonFunction.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/python/PythonFunction.scala
@@ -1,0 +1,35 @@
+package polynote.runtime.python
+
+import java.util.concurrent.{Callable, ExecutorService}
+
+import jep.python.PyCallable
+
+import scala.collection.JavaConverters._
+import scala.language.dynamics
+
+/**
+  * Some Scala sugar around [[PyCallable]]
+  */
+class PythonFunction(callable: PyCallable, runner: PythonObject.Runner) extends PythonObject(callable, runner) with Dynamic {
+
+  private def unwrapArg(arg: Any): Any = arg match {
+    case pyObj: PythonObject => pyObj.unwrap
+    case obj => obj
+  }
+
+  override def applyDynamic(method: String)(args: Any*): Any = {
+    if (method == "apply" || method == "call" || method == "__call__")
+      callPosArgs(callable, args.asInstanceOf[Seq[AnyRef]])
+    else
+      super.applyDynamic(method)(args: _*)
+
+  }
+
+  override def applyDynamicNamed(method: String)(args: (String, Any)*): Any = {
+    if (method == "apply" || method == "call" || method == "__call__")
+      callKwArgs(callable, args)
+    else
+      super.applyDynamicNamed(method)(args: _*)
+  }
+
+}

--- a/polynote-runtime/src/main/scala/polynote/runtime/python/PythonObject.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/python/PythonObject.scala
@@ -97,7 +97,7 @@ object PythonObject {
     def tag: ClassTag[Class]
   }
 
-  object ReturnTypeFor extends ReturnTypeForNothing {
+  object ReturnTypeFor extends ReturnTypeForSomething {
     type Aux[T, Out0] = ReturnTypeFor[T] { type Out = Out0 }
 
     implicit val forNothing: Aux[Nothing, PythonObject] = new ReturnTypeFor[Nothing] {
@@ -111,7 +111,7 @@ object PythonObject {
     }
   }
 
-  private[PythonObject] trait ReturnTypeForNothing { self: ReturnTypeFor.type =>
+  private[PythonObject] trait ReturnTypeForSomething { self: ReturnTypeFor.type =>
     implicit def forSomething[T : ClassTag]: Aux[T, T] = new ReturnTypeFor[T] {
       type Out = T
       type Class = T

--- a/polynote-runtime/src/main/scala/polynote/runtime/python/PythonObject.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/python/PythonObject.scala
@@ -1,0 +1,127 @@
+package polynote.runtime.python
+
+import java.util.concurrent.{Callable, ExecutorService}
+
+import jep.python.{PyCallable, PyObject}
+import polynote.runtime.python.PythonObject.ReturnTypeFor
+
+import scala.collection.JavaConverters._
+import scala.reflect.{ClassTag, classTag}
+
+import scala.language.dynamics
+
+/**
+  * Just a bit of Scala sugar over [[PyObject]]
+  */
+class PythonObject(obj: PyObject, runner: PythonObject.Runner) extends Dynamic {
+  import PythonObject.unwrapArg
+
+  private[polynote] def unwrap: PyObject = obj
+
+  protected def callPosArgs(callable: PyCallable, args: Seq[AnyRef]): AnyRef = {
+    runner.run {
+      callable.call(args.map(unwrapArg): _*)
+    } match {
+      case pc: PyCallable => new PythonFunction(pc, runner)
+      case po: PyObject   => new PythonObject(po, runner)
+      case other => other
+    }
+  }
+
+  protected def callKwArgs(callable: PyCallable, args: Seq[(String, Any)]): AnyRef = {
+    val kwArgIndex = args.indexWhere(_._1.nonEmpty)
+    val (posArgs, kwArgs) = if (kwArgIndex >= 0) {
+      args.splitAt(kwArgIndex)
+    } else (args, Nil)
+
+    val posArgsArray = posArgs.map(tup => unwrapArg(tup._2.asInstanceOf[AnyRef])).toArray
+    val kwArgsMap = kwArgs.toMap.mapValues(_.asInstanceOf[AnyRef]).mapValues(unwrapArg).toSeq.toMap // make sure it's a strict map
+
+    runner.run {
+      if (posArgsArray.nonEmpty && kwArgsMap.nonEmpty) {
+        callable.call(posArgsArray, kwArgsMap.asJava)
+      } else if (posArgsArray.nonEmpty) {
+        callable.call(posArgsArray: _*)
+      } else if (kwArgsMap.nonEmpty) {
+        callable.call(kwArgsMap.asJava)
+      } else {
+        callable.call()
+      }
+    } match {
+      case pc: PyCallable => new PythonFunction(pc, runner)
+      case po: PyObject   => new PythonObject(po, runner)
+      case other => other
+    }
+  }
+
+  def selectDynamic[T](name: String)(implicit returnType: ReturnTypeFor[T]): returnType.Out = {
+    runner.run {
+      returnType.wrap(obj.getAttr(name, returnType.tag.runtimeClass.asInstanceOf[Class[returnType.Class]]), runner)
+    }
+  }
+
+  def updateDynamic(name: String)(value: Any): Unit = runner.run {
+    obj.setAttr(name, value)
+  }
+
+  // TODO: Jep doesn't give us a way to invoke a PyCallable and get back a PyObject in case the result can't be converted
+  //       to a Java representation. So we'll run into the stringification problem here. We should try to fix this upstream
+  //       in Jep.
+  def applyDynamic(method: String)(args: Any*): Any =
+      callPosArgs(selectDynamic[PyCallable](method), args.asInstanceOf[Seq[AnyRef]])
+
+
+  def applyDynamicNamed(method: String)(args: (String, Any)*): Any =
+      callKwArgs(selectDynamic[PyCallable](method), args)
+
+  override def toString: String = runner.run {
+    obj.toString
+  }
+
+}
+
+object PythonObject {
+
+  def unwrapArg(arg: AnyRef): AnyRef = arg match {
+    case pyObj: PythonObject => pyObj.unwrap
+    case other => other
+  }
+
+  // We can't have an overloaded selectDynamic, so this is an approximation of it.
+  // When called with no type argument, the type argument is inferred to be Nothing, so we can use this type function
+  // to catch that case and return PythonObject.
+  trait ReturnTypeFor[T] {
+    type Out
+    type Class
+    def wrap(value: Class, runner: Runner): Out
+    def tag: ClassTag[Class]
+  }
+
+  object ReturnTypeFor extends ReturnTypeForNothing {
+    type Aux[T, Out0] = ReturnTypeFor[T] { type Out = Out0 }
+
+    implicit val forNothing: Aux[Nothing, PythonObject] = new ReturnTypeFor[Nothing] {
+      type Out = PythonObject
+      type Class = PyObject
+      val tag: ClassTag[PyObject] = classTag[PyObject]
+      def wrap(value: PyObject, runner: Runner): PythonObject = value match {
+        case v: PyCallable => new PythonFunction(v, runner)
+        case v => new PythonObject(v, runner)
+      }
+    }
+  }
+
+  private[PythonObject] trait ReturnTypeForNothing { self: ReturnTypeFor.type =>
+    implicit def forSomething[T : ClassTag]: Aux[T, T] = new ReturnTypeFor[T] {
+      type Out = T
+      type Class = T
+      val tag: ClassTag[T] = classTag[T]
+      def wrap(value: T, runner: Runner): T = value
+    }
+  }
+
+  trait Runner {
+    def run[T](task: => T): T
+  }
+
+}


### PR DESCRIPTION
Fixes the Java-package-clash in python imports (particularly py4j).

Note that PySpark still doesn't work; more support is needed for that which will come in a later PR.