### PR TITLE
Improvements to plotting

### DIFF
--- a/polynote-frontend/polynote/fake_select.js
+++ b/polynote-frontend/polynote/fake_select.js
@@ -114,6 +114,68 @@ export class FakeSelect extends UIEventTarget {
         });
     }
 
+    recomputeVisible() {
+        this.element.querySelectorAll('.first-visible').forEach(el => el.classList.remove('first-visible'));
+        this.element.querySelectorAll('.last-visible').forEach(el => el.classList.remove('last-visible'));
+        let prevVisible = false;
+        let lastVisible = false;
+        this.options.forEach(opt => {
+           if (!opt.disabled) {
+               if (!prevVisible) {
+                   prevVisible = true;
+                   opt.classList.add('first-visible');
+               }
+               lastVisible = opt;
+           }
+        });
+
+        if (lastVisible) {
+            lastVisible.classList.add('last-visible');
+        }
+    }
+
+    hideOption(valueOrIndex) {
+        if (typeof(valueOrIndex) === "string") {
+            const idx = this.options.findIndex(opt => opt.value === valueOrIndex);
+            if (idx >= 0) {
+                this.hideOption(idx);
+            }
+        } else {
+            if (this.selectedIndex === valueOrIndex) {
+                if (this.options.length > this.selectedIndex) {
+                    this.selectedIndex = this.selectedIndex + 1;
+                } else if (this.selectedIndex > 0) {
+                    this.selectedIndex = this.selectedIndex - 1;
+                }
+            }
+            const opt = this.options[valueOrIndex];
+            if (opt) {
+                opt.disabled = true;
+            }
+
+            this.recomputeVisible();
+        }
+    }
+
+    showOption(valueOrIndex) {
+        if (typeof(valueOrIndex) === "string") {
+            const idx = this.options.findIndex(opt => opt.value === valueOrIndex);
+            if (idx >= 0) {
+                this.showOption(idx);
+            }
+        } else {
+            const opt = this.options[valueOrIndex];
+            if (opt) {
+                opt.disabled = false;
+            }
+            this.recomputeVisible();
+        }
+    }
+
+    showAllOptions() {
+        this.options.forEach((opt, index) => this.showOption(index));
+    }
+
     get selectedIndex() {
         return this.options.indexOf(this.selectedElement);
     }

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -204,7 +204,7 @@ body {
     position: absolute;
     right: 0;
     top: 0;
-    width: 1.5em;
+    width: 1em;
     height: 2em;
     line-height: 2em;
     user-select: none;
@@ -214,7 +214,7 @@ body {
   button {
     height: 0;
     width: auto;
-    padding: 0 2.5em 0 1em;
+    padding: 0 2em 0 1em;
     visibility: hidden;
     overflow: visible;
     display: block;
@@ -226,7 +226,7 @@ body {
   }
 
   button.selected, &.open button {
-    padding: .5em 2.5em .5em 1em;
+    padding: .5em 2em .5em 1em;
     line-height: 1;
     width: auto;
     height: auto;
@@ -241,21 +241,25 @@ body {
     border-color: @ui-border;
   }
 
-  &.open button {
+  &.open button:enabled {
     border-radius: 0;
     border-color: transparent @ui-border;
 
-    &:first-of-type {
+    &:first-of-type, &.first-visible {
       border-top-left-radius: 4px;
       border-top-right-radius: 4px;
       border-top-color: @ui-border;
     }
 
-    &:last-of-type {
+    &:last-of-type, &.last-visible {
       border-bottom-left-radius: 4px;
       border-bottom-right-radius: 4px;
       border-bottom-color: @ui-border;
     }
+  }
+
+  &.open button:disabled {
+    display: none;
   }
 
   &.open button:hover {
@@ -2042,6 +2046,10 @@ button {
     .dropdown {
       position: absolute;
       width: 6.5em;
+    }
+
+    .dropdown.open {
+      z-index: 10;
     }
   }
 


### PR DESCRIPTION
- Can have multiple series
- Can use quantiles in line plots, for confidence bounds
- Unsupported measures for current plot type are hidden from menu

I know this code is getting pretty messy. We're having to fight with vega-lite because we want to do the aggregation server-side and its "out-of-the-box" plots just aren't intended for that.

Still TODO is the ability to actually save a plot back to the notebook... have to figure out how that could be done in a reproducible way. Maybe a vega-lite interpreter that runs client-side and outputs an SVG? Which somehow gets shipped back to the server to save in the notebook? Yeesh 😬 