### PR TITLE
Refined python reprs

### DIFF
--- a/polynote-runtime/src/main/scala/polynote/runtime/ReprsOf.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/ReprsOf.scala
@@ -9,7 +9,9 @@ import shapeless.HNil
 import scala.collection.GenSeq
 import scala.concurrent.Future
 
-trait ReprsOf[T] extends (T => Array[ValueRepr]) with Serializable
+trait ReprsOf[T] extends Serializable {
+  def apply(value: T): Array[ValueRepr]
+}
 
 object ReprsOf extends ExpandedScopeReprs {
 

--- a/polynote-runtime/src/main/scala/polynote/runtime/python/PythonFunction.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/python/PythonFunction.scala
@@ -3,6 +3,7 @@ package polynote.runtime.python
 import java.util.concurrent.{Callable, ExecutorService}
 
 import jep.python.PyCallable
+import shapeless.Witness
 
 import scala.collection.JavaConverters._
 import scala.language.dynamics
@@ -10,7 +11,7 @@ import scala.language.dynamics
 /**
   * Some Scala sugar around [[PyCallable]]
   */
-class PythonFunction(callable: PyCallable, runner: PythonObject.Runner) extends PythonObject(callable, runner) with Dynamic {
+class PythonFunction(callable: PyCallable, runner: PythonObject.Runner) extends TypedPythonObject[PythonFunction.function](callable, runner) with Dynamic {
 
   private def unwrapArg(arg: Any): Any = arg match {
     case pyObj: PythonObject => pyObj.unwrap
@@ -32,4 +33,8 @@ class PythonFunction(callable: PyCallable, runner: PythonObject.Runner) extends 
       super.applyDynamicNamed(method)(args: _*)
   }
 
+}
+
+object PythonFunction {
+  type function = Witness.`"function"`.T
 }


### PR DESCRIPTION
- Add `TypedPythonObject` which we type `PyObject`s as in the interpreter. It will let us make specific reprs for different python types. (TODO)
- Some tweaks (and tests) for `PythonObject` and `PythonFunction`.
- Default reprs for `PythonObject` which poll the `__repr__`, `_repr_html_`, and `_repr_latex_` methods of the underlying python object