### PR TITLE
Before & after sections of symbol table

### DIFF
--- a/polynote-frontend/polynote/tags.js
+++ b/polynote-frontend/polynote/tags.js
@@ -67,6 +67,11 @@ export function tag(name, classes, attributes, content) {
         return el
     };
 
+    el.addClass = function(cls) {
+        el.classList.add(cls);
+        return el;
+    };
+
     return el;
 }
 
@@ -231,12 +236,15 @@ export function table(classes, contentSpec) {
         ...heading, body
     ]);
 
-    table.addRow = (row) => {
+    table.addRow = (row, whichBody) => {
+        const tbody = whichBody === undefined
+            ? body
+            : whichBody instanceof HTMLTableSectionElement ? whichBody : table.tBodies[whichBody];
         const rowEl = mkTR(row);
         if (contentSpec.addToTop)
-            body.insertBefore(rowEl, body.firstChild);
+            tbody.insertBefore(rowEl, tbody.firstChild);
         else
-            body.appendChild(rowEl);
+            tbody.appendChild(rowEl);
         return rowEl;
     };
 
@@ -258,6 +266,20 @@ export function table(classes, contentSpec) {
             }
         });
         return matches;
+    };
+
+    table.addBody = (rows) => {
+        const newBody = tag(
+            'tbody', [], [],
+            contentSpec.rows ? contentSpec.rows.map(mkTR) : []
+        );
+
+        table.appendChild(newBody);
+
+        if (rows) {
+            rows.forEach(row => this.addRow(row, newBody));
+        }
+        return newBody;
     };
 
     return table;

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -1987,6 +1987,10 @@ button {
     }
   }
   tbody {
+    &.results {
+      border-bottom: 2pt solid black;
+    }
+
     overflow-y: auto;
     background: white;
 


### PR DESCRIPTION
Adds an "after" section to the symbol table UI, so we can show both the
input values and output values of the current cell.

Now the result values of the current cell are shown (if there are any), followed by the "in scope" values, with a thicker border in between to show the separation.

Also fixes some strange behavior due to a bug in the order in which cells were considered