### PR TITLE
Don't throw on closed output

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/util/QueueOutputStream.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/QueueOutputStream.scala
@@ -18,7 +18,9 @@ class QueueOutputStream(
 
   def write(b: Int): Unit = buf.synchronized {
     if (closed.get()) {
-      throw new IllegalStateException("Writing to closed QueueOutputStream")
+      // TODO: Trouble is, we close the output right after running all the code, but what if there are background threads printing to stuff?
+      //       I guess we might want to keep the channel open and keep streaming output? But how to know when it's done?
+      //throw new IllegalStateException("Writing to closed QueueOutputStream")
     }
     if (!buf.hasRemaining) {
       flush()


### PR DESCRIPTION
Currently, if something tries to write to stdout after all the code in a cell has run, we throw an error. But, there might still be background threads that still try to write to that stdout. This probably deserves a better solution, but for now we'll just swallow that future output rather than throw.