### PR TITLE
Update monaco

### DIFF
--- a/polynote-frontend/package-lock.json
+++ b/polynote-frontend/package-lock.json
@@ -3159,9 +3159,9 @@
       }
     },
     "monaco-editor": {
-      "version": "0.15.6",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.15.6.tgz",
-      "integrity": "sha512-JoU9V9k6KqT9R9Tiw1RTU8ohZ+Xnf9DMg6Ktqqw5hILumwmq7xqa/KLXw513uTUsWbhtnHoSJYYR++u3pkyxJg=="
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.16.2.tgz",
+      "integrity": "sha512-NtGrFzf54jADe7qsWh3lazhS7Kj0XHkJUGBq9fA/Jbwc+sgVcyfsYF6z2AQ7hPqDC+JmdOt/OwFjBnRwqXtx6w=="
     },
     "monaco-editor-webpack-plugin": {
       "version": "1.7.0",

--- a/polynote-frontend/package.json
+++ b/polynote-frontend/package.json
@@ -4,7 +4,7 @@
     "katex": "^0.10.0",
     "markdown-it": "latest",
     "markdown-it-katex": "latest",
-    "monaco-editor": "^0.15.6",
+    "monaco-editor": "^0.16.2",
     "monaco-editor-webpack-plugin": "^1.7.0",
     "requirejs": "latest",
     "vega": "^5.2.0",

--- a/polynote-frontend/polynote/ui.js
+++ b/polynote-frontend/polynote/ui.js
@@ -39,7 +39,8 @@ export class KernelSymbolsUI {
             this.tableEl = table(['kernel-symbols-table'], {
                 header: ['Name', 'Type', 'Value'],
                 classes: ['name', 'type', 'value'],
-                rowHeading: true
+                rowHeading: true,
+                addToTop: true
             })
         ]);
         this.resultSymbols = this.tableEl.tBodies[0].addClass('results');
@@ -1300,7 +1301,6 @@ export class NotebookUI extends UIEventTarget {
                         result.valueText,
                         result.sourceCell);
                     const ids = this.cellUI.getCodeCellIdsBefore(id);
-                    this.kernelUI.symbols.presentFor(id, ids);
                 }
             }
         });


### PR DESCRIPTION
Seems like this fixes #174.

Also some tweaks to symbol UI (i.e. remove duplicated `kernel` and `spark` on initial load)

NPM and Webpack complain about some stuff due to `monaco-webpack-plugin` not being updated (there is an open PR for it, waiting for it to merge) but everything seems to work fine anyway.