### PR TITLE
Some fixes to the symbol table

### DIFF
--- a/polynote-frontend/polynote/cell.js
+++ b/polynote-frontend/polynote/cell.js
@@ -116,7 +116,10 @@ export class Cell extends UIEventTarget {
         // TODO: this is incomplete (hook up all the run buttons etc)
         this.cellInput.querySelector('.run-cell').onclick = (evt) => {
             this.dispatchEvent(new RunCellEvent(this.id));
-        }
+        };
+
+        // clicking anywhere in a cell should select it
+        this.container.addEventListener('mousedown', evt => this.makeActive());
 
     }
 
@@ -128,10 +131,13 @@ export class Cell extends UIEventTarget {
         if (Cell.currentFocus && Cell.currentFocus !== this) {
             Cell.currentFocus.blur();
         }
-        Cell.currentFocus = this;
-        this.container.classList.add('active');
 
-        this.dispatchEvent(new SelectCellEvent(this));
+        if (Cell.currentFocus !== this) {
+            Cell.currentFocus = this;
+            this.container.classList.add('active');
+
+            this.dispatchEvent(new SelectCellEvent(this));
+        }
     }
 
     blur() {

--- a/polynote-frontend/polynote/tags.js
+++ b/polynote-frontend/polynote/tags.js
@@ -248,7 +248,7 @@ export function table(classes, contentSpec) {
         return rowEl;
     };
 
-    table.findRows = (props) => table.findRowsBy((row) => {
+    table.findRows = (props, tbody) => table.findRowsBy((row, tbody) => {
         for (var prop in props) {
             if (props.hasOwnProperty(prop)) {
                 if (row[prop] !== props[prop])
@@ -258,9 +258,10 @@ export function table(classes, contentSpec) {
         return true;
     });
 
-    table.findRowsBy = (fn) => {
+    table.findRowsBy = (fn, tbody) => {
+        const [searchEl, selector] = tbody ? [tbody, 'tr'] : [table, 'tbody tr'];
         const matches = [];
-        [...table.querySelectorAll('tbody tr')].forEach(tr => {
+        [...searchEl.querySelectorAll(selector)].forEach(tr => {
             if (fn(tr.row)) {
                 matches.push(tr);
             }

--- a/polynote-frontend/polynote/ui.js
+++ b/polynote-frontend/polynote/ui.js
@@ -96,9 +96,19 @@ export class KernelSymbolsUI {
         }
 
         if (cellId === this.presentedCell) {
-            this.addResultRow(name, type, value);
+            const existing = this.tableEl.findRows({name}, this.resultSymbols)[0];
+            if (existing) {
+                this.updateRow(existing, name, type, value);
+            } else {
+                this.addResultRow(name, type, value);
+            }
         } else if (this.visibleCells.indexOf(cellId) >= 0 || this.predefs[cellId]) {
-            this.addScopeRow(name, type, value);
+            const existing = this.tableEl.findRows({name}, this.scopeSymbols)[0];
+            if (existing) {
+                this.updateRow(existing, name, type, value);
+            } else {
+                this.addScopeRow(name, type, value);
+            }
         }
     }
 
@@ -1228,7 +1238,6 @@ export class NotebookUI extends UIEventTarget {
                 switch (update.constructor) {
                     case messages.UpdatedTasks:
                         update.tasks.forEach(taskInfo => {
-                            //console.log(taskInfo);
                             this.kernelUI.tasks.updateTask(taskInfo.id, taskInfo.label, taskInfo.detail, taskInfo.status, taskInfo.progress);
 
                             // TODO: this is a quick-and-dirty running cell indicator. Should do this in a way that doesn't use the task updates

--- a/polynote-kernel/src/main/scala/polynote/kernel/util/NotebookContext.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/NotebookContext.scala
@@ -123,7 +123,17 @@ class NotebookContext(implicit concurrent: Concurrent[IO]) {
   def first: Option[CellContext] = Option(_first)
   def last: Option[CellContext] = Option(_last)
 
-  def allResultValues: List[ResultValue] = Option(_last).toList.flatMap(_.visibleValues)
+  /**
+    * @return All the [[ResultValue]]s that are visible from the last cell
+    */
+  def lastScope: List[ResultValue] = Option(_last).toList.flatMap(_.visibleValues)
+
+  /**
+    * @return All the [[ResultValue]]s that are visible from any cell
+    */
+  def allResultValues: List[ResultValue] = Option(_last).toList.flatMap(_.collectBack {
+    case ctx => ctx.resultValues
+  }.flatten)
 
   /**
     * If the context is already present, replace it with the given context and return old context. Otherwise, return None.

--- a/polynote-kernel/src/test/scala/polynote/kernel/util/NotebookContextSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/util/NotebookContextSpec.scala
@@ -231,7 +231,7 @@ class NotebookContextSpec extends FreeSpec with Matchers {
       }
     }
 
-    "allResultValues" in {
+    "lastScope" in {
       val notebookContext = new NotebookContext()
       val a = CellContext.unsafe(0)
       val b = CellContext.unsafe(1)
@@ -253,7 +253,7 @@ class NotebookContextSpec extends FreeSpec with Matchers {
       Stream.emit(b_b1).through(b.results.enqueue).compile.drain.unsafeRunSync()
       Stream.emits(Seq(c_c1, c_a2)).through(c.results.enqueue).compile.drain.unsafeRunSync()
 
-      notebookContext.allResultValues should contain theSameElementsAs List(a_a1, b_b1, c_c1, c_a2)
+      notebookContext.lastScope should contain theSameElementsAs List(a_a1, b_b1, c_c1, c_a2)
     }
 
   }


### PR DESCRIPTION
I guess I didn't think through the symbol table changes enough - there remained some issues and odd behavior which I hope this will address.

For one, we were only sending the visible results from the *last cell of the notebook* when the notebook is loaded. So if you reloaded the page and clicked through the notebook cells, some results just wouldn't show up (unless you ran the cells again). This is fixed by sending all results from all cells.

Another thing is that it's a bit odd when you click the "run" button on a cell and don't see anything happen on the symbol table. This is because the cell doesn't get "selected" when you click anything but the editor inside. This is fixed by making any click on the cell cause that cell to be "selected" (but not necessarily focused).

Also fixed some issues with symbols being duplicated oddly.