### PR TITLE
Warn if eta-expansion fails

### DIFF
--- a/polynote-frontend/polynote/cell.js
+++ b/polynote-frontend/polynote/cell.js
@@ -327,12 +327,13 @@ export class CodeCell extends Cell {
             reportInfos
         );
 
-        // clear the display
-        this.cellOutputDisplay.innerHTML = '';
-        this.stdOutDetails = null;
-        this.stdOutEl = null;
-        if (reports.length) {
+        // clear the display if there was a compile error
+        if (reportInfos.find(report => report.originalSeverity > 1)) {
+            this.clearResult();
             this.container.classList.add('error');
+        }
+
+        if (reports.length) {
             this.cellOutputDisplay.classList.add('errors');
             this.cellOutputDisplay.appendChild(
                 div(
@@ -348,9 +349,6 @@ export class CodeCell extends Cell {
                     })
                 )
             );
-        } else {
-            this.cellOutputDisplay.classList.remove('errors');
-            this.cellOutput.classList.remove('output');
         }
     }
 
@@ -603,7 +601,11 @@ export class CodeCell extends Cell {
     clearResult() {
         this.container.classList.remove('error', 'success');
         this.execInfoEl.classList.remove('output');
-        this.setErrors([]);
+        this.cellOutputDisplay.innerHTML = '';
+        this.cellOutputDisplay.classList.remove('errors');
+        this.cellOutput.classList.remove('output');
+        this.stdOutDetails = null;
+        this.stdOutEl = null;
     }
 
     requestCompletion(pos) {

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -1271,6 +1271,12 @@ body {
           cursor: pointer;
         }
       }
+
+      .error-report.Warning {
+        color: #8a6d3b;
+        background-color: #fcf8e3;
+        border-color: #faebcc;
+      }
     }
   }
 }

--- a/polynote-kernel/src/main/scala/polynote/kernel/util/KernelContext.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/KernelContext.scala
@@ -169,8 +169,7 @@ object KernelContext {
     /**
       * The class loader which loads the dependencies
       */
-    val dependencyClassLoader: URLClassLoader =
-    new LimitedSharingClassLoader(
+    val dependencyClassLoader: URLClassLoader = new LimitedSharingClassLoader(
       "^(scala|javax?|jdk|sun|com.sun|com.oracle|polynote|org.w3c|org.xml|org.omg|org.ietf|org.jcp|org.apache.spark|org.apache.hadoop|org.codehaus|org.slf4j|org.log4j)\\.",
       dependencyClassPath,
       parentClassLoader)

--- a/polynote-kernel/src/main/scala/polynote/kernel/util/LimitedSharingClassLoader.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/LimitedSharingClassLoader.scala
@@ -27,9 +27,12 @@ class LimitedSharingClassLoader(
   override def loadClass(name: String, resolve: Boolean): Class[_] =  getClassLoadingLock(name).synchronized {
     val c = if (share.test(name)) {
       //System.err.println(s"Delegating class $name")
-      super.loadClass(name, resolve)
-    }
-    else try {
+      try {
+        super.loadClass(name, resolve)
+      } catch {
+        case err: ClassNotFoundException => findClass(name)
+      }
+    } else try {
       findLoadedClass(name) match {
         case null =>
           //System.err.println(s"Privately loading class $name")


### PR DESCRIPTION
Sometimes a method can fail to be eta-expanded into a function (which we use to share the method with i.e. python). If this happens, don't throw an exception; emit a warning instead and skip the symbol.

Also, added UI support for warnings (since we had never used them before).

Will still try and solve the cyclic reference problem, but this is a good step.

Also fixes the issue with warning markers being in the wrong position.