### PR TITLE
Fix vim normal mode swallowing Shift+Enter

### DIFF
--- a/polynote-frontend/polynote/cell.js
+++ b/polynote-frontend/polynote/cell.js
@@ -8,8 +8,8 @@ import { default as Diff } from './diff.js'
 import {ReprUI} from "./repr_ui";
 import {details} from "./tags";
 import {ExecutionInfo} from "./result";
-import { initVimMode } from 'monaco-vim';
 import {prefs} from "./prefs";
+import {createVim} from "./vim";
 
 const JsDiff = new Diff();
 
@@ -275,6 +275,8 @@ export class CodeCell extends Cell {
             this.setExecutionInfo(this.metadata.executionInfo);
         }
     }
+
+
 
     onChangeModelContent(event) {
         this.updateEditorHeight();
@@ -669,7 +671,7 @@ export class CodeCell extends Cell {
                 if (!this.statusLine) {
                     this.statusLine = div(["vim-status"], []);
                 }
-                this.vim = initVimMode(this.editor, this.statusLine);
+                this.vim = createVim(this.editor, this.statusLine);
                 this.cellInput.insertBefore(this.statusLine, this.execInfoEl);
             }
             this.statusLine.classList.toggle('hide', false);

--- a/polynote-frontend/polynote/vim.js
+++ b/polynote-frontend/polynote/vim.js
@@ -1,0 +1,16 @@
+// Handle some modifications/customizations for monaco-vim
+// The only thing this does for now is handle the stupid default mapping of `<CR>` to
+// `j^` (jump to beginning of the line). Unfortunately the vim plugin eats all keypresses
+// and doesn't propagate the event out back to Monaco, so the easiest way to get
+// Shift+Enter to work in normal mode is just to remove that default mapping.
+
+import { default as CodeMirror } from "monaco-vim/lib/cm/keymap_vim";
+import {initVimMode} from "monaco-vim";
+
+const vimSettings = CodeMirror.Vim;
+vimSettings.unmap("<CR>", "normal");
+
+export function createVim(editor, statusLine) {
+    return initVimMode(editor, statusLine);
+}
+


### PR DESCRIPTION
Simple change that was really annoying to find... 🤷‍♂️ 