### PR TITLE
log errors to stdout, show Kernel Error stack trace in UI

### DIFF
--- a/polynote-frontend/polynote/cell.js
+++ b/polynote-frontend/polynote/cell.js
@@ -167,7 +167,7 @@ export class Cell extends UIEventTarget {
     }
 }
 
-function errorDisplay(error, currentFile, maxDepth, nested) {
+export function errorDisplay(error, currentFile, maxDepth, nested) {
     maxDepth = maxDepth || 0;
     nested = nested || false;
     let cellLine = null;
@@ -195,7 +195,7 @@ function errorDisplay(error, currentFile, maxDepth, nested) {
     const causeEl = (maxDepth > 0 && error.cause)
                     ? [errorDisplay(error.cause, currentFile, maxDepth - 1, true).el]
                     : [];
-    const label = nested ? "Caused by" : "Uncaught exception";
+    const label = nested ? "Caused by: " : "Uncaught exception: ";
     const summaryContent = [span(['severity'], [label]), span(['message'], [messageStr])];
     const traceContent = [tag('ul', ['stack-trace'], {}, traceItems), ...causeEl];
     const el = traceItems.length

--- a/polynote-frontend/polynote/cell.js
+++ b/polynote-frontend/polynote/cell.js
@@ -167,6 +167,7 @@ export class Cell extends UIEventTarget {
     }
 }
 
+// TODO: it's a bit hacky to export this, should probably put this in some utils module
 export function errorDisplay(error, currentFile, maxDepth, nested) {
     maxDepth = maxDepth || 0;
     nested = nested || false;

--- a/polynote-frontend/polynote/ui.js
+++ b/polynote-frontend/polynote/ui.js
@@ -17,6 +17,7 @@ import match from "./match.js";
 import {ExecutionInfo} from "./result";
 import {CellMetadata} from "./messages";
 import {Either} from "./codec";
+import {errorDisplay} from "./cell";
 
 document.execCommand("defaultParagraphSeparator", false, "p");
 document.execCommand("styleWithCSS", false, false);
@@ -1343,10 +1344,13 @@ export class NotebookUI extends UIEventTarget {
 
         socket.addMessageListener(messages.Error, (code, err) => {
             console.log("Kernel error:", err);
+
+            const {el, messageStr, cellLine} = errorDisplay(err);
+
             const id = err.id;
             const message = div(["message"], [
                 para([], `${err.className}: ${err.message}`),
-                para([], err.extraContent)
+                para([], el)
             ]);
             this.kernelUI.tasks.updateTask(id, id, message, TaskStatus.Error, 0);
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -17,4 +17,4 @@ jar xf ${polynote_jar} ${scala_jar}
 
 actual_command=$(java -cp ${scala_jar}:${polynote_jar} polynote.server.SparkServer --printCommand 2>&1 | grep "SparkSubmit:" | grep -o '[^:]*$')
 echo "${actual_command}"
-${actual_command}
+${actual_command} | tee polynote-server-`date +"%Y-%m-%dT%H:%MZ"`.log


### PR DESCRIPTION
Resolves #218 

Doesn't resolve the "writing to file" requirement but maybe that's less pressing as users could always do `./run.sh &2>1 > polynote.out`