### PR TITLE
Fix delegation of failed classloadings

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/util/LimitedSharingClassLoader.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/LimitedSharingClassLoader.scala
@@ -40,7 +40,7 @@ class LimitedSharingClassLoader(
         case lc => lc
       }
     } catch {
-      case err: ClassNotFoundException =>
+      case _: ClassNotFoundException | _: LinkageError =>
         super.loadClass(name, resolve)
     }
 


### PR DESCRIPTION
Sometimes we can get a `LinkageError` rather than a `ClassNotFoundException` if we fail to load a class locally. Also delegate these to the parent classloader.