### PR TITLE
Update coursier fetcher, add ivy fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # UNRELEASED 
 
-* 
+* Update coursier, giving an order-of-magnitude performance boost to dependency resolution (especially for deep dependency trees)
 
 # 0.1.4 (April 16, 2019) 
 

--- a/build.sbt
+++ b/build.sbt
@@ -72,9 +72,10 @@ val `polynote-kernel` = project.settings(
     "io.circe" %% "circe-yaml" % "0.9.0",
     "io.circe" %% "circe-generic" % "0.10.0",
     "io.circe" %% "circe-generic-extras" % "0.10.0",
-    "io.get-coursier" %% "coursier" % "1.1.0-M9",
-    "io.get-coursier" %% "coursier-cache" % "1.1.0-M9",
-    "org.apache.ivy" % "ivy" % "2.4.0"
+    "io.get-coursier" %% "coursier" % "1.1.0-M14-1",
+    "io.get-coursier" %% "coursier-cache" % "1.1.0-M14-1",
+    "io.get-coursier" %% "coursier-cats-interop" % "1.1.0-M14-1",
+    "org.apache.ivy" % "ivy" % "2.4.0" % "provided"
   )
 ).dependsOn(`polynote-runtime`)
 

--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,8 @@ val `polynote-kernel` = project.settings(
     "io.circe" %% "circe-generic" % "0.10.0",
     "io.circe" %% "circe-generic-extras" % "0.10.0",
     "io.get-coursier" %% "coursier" % "1.1.0-M9",
-    "io.get-coursier" %% "coursier-cache" % "1.1.0-M9"
+    "io.get-coursier" %% "coursier-cache" % "1.1.0-M9",
+    "org.apache.ivy" % "ivy" % "2.4.0"
   )
 ).dependsOn(`polynote-runtime`)
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/dependency/CoursierFetcher.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/dependency/CoursierFetcher.scala
@@ -1,0 +1,260 @@
+package polynote.kernel.dependency
+
+import java.io._
+import java.util.concurrent.{ExecutorService, Executors}
+import java.net.URI
+import java.nio.file.{Files, Path, Paths}
+
+import cats.Parallel
+import cats.data.{Validated, ValidatedNel}
+import cats.effect.{ContextShift, IO}
+import cats.implicits._
+import coursier.ivy.IvyRepository
+import coursier.util.{Monad, Schedulable}
+import coursier.core._
+import coursier.{Attributes, Cache, Dependency, Fetch, FileError, MavenRepository, Module, ModuleName, Organization, ProjectCache, Repository, Resolution}
+import polynote.config.{DependencyConfigs, RepositoryConfig, ivy, maven}
+import polynote.kernel.util.{DownloadableFileProvider, Publish}
+import polynote.kernel._
+import polynote.messages.{TinyList, TinyMap, TinyString}
+
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext
+
+
+// Fetches only Scala dependencies
+class CoursierFetcher extends URLDependencyFetcher {
+  import CoursierFetcher._, instances._
+
+  protected implicit val executionContext: ExecutionContext = ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
+  protected implicit val contextShift: ContextShift[IO] =  IO.contextShift(executionContext)
+
+  private val excludedOrgs = Set(Organization("org.scala-lang"), Organization("org.apache.spark"))
+  val artifactTypes = coursier.core.Resolution.defaultTypes - Type.testJar
+
+  private val resolutionCacheFile = "resolution-cache"
+  private lazy val resolutionCachePath = Cache.default.toPath.resolve(resolutionCacheFile)
+
+  private def resolution(dependencies: List[DependencyConfigs], exclusions: List[String]): Resolution = {
+    // exclusions are applied to all direct and transitive dependencies.
+    val coursierExclude = exclusions.map { exclusionStr =>
+      exclusionStr.split(":") match {
+        case Array(org, name) => (Organization(org), ModuleName(name))
+        case Array(org) => (Organization(org), Exclusions.allNames)
+      }
+    }.toSet
+
+    Resolution(
+      dependencies.flatMap(_.get(TinyString("scala"))).flatten.map {
+        moduleStr =>
+          val (org, name, typ, config, classifier, ver) = moduleStr.split(':') match {
+            case Array(org, name, ver) => (Organization(org), ModuleName(name), Type.empty, Configuration.default, Classifier.empty, ver)
+            case Array(org, name, classifier, ver) => (Organization(org), ModuleName(name), Type.empty, Configuration.default, Classifier(classifier), ver)
+            case Array(org, name, typ, classifier, ver) => (Organization(org), ModuleName(name), Type(typ), Configuration.default, Classifier(classifier), ver)
+            case Array(org, name, typ, config, classifier, ver) => (Organization(org), ModuleName(name), Type(typ), Configuration(config), Classifier(classifier), ver)
+            case _ => throw new Exception(s"Unable to parse dependency '$moduleStr'")
+          }
+          Dependency(Module(org, name), ver, config, Attributes(typ, classifier), coursierExclude, transitive = classifier.value != "all")
+
+      }.toSet,
+      filter = Some(dep => !dep.optional && !excludedOrgs(dep.module.organization))
+    )
+  }
+
+  private def repos(repositories: List[RepositoryConfig]): Either[Throwable, List[Repository]] = repositories.map {
+    case repo @ ivy(base, _, _, changing) =>
+      val baseUri = base.stripSuffix("/") + "/"
+      val artifactPattern = s"$baseUri${repo.artifactPattern}"
+      val metadataPattern = s"$baseUri${repo.metadataPattern}"
+      Validated.fromEither(IvyRepository.parse(artifactPattern, Some(metadataPattern), changing = changing)).toValidatedNel
+    case maven(base, changing) => Validated.validNel(MavenRepository(base, changing = changing))
+  }.sequence[ValidatedNel[String, ?], Repository].leftMap {
+    errs => new RuntimeException(s"Errors parsing repositories:\n- ${errs.toList.mkString("\n- ")}")
+  }.toEither.map {
+    repos => (Cache.ivy2Local :: Cache.ivy2Cache :: repos) :+ MavenRepository("https://repo1.maven.org/maven2")
+  }
+
+  private def cacheFilesList(resolved: Resolution, statusUpdates: Publish[IO, KernelStatusUpdate]): List[(String, IO[File])] = {
+    val logger = new Cache.Logger {
+      private val size = new mutable.HashMap[String, Long]()
+
+      private def update(url: String, progress: Double) = statusUpdates.publish1(
+        UpdatedTasks(TaskInfo(url, s"Download ${url.split('/').last}", url, if (progress < 1.0) TaskStatus.Running else TaskStatus.Complete, (progress * 255).toByte) :: Nil)
+      ).unsafeRunAsyncAndForget()
+
+      override def downloadLength(url: String, totalLength: Long, alreadyDownloaded: Long, watching: Boolean): Unit = if (totalLength > 0) {
+        size.synchronized {
+          size.put(url, totalLength)
+        }
+        update(url, alreadyDownloaded.toDouble / totalLength)
+
+      }
+
+      override def downloadProgress(url: String, downloaded: Long): Unit = {
+        size.get(url).foreach {
+          totalLength => update(url, downloaded.toDouble / totalLength)
+        }
+      }
+
+      override def downloadedArtifact(url: String, success: Boolean): Unit = size.get(url).foreach { _ =>
+        val progress = if (success) 1.0 else Double.NaN
+        update(url, progress)
+      }
+    }
+
+    val allArtifacts = resolved.dependencyArtifacts().filter(da => artifactTypes(da._2.`type`))
+
+    val filteredArtifacts = allArtifacts.distinct.collect {
+      case (dependency, attributes, artifact) =>
+        s"${dependency.module}:${dependency.version}" -> artifact
+    }.distinct.map {
+      case (mv, artifact) => mv -> Cache.file[IO](artifact, logger = Some(logger)).leftMap(FileErrorException).run.flatMap(IO.fromEither)
+    }.toList
+
+
+    filteredArtifacts
+  }
+
+  private def resolveCoursierDependencies(
+    resolution: Resolution,
+    fetch: Fetch.Metadata[IO],
+    taskInfo: TaskInfo,
+    statusUpdates: Publish[IO, KernelStatusUpdate],
+    maxIterations: Int = 100
+  ): IO[Resolution] = {
+    // check whether we care about a missing resolution
+    def shouldErrorIfMissing(mv: (Module, String)): Boolean = {
+      resolution.rootDependencies.exists(dep => dep.module == mv._1 && dep.version == mv._2)
+    }
+
+    // reimplements ResolutionProcess.run, so we can update the iteration progress
+    def run(resolutionProcess: ResolutionProcess, iteration: Int): IO[Resolution] =
+      statusUpdates.publish1(UpdatedTasks(taskInfo.copy(progress = (iteration.toDouble / maxIterations * 255).toByte) :: Nil)) *> {
+        if (iteration > maxIterations) {
+          IO.pure(resolutionProcess.current)
+        } else {
+          resolutionProcess match {
+            case Done(res) if res.errorCache.keys.exists(shouldErrorIfMissing) =>
+              res.errorCache.map {
+                case (mv, err) if shouldErrorIfMissing(mv) =>
+                  val depStr = s"${mv._1}:${mv._2}"
+                  statusUpdates.publish1(
+                    UpdatedTasks(TaskInfo(
+                      id = s"${taskInfo.id}_$depStr",
+                      label = s"Error fetching dependency $depStr",
+                      detail = err.mkString("\n\n"),
+                      status = TaskStatus.Error
+                    ) :: taskInfo.copy(status = TaskStatus.Complete) :: Nil)
+                  )
+                case _ => IO.unit
+              }.toList.sequence *> IO.raiseError(new Exception("Dependency Resolution Error"))
+            case Done(res) =>
+              IO.pure(res)
+            case missing0 @ Missing(missing, _, _) =>
+              CoursierFetcher.fetchAll(missing, fetch).flatMap {
+                result => run(missing0.next(result), iteration + 1)
+              }
+            case cont @ Continue(_, _) =>
+              run(cont.nextNoCont, iteration + 1)
+          }
+        }
+      }
+
+    run(resolution.process, 0)
+  }
+
+  override protected def resolveDependencies(
+    repositories: List[RepositoryConfig],
+    dependencies: List[DependencyConfigs],
+    exclusions: List[String],
+    taskInfo: TaskInfo,
+    statusUpdates: Publish[IO, KernelStatusUpdate]
+  ): IO[List[(String, IO[File])]] = for {
+    repos      <- IO.fromEither(repos(repositories))
+    res         = resolution(dependencies, exclusions)
+    resolved   <- resolveCoursierDependencies(res, Fetch.from(repos, Cache.fetch[IO]()), taskInfo, statusUpdates)
+  } yield cacheFilesList(resolved, statusUpdates)
+
+  protected def cacheLocation(uri: URI): Path = {
+    val pathParts = Seq(uri.getScheme, uri.getAuthority, uri.getPath).flatMap(Option(_)) // URI methods sometimes return `null`, great.
+    Cache.default.toPath.resolve(Paths.get(pathParts.head, pathParts.tail: _*))
+  }
+}
+
+object CoursierFetcher {
+
+  object instances extends LowPriorityInstances {
+    implicit def deriveSchedulable[M[_], F[_]](implicit
+      shift: ContextShift[M],
+      M: cats.effect.Effect[M],
+      parM: cats.Parallel[M, F]
+    ): coursier.util.Schedulable[M] = new Schedulable[M] {
+      def schedule[A](pool: ExecutorService)(f: => A): M[A] =
+        shift.evalOn(ExecutionContext.fromExecutorService(pool))(M.delay(f))
+
+      def gather[A](elems: Seq[M[A]]): M[Seq[A]] = Parallel.parSequence[List, M, F, A](elems.toList).map(_.toSeq)
+
+      def point[A](a: A): M[A] = M.point(a)
+
+      def bind[A, B](elem: M[A])(f: A => M[B]): M[B] = M.flatMap(elem)(f)
+
+      def delay[A](a: => A): M[A] = M.delay(a)
+
+      def handle[A](a: M[A])(f: PartialFunction[Throwable, A]): M[A] = M.handleErrorWith(a) {
+        err => if (f.isDefinedAt(err)) M.pure(f(err)) else M.raiseError(err)
+      }
+    }
+
+  }
+
+  private[dependency] trait LowPriorityInstances {
+    implicit def deriveMonad[F[_]](implicit F: cats.Monad[F]): coursier.util.Monad[F] = new Monad[F] {
+      def point[A](a: A): F[A] = F.point(a)
+      def bind[A, B](elem: F[A])(f: A => F[B]): F[B] = F.flatMap(elem)(f)
+    }
+  }
+
+  final case class FileErrorException(err: FileError) extends Throwable(err.message)
+
+  private def fetchAll[F[_]](
+    modVers: Seq[(Module, String)],
+    fetch: Fetch.Metadata[F]
+  )(implicit F: Monad[F]): F[Vector[((Module, String), Either[Seq[String], (Artifact.Source, Project)])]] = {
+
+    def uniqueModules(modVers: Seq[(Module, String)]): Stream[Seq[(Module, String)]] = {
+
+      val res = modVers.groupBy(_._1).toSeq.map(_._2).map {
+        case Seq(v) => (v, Nil)
+        case Seq() => sys.error("Cannot happen")
+        case v =>
+          // there might be version intervals in there, but that shouldn't matter...
+          val res = v.maxBy { case (_, v0) => Version(v0) }
+          (res, v.filter(_ != res))
+      }
+
+      val other = res.flatMap(_._2)
+
+      if (other.isEmpty)
+        Stream(modVers)
+      else {
+        val missing0 = res.map(_._1)
+        missing0 #:: uniqueModules(other)
+      }
+    }
+
+    uniqueModules(modVers)
+      .toVector
+      .foldLeft(F.point(Vector.empty[((Module, String), Either[Seq[String], (Artifact.Source, Project)])])) {
+        (acc, l) =>
+          F.bind(acc) { v =>
+            F.map(fetch(l)) { e =>
+              v ++ e.map {
+                case (mv, Right((src, proj))) =>
+                  (mv, Right(src, proj.copy(dependencies = proj.dependencies.filter(_._2.version != ""))))
+                case ee => ee
+              }
+            }
+          }
+      }
+  }
+}

--- a/polynote-kernel/src/main/scala/polynote/kernel/dependency/DependencyFetcher.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/dependency/DependencyFetcher.scala
@@ -11,7 +11,6 @@ import cats.syntax.apply._
 import cats.syntax.either._
 import cats.instances.either._
 import cats.instances.list._
-import coursier.Cache
 import polynote.config.{DependencyConfigs, RepositoryConfig}
 import polynote.kernel._
 import polynote.kernel.util.{DownloadableFileProvider, Publish}

--- a/polynote-kernel/src/main/scala/polynote/kernel/dependency/DependencyFetcher.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/dependency/DependencyFetcher.scala
@@ -1,24 +1,22 @@
 package polynote.kernel.dependency
 
 import java.io._
-import java.util.concurrent.{ExecutorService, Executors}
-import java.net.{MalformedURLException, URI, URL}
-import java.nio.file.{Files, Paths}
+import java.net.URI
+import java.nio.file.{Files, Path, Paths}
+import java.util.concurrent.Executors
 
-import cats.Parallel
-import cats.data.{Validated, ValidatedNel}
 import cats.effect.{ContextShift, IO}
-import cats.implicits._
-import coursier.ivy.IvyRepository
-import coursier.util.{Monad, Schedulable}
-import coursier.core._
-import coursier.{Attributes, Cache, Dependency, Fetch, FileError, MavenRepository, Module, ModuleName, Organization, ProjectCache, Repository, Resolution}
-import polynote.config.{DependencyConfigs, RepositoryConfig, ivy, maven}
-import polynote.kernel.util.{DownloadableFileProvider, Publish}
+import cats.syntax.alternative._
+import cats.syntax.apply._
+import cats.syntax.either._
+import cats.instances.either._
+import cats.instances.list._
+import coursier.Cache
+import polynote.config.{DependencyConfigs, RepositoryConfig}
 import polynote.kernel._
-import polynote.messages.{TinyList, TinyMap, TinyString}
+import polynote.kernel.util.{DownloadableFileProvider, Publish}
+import polynote.messages.{TinyList, TinyMap}
 
-import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 
 trait DependencyFetcher[F[_]] {
@@ -33,157 +31,14 @@ trait DependencyFetcher[F[_]] {
 
 }
 
-// Fetches only Scala dependencies
-class CoursierFetcher extends DependencyFetcher[IO] {
-  import CoursierFetcher._, instances._
+trait URLDependencyFetcher extends DependencyFetcher[IO] {
+  protected implicit def executionContext: ExecutionContext
+  protected implicit def contextShift: ContextShift[IO]
 
-  private implicit val executionContext: ExecutionContext = ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
-  private implicit val contextShift: ContextShift[IO] =  IO.contextShift(executionContext)
-
-  private val excludedOrgs = Set(Organization("org.scala-lang"), Organization("org.apache.spark"))
-  val artifactTypes = coursier.core.Resolution.defaultTypes - Type.testJar
-
-  private val resolutionCacheFile = "resolution-cache"
-  private lazy val resolutionCachePath = Cache.default.toPath.resolve(resolutionCacheFile)
-
-  private def resolution(dependencies: List[DependencyConfigs], exclusions: List[String]): Resolution = {
-    // exclusions are applied to all direct and transitive dependencies.
-    val coursierExclude = exclusions.map { exclusionStr =>
-      exclusionStr.split(":") match {
-        case Array(org, name) => (Organization(org), ModuleName(name))
-        case Array(org) => (Organization(org), Exclusions.allNames)
-      }
-    }.toSet
-
-    Resolution(
-      dependencies.flatMap(_.get(TinyString("scala"))).flatten.map {
-        moduleStr =>
-          val (org, name, typ, config, classifier, ver) = moduleStr.split(':') match {
-            case Array(org, name, ver) => (Organization(org), ModuleName(name), Type.empty, Configuration.default, Classifier.empty, ver)
-            case Array(org, name, classifier, ver) => (Organization(org), ModuleName(name), Type.empty, Configuration.default, Classifier(classifier), ver)
-            case Array(org, name, typ, classifier, ver) => (Organization(org), ModuleName(name), Type(typ), Configuration.default, Classifier(classifier), ver)
-            case Array(org, name, typ, config, classifier, ver) => (Organization(org), ModuleName(name), Type(typ), Configuration(config), Classifier(classifier), ver)
-            case _ => throw new Exception(s"Unable to parse dependency '$moduleStr'")
-          }
-          Dependency(Module(org, name), ver, config, Attributes(typ, classifier), coursierExclude, transitive = classifier.value != "all")
-
-      }.toSet,
-      filter = Some(dep => !dep.optional && !excludedOrgs(dep.module.organization))
-    )
-  }
-
-  private def repos(repositories: List[RepositoryConfig]): Either[Throwable, List[Repository]] = repositories.map {
-    case repo @ ivy(base, _, _, changing) =>
-      val baseUri = base.stripSuffix("/") + "/"
-      val artifactPattern = s"$baseUri${repo.artifactPattern}"
-      val metadataPattern = s"$baseUri${repo.metadataPattern}"
-      Validated.fromEither(IvyRepository.parse(artifactPattern, Some(metadataPattern), changing = changing)).toValidatedNel
-    case maven(base, changing) => Validated.validNel(MavenRepository(base, changing = changing))
-  }.sequence[ValidatedNel[String, ?], Repository].leftMap {
-    errs => new RuntimeException(s"Errors parsing repositories:\n- ${errs.toList.mkString("\n- ")}")
-  }.toEither.map {
-    repos => (Cache.ivy2Local :: Cache.ivy2Cache :: repos) :+ MavenRepository("https://repo1.maven.org/maven2")
-  }
-
-  private def cacheFilesList(resolved: Resolution, downloaded: List[(String, IO[File])], statusUpdates: Publish[IO, KernelStatusUpdate]): List[(String, IO[File])] = {
-    val logger = new Cache.Logger {
-      private val size = new mutable.HashMap[String, Long]()
-
-      private def update(url: String, progress: Double) = statusUpdates.publish1(
-        UpdatedTasks(TaskInfo(url, s"Download ${url.split('/').last}", url, if (progress < 1.0) TaskStatus.Running else TaskStatus.Complete, (progress * 255).toByte) :: Nil)
-      ).unsafeRunAsyncAndForget()
-
-      override def downloadLength(url: String, totalLength: Long, alreadyDownloaded: Long, watching: Boolean): Unit = if (totalLength > 0) {
-        size.synchronized {
-          size.put(url, totalLength)
-        }
-        update(url, alreadyDownloaded.toDouble / totalLength)
-
-      }
-
-      override def downloadProgress(url: String, downloaded: Long): Unit = {
-        size.get(url).foreach {
-          totalLength => update(url, downloaded.toDouble / totalLength)
-        }
-      }
-
-      override def downloadedArtifact(url: String, success: Boolean): Unit = size.get(url).foreach { _ =>
-        val progress = if (success) 1.0 else Double.NaN
-        update(url, progress)
-      }
-    }
-
-    val allArtifacts = resolved.dependencyArtifacts().filter(da => artifactTypes(da._2.`type`))
-
-    val filteredArtifacts = allArtifacts.distinct.collect {
-      case (dependency, attributes, artifact) =>
-        s"${dependency.module}:${dependency.version}" -> artifact
-    }.distinct.map {
-      case (mv, artifact) => mv -> Cache.file[IO](artifact, logger = Some(logger)).leftMap(FileErrorException).run.flatMap(IO.fromEither)
-    }.toList
-
-    val downloadedFiles = downloaded.map {
-      case (url, ioF) =>
-        val ioWithUpdated = statusUpdates.publish1(UpdatedTasks(TaskInfo(url, s"Downloading $url", url, TaskStatus.Running) :: Nil)).bracket { _ =>
-          ioF
-        } { _ =>
-          statusUpdates.publish1(UpdatedTasks(TaskInfo(url, s"Downloading $url", url, TaskStatus.Complete) :: Nil))
-        }
-        "downloaded" -> ioWithUpdated
-    }
-
-    filteredArtifacts ++ downloadedFiles
-  }
-
-  private def resolveDependencies(
-    resolution: Resolution,
-    fetch: Fetch.Metadata[IO],
-    taskInfo: TaskInfo,
-    statusUpdates: Publish[IO, KernelStatusUpdate],
-    maxIterations: Int = 100
-  ): IO[Resolution] = {
-    // check whether we care about a missing resolution
-    def shouldErrorIfMissing(mv: (Module, String)): Boolean = {
-      resolution.rootDependencies.exists(dep => dep.module == mv._1 && dep.version == mv._2)
-    }
-
-    // reimplements ResolutionProcess.run, so we can update the iteration progress
-    def run(resolutionProcess: ResolutionProcess, iteration: Int): IO[Resolution] =
-      statusUpdates.publish1(UpdatedTasks(taskInfo.copy(progress = (iteration.toDouble / maxIterations * 255).toByte) :: Nil)) *> {
-        if (iteration > maxIterations) {
-          IO.pure(resolutionProcess.current)
-        } else {
-          resolutionProcess match {
-            case Done(res) if res.errorCache.keys.exists(shouldErrorIfMissing) =>
-              res.errorCache.map {
-                case (mv, err) if shouldErrorIfMissing(mv) =>
-                  val depStr = s"${mv._1}:${mv._2}"
-                  statusUpdates.publish1(
-                    UpdatedTasks(TaskInfo(
-                      id = s"${taskInfo.id}_$depStr",
-                      label = s"Error fetching dependency $depStr",
-                      detail = err.mkString("\n\n"),
-                      status = TaskStatus.Error
-                    ) :: taskInfo.copy(status = TaskStatus.Complete) :: Nil)
-                  )
-                case _ => IO.unit
-              }.toList.sequence *> IO.raiseError(new Exception("Dependency Resolution Error"))
-            case Done(res) =>
-              IO.pure(res)
-            case missing0 @ Missing(missing, _, _) =>
-              CoursierFetcher.fetchAll(missing, fetch).flatMap {
-                result => run(missing0.next(result), iteration + 1)
-              }
-            case cont @ Continue(_, _) =>
-              run(cont.nextNoCont, iteration + 1)
-          }
-        }
-    }
-
-    run(resolution.process, 0)
-  }
-
-  def splitDependencies(deps: List[DependencyConfigs]): (List[DependencyConfigs], List[URI]) = {
+  /**
+    * Split the dependencies into actual dependency coordinates vs direct URLs
+    */
+  protected def splitDependencies(deps: List[DependencyConfigs]): (List[DependencyConfigs], List[URI]) = {
     val (dependencies, uriList) = deps.flatMap { dep =>
       dep.toList.collect {
         case (k, v) =>
@@ -205,9 +60,13 @@ class CoursierFetcher extends DependencyFetcher[IO] {
     (dependencies, uriList.flatten)
   }
 
-  def fetchUrls(uris: List[URI], statusUpdates: Publish[IO, KernelStatusUpdate], chunkSize: Int = 8192)(implicit ctx: ExecutionContext): List[(String, IO[File])] = {
+  /**
+    * Given a URI, return the local Path to which it should cache/download
+    */
+  protected def cacheLocation(uri: URI): Path
 
-    def withProgress(s: fs2.Stream[IO, Byte], uri: String, fileSize: Long): fs2.Stream[IO, Byte] = {
+  protected def fetchUrl(uri: URI, localFile: File, statusUpdates: Publish[IO, KernelStatusUpdate], chunkSize: Int = 8192): (String, IO[File]) = {
+    def withProgress(s: fs2.Stream[IO, Byte], uri: String, fileSize: Long, taskInfo: TaskInfo): fs2.Stream[IO, Byte] = {
       val size = if (fileSize > 0) fileSize else 300 * 1024 * 1024 // this is roughly the size of the largest uber jars we have
 
       // is there a better way to do this? seems more convoluted than necessary but I couldn't quite get there...
@@ -215,45 +74,71 @@ class CoursierFetcher extends DependencyFetcher[IO] {
       s.chunks
         .mapAccumulate(0)((n, c) => (n + c.size, c)) // carry along the size of the chunks so far
         .evalTap { case (i, _) =>
-          statusUpdates.publish1(UpdatedTasks(TaskInfo(uri, s"Downloading $uri", uri, TaskStatus.Running, (i.toDouble * 255 / size).toByte) :: Nil))
-        }.flatMap { case (_, c) =>
-          fs2.Stream.chunk(c) // this looks like the only way to re-chunk the Stream...
-        }
+        statusUpdates.publish1(UpdatedTasks(taskInfo.copy(progress = (i.toDouble * 255 / size).toByte) :: Nil))
+      }.flatMap { case (_, c) =>
+        fs2.Stream.chunk(c) // this looks like the only way to re-chunk the Stream...
+      }
     }
 
-    uris.map { uri =>
-      val dlIO = IO.fromEither(Either.fromOption(DownloadableFileProvider.getFile(uri), new Exception(s"Unable to find provider for uri $uri"))).flatMap { file =>
-        // try to short circuit - maybe it's on the local FS?
-        val inputAsFile = Paths.get(uri.getPath).toFile
-        // if not, maybe it's already been cached?
-        val pathParts = Seq(uri.getScheme, uri.getAuthority, uri.getPath).flatMap(Option(_)) // URI methods sometimes return `null`, great.
-        val cacheFile = Cache.default.toPath.resolve(Paths.get(pathParts.head, pathParts.tail: _*)).toFile
+    val uriStr = uri.toString
+    val taskInfo = TaskInfo(uriStr, s"Downloading $uriStr", uriStr, TaskStatus.Running)
+    val dlIO = IO.fromEither(Either.fromOption(DownloadableFileProvider.getFile(uri), new Exception(s"Unable to find provider for uri $uri"))).flatMap { file =>
+      // try to short circuit - maybe it's on the local FS?
+      val inputAsFile = Paths.get(uri.getPath).toFile
+      // if not, maybe it's already been cached?
+      val cacheFile = localFile
 
-        if (inputAsFile.exists()) {
-          IO.pure(inputAsFile)
-        } else if (cacheFile.exists()) {
-          IO.pure(cacheFile)
-        } else {
-          // ok we actually have to fetch it I guess
-          (for {
-            _ <- IO(Files.createDirectories(cacheFile.toPath.getParent))
-            os = new FileOutputStream(cacheFile)
-            // is it overkill to use fs2 steams for this...?
-            fs2IS = fs2.io.readInputStream[IO](file.openStream, chunkSize, ctx)
-            fs2OS = fs2.io.writeOutputStream[IO](IO(os), ctx)
-            fileSize <- file.size
-            _ <- withProgress(fs2IS, uri.toString, fileSize).through(fs2OS).compile.drain
-          } yield cacheFile).handleErrorWith { t: Throwable =>
-            IO.raiseError(t).guarantee(IO {
+      if (inputAsFile.exists()) {
+        IO.pure(inputAsFile)
+      } else if (cacheFile.exists()) {
+        IO.pure(cacheFile)
+      } else {
+        // ok we actually have to fetch it I guess
+        (for {
+          _ <- IO(Files.createDirectories(cacheFile.toPath.getParent))
+          os = new FileOutputStream(cacheFile)
+          // is it overkill to use fs2 steams for this...?
+          fs2IS = fs2.io.readInputStream[IO](file.openStream, chunkSize, executionContext)
+          fs2OS = fs2.io.writeOutputStream[IO](IO(os), executionContext)
+          fileSize <- file.size
+          _ <- withProgress(fs2IS, uriStr, fileSize, taskInfo).through(fs2OS).compile.drain
+          _ <- statusUpdates.publish1(UpdatedTasks(List(taskInfo.copy(status = TaskStatus.Complete, progress = 255.toByte))))
+        } yield cacheFile).handleErrorWith { t: Throwable =>
+          IO.raiseError(t).guarantee(IO {
+            if (cacheFile.exists())
               Files.delete(cacheFile.toPath) // clean up
-            })
-          }
+          } *> statusUpdates.publish1(UpdatedTasks(List(taskInfo.copy(status = TaskStatus.Error)))))
         }
       }
-
-      uri.toString -> dlIO
     }
+
+    uri.toString -> dlIO
   }
+
+  /**
+    * Fetch the given URI dependencies, after computing their local file paths
+    */
+  protected def fetchUrls(
+    uris: List[URI],
+    statusUpdates: Publish[IO, KernelStatusUpdate],
+    chunkSize: Int = 8192
+  ): List[(String, IO[File])] = uris.map {
+    uri =>
+      val localFile = cacheLocation(uri)
+      fetchUrl(uri, localFile.toFile, statusUpdates, chunkSize)
+  }
+
+  /**
+    * Resolve the actual dependency coordinates, and return tasks which will download the files while reporting on
+    * progress
+    */
+  protected def resolveDependencies(
+    repositories: List[RepositoryConfig],
+    dependencies: List[DependencyConfigs],
+    exclusions: List[String],
+    taskInfo: TaskInfo,
+    statusUpdates: Publish[IO, KernelStatusUpdate]
+  ): IO[List[(String, IO[File])]]
 
   def fetchDependencyList(
     repositories: List[RepositoryConfig],
@@ -261,90 +146,12 @@ class CoursierFetcher extends DependencyFetcher[IO] {
     exclusions: List[String],
     taskInfo: TaskInfo,
     statusUpdates: Publish[IO, KernelStatusUpdate]
-  ): IO[List[(String, IO[File])]] = for {
-    repos <- IO.fromEither(repos(repositories))
-    (deps, urls) = splitDependencies(dependencies)
-    downloadFiles = fetchUrls(urls, statusUpdates)
-    res   = resolution(deps, exclusions)
-    resolved <- resolveDependencies(res, Fetch.from(repos, Cache.fetch[IO]()), taskInfo, statusUpdates)
-  } yield cacheFilesList(resolved, downloadFiles, statusUpdates)
-
-}
-
-object CoursierFetcher {
-
-  object instances extends LowPriorityInstances {
-    implicit def deriveSchedulable[M[_], F[_]](implicit
-      shift: ContextShift[M],
-      M: cats.effect.Effect[M],
-      parM: cats.Parallel[M, F]
-    ): coursier.util.Schedulable[M] = new Schedulable[M] {
-      def schedule[A](pool: ExecutorService)(f: => A): M[A] =
-        shift.evalOn(ExecutionContext.fromExecutorService(pool))(M.delay(f))
-
-      def gather[A](elems: Seq[M[A]]): M[Seq[A]] = Parallel.parSequence[List, M, F, A](elems.toList).map(_.toSeq)
-
-      def point[A](a: A): M[A] = M.point(a)
-
-      def bind[A, B](elem: M[A])(f: A => M[B]): M[B] = M.flatMap(elem)(f)
-
-      def delay[A](a: => A): M[A] = M.delay(a)
-
-      def handle[A](a: M[A])(f: PartialFunction[Throwable, A]): M[A] = M.handleErrorWith(a) {
-        err => if (f.isDefinedAt(err)) M.pure(f(err)) else M.raiseError(err)
-      }
-    }
-
-  }
-
-  private[dependency] trait LowPriorityInstances {
-    implicit def deriveMonad[F[_]](implicit F: cats.Monad[F]): coursier.util.Monad[F] = new Monad[F] {
-      def point[A](a: A): F[A] = F.point(a)
-      def bind[A, B](elem: F[A])(f: A => F[B]): F[B] = F.flatMap(elem)(f)
+  ): IO[List[(String, IO[File])]] = {
+    val (deps, urls) = splitDependencies(dependencies)
+    val downloadFiles = fetchUrls(urls, statusUpdates)
+    resolveDependencies(repositories, deps, exclusions, taskInfo, statusUpdates).map {
+      resolved => downloadFiles ::: resolved
     }
   }
 
-  final case class FileErrorException(err: FileError) extends Throwable(err.message)
-
-  private def fetchAll[F[_]](
-    modVers: Seq[(Module, String)],
-    fetch: Fetch.Metadata[F]
-  )(implicit F: Monad[F]): F[Vector[((Module, String), Either[Seq[String], (Artifact.Source, Project)])]] = {
-
-    def uniqueModules(modVers: Seq[(Module, String)]): Stream[Seq[(Module, String)]] = {
-
-      val res = modVers.groupBy(_._1).toSeq.map(_._2).map {
-        case Seq(v) => (v, Nil)
-        case Seq() => sys.error("Cannot happen")
-        case v =>
-          // there might be version intervals in there, but that shouldn't matter...
-          val res = v.maxBy { case (_, v0) => Version(v0) }
-          (res, v.filter(_ != res))
-      }
-
-      val other = res.flatMap(_._2)
-
-      if (other.isEmpty)
-        Stream(modVers)
-      else {
-        val missing0 = res.map(_._1)
-        missing0 #:: uniqueModules(other)
-      }
-    }
-
-    uniqueModules(modVers)
-      .toVector
-      .foldLeft(F.point(Vector.empty[((Module, String), Either[Seq[String], (Artifact.Source, Project)])])) {
-        (acc, l) =>
-          F.bind(acc) { v =>
-            F.map(fetch(l)) { e =>
-              v ++ e.map {
-                case (mv, Right((src, proj))) =>
-                  (mv, Right(src, proj.copy(dependencies = proj.dependencies.filter(_._2.version != ""))))
-                case ee => ee
-              }
-            }
-          }
-      }
-  }
 }

--- a/polynote-kernel/src/main/scala/polynote/kernel/dependency/IvyFetcher.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/dependency/IvyFetcher.scala
@@ -1,0 +1,306 @@
+package polynote.kernel.dependency
+
+import java.io.File
+import java.net.URI
+import java.nio.file.Path
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+import cats.effect.{ContextShift, IO}
+import cats.syntax.apply._
+import cats.syntax.parallel._
+import cats.syntax.either._
+import cats.syntax.traverse._
+import cats.instances.list._
+import cats.instances.either._
+import polynote.config.{DependencyConfigs, RepositoryConfig, ivy, maven}
+import polynote.kernel.{KernelStatusUpdate, TaskInfo, TaskStatus, UpdatedTasks}
+import polynote.kernel.util.Publish
+import org.apache.ivy.Ivy
+import org.apache.ivy.core.cache.{CacheDownloadOptions, RepositoryCacheManager}
+import org.apache.ivy.core.module.descriptor.{Artifact, DefaultDependencyDescriptor, DefaultModuleDescriptor}
+import org.apache.ivy.core.module.id.ModuleRevisionId
+import org.apache.ivy.core.report.{ArtifactDownloadReport, DownloadReport, DownloadStatus}
+import org.apache.ivy.core.resolve.{DownloadOptions, ResolveOptions}
+import org.apache.ivy.core.settings.IvySettings
+import org.apache.ivy.plugins.namespace.NameSpaceHelper
+import org.apache.ivy.plugins.repository.file.FileResource
+import org.apache.ivy.plugins.repository.url.URLResource
+import org.apache.ivy.plugins.repository.{ArtifactResourceResolver, Resource, ResourceDownloader, TransferEvent, TransferListener}
+import org.apache.ivy.plugins.resolver.util.ResolvedResource
+import org.apache.ivy.plugins.resolver.{CacheResolver, ChainResolver, IBiblioResolver, URLResolver}
+import org.apache.ivy.util.filter.{Filter => IvyFilter}
+import org.log4s.getLogger
+
+import scala.concurrent.ExecutionContext
+import scala.collection.JavaConverters._
+
+class IvyFetcher extends URLDependencyFetcher {
+  protected implicit val executionContext: ExecutionContext = ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
+  protected implicit val contextShift: ContextShift[IO] =  IO.contextShift(executionContext)
+
+  private val logger = getLogger
+
+  private val settings = new IvySettings()
+  private val cachePath = settings.getDefaultCache.toPath
+
+  override protected def resolveDependencies(
+    repositories: List[RepositoryConfig],
+    dependencies: List[DependencyConfigs],
+    exclusions: List[String],
+    taskInfo: TaskInfo,
+    statusUpdates: Publish[IO, KernelStatusUpdate]
+  ): IO[List[(String, IO[File])]] = {
+
+    val settings = createSettings(repositories, statusUpdates)
+    val ivy = Ivy.newInstance(settings)
+    ivy.getEventManager.addTransferListener(new TransferListener {
+      def transferProgress(evt: TransferEvent): Unit = {
+        if (evt.isTotalLengthSet) {
+          val totalLength = evt.getTotalLength
+          val downloaded = evt.getLength
+          val status = if (downloaded >= totalLength) TaskStatus.Complete else TaskStatus.Running
+          statusUpdates.publish1(UpdatedTasks(
+            List(TaskInfo(
+              evt.getResource.getName,
+              s"Downloading ${evt.getLocalFile.getName}",
+              "",
+              status,
+              (downloaded.toDouble / totalLength * 255).toByte)))).unsafeRunAsyncAndForget()
+        }
+      }
+    })
+
+    val updateProgress = (progress: Double) => statusUpdates.publish1(UpdatedTasks(List(taskInfo.copy(progress = (progress * 255).toByte))))
+
+    resolve(ivy, dependencies.flatMap(_.get("scala").toList).flatten, exclusions, updateProgress)
+  }
+
+
+  private def createSettings(repositories: List[RepositoryConfig], statusUpdates: Publish[IO, KernelStatusUpdate]) = {
+    val chain = new ChainResolver()
+    chain.setName("Resolver chain")
+
+    val cacheResolver = new CacheResolver(settings)
+    chain.add(cacheResolver)
+
+    val resolvers = repositories.map {
+      case repo@ivy(base, _, _, changing) =>
+        val resolver = new ParallelURLResolver(statusUpdates)
+        val normedBase = base.stripSuffix("/") + "/"
+        resolver.addArtifactPattern(normedBase + repo.artifactPattern.stripPrefix("/"))
+        resolver.addIvyPattern(normedBase + repo.metadataPattern.stripPrefix("/"))
+        resolver.setName(base)
+        resolver
+      case repo@maven(base, changing) =>
+        val resolver = new ParallelIBiblioResolver(statusUpdates)
+        resolver.setRoot(base)
+        resolver.setM2compatible(true)
+        resolver.setName(base)
+        resolver
+    }
+
+    // add maven central to the end of the chain
+    val mavenCentral = new ParallelIBiblioResolver(statusUpdates)
+    mavenCentral.setName("Maven central")
+    mavenCentral.setRoot(IBiblioResolver.DEFAULT_M2_ROOT)
+    mavenCentral.setM2compatible(true)
+
+    chain.add(mavenCentral)
+
+    resolvers foreach chain.add
+
+    settings.addResolver(chain)
+    settings.setDefaultResolver(chain.getName)
+
+    settings
+  }
+
+  private def resolve(
+    ivy: Ivy,
+    dependencies: List[String],
+    exclusions: List[String],
+    updateProgress: Double => IO[Unit]): IO[List[(String, IO[File])]] = {
+
+    val excludedOrgModules = exclusions.map {
+      e => e.split(':') match {
+        case Array(org) => org -> "*"
+        case Array(org, module) => org -> module
+      }
+    }.groupBy(_._1).mapValues(_.map(_._2).toSet) ++ Map("org.scala-lang" -> Set("*"), "org.apache.spark" -> Set("*"))
+
+    val baseFilter = Filter {
+      case artifact if excludedOrgModules contains artifact.getModuleRevisionId.getOrganisation =>
+        val excluded = excludedOrgModules(artifact.getModuleRevisionId.getOrganisation)
+        !(excluded(artifact.getModuleRevisionId.getModuleId.getName) || excluded("*"))
+      case _ => true
+    }
+
+    val defaultOptions = new ResolveOptions()
+    //defaultOptions.setLog("quiet")
+    defaultOptions.setDownload(true)
+    defaultOptions.setTransitive(true)
+    defaultOptions.setConfs(Array("default", "compile"))
+    defaultOptions.setArtifactFilter(baseFilter)
+
+
+    def mdOpts(org: String, name: String, ver: String, classifier: String = "", typ: String = "jar", config: String = "default") = {
+      val attrs = Map(
+        "classifier" -> classifier,
+        "type" -> typ
+      )
+
+      val mrid = ModuleRevisionId.newInstance(org, name, ver, attrs.asJava)
+
+      (mrid, (classifier != "all"), Option(config).getOrElse("default"))
+    }
+
+    val ivyDeps = dependencies.map {
+      moduleStr => moduleStr.split(':') match {
+        case Array(org, name, ver) => mdOpts(org, name, ver)
+        case Array(org, name, classifier, ver) => mdOpts(org, name, ver, classifier)
+        case Array(org, name, typ, classifier, ver) => mdOpts(org, name, ver, classifier, typ)
+        case Array(org, name, typ, config, classifier, ver) => mdOpts(org, name, ver, classifier, typ, config)
+        case _ => throw new Exception(s"Unable to parse dependency '$moduleStr'")
+      }
+    }
+
+    val downloaded = new AtomicInteger(0)
+    val total = ivyDeps.size
+
+    val ivyModule = new DefaultModuleDescriptor(ModuleRevisionId.newInstance("caller", "all-caller", "working"), "integration", null, true)
+    org.apache.ivy.plugins.parser.m2.PomModuleDescriptorBuilder.MAVEN2_CONFIGURATIONS.foreach(ivyModule.addConfiguration)
+
+    ivyDeps.foreach {
+      case (mrid, transitive, config) =>
+        val dd = new DefaultDependencyDescriptor(ivyModule, mrid, mrid, true, false, transitive)
+        dd.addDependencyConfiguration("default", config)
+        ivyModule.addDependency(dd)
+    }
+
+    (IO(println(s"Starting resolve at ${java.time.Instant.now()}")) *>
+      IO(ivy.resolve(ivyModule, defaultOptions)) <* IO(println(s"Finished resolve at ${java.time.Instant.now()}"))
+    ).map {
+      report =>
+
+        // TODO: handle errors
+        if (report.hasError) {
+          report.getAllProblemMessages.asScala.foreach {
+            msg => logger.error(s"Resolution error: $msg")
+          }
+        }
+
+        report.getArtifactsReports(null, false).toList.flatMap {
+          artifactReport =>
+            val localFile = Option(artifactReport.getLocalFile)
+            if (localFile.isEmpty) {
+              logger.error(s"Local file is null for artifact ${artifactReport.getArtifact}, download ${artifactReport.getDownloadStatus}")
+            }
+            localFile.map {
+              file => file.getName -> IO.pure(file)
+            }
+        }.toMap.toList
+    }
+  }
+
+  case class Filter(fn: Artifact => Boolean) extends IvyFilter {
+    override def accept(o: Any): Boolean = o match {
+      case artifact: Artifact => fn(artifact)
+      case _ => false
+    }
+
+    def &&(next: Artifact => Boolean): Filter = copy(fn = artifact => fn(artifact) && next(artifact))
+    def ||(next: Artifact => Boolean): Filter = copy(fn = artifact => fn(artifact) || next(artifact))
+  }
+
+  protected def cacheLocation(uri: URI): Path = {
+    val pathParts = Seq(uri.getScheme, uri.getAuthority, uri.getPath).flatMap(Option(_))
+    pathParts.foldLeft(cachePath)(_ resolve _)
+  }
+
+
+  class ParallelURLResolver(statusUpdates: Publish[IO, KernelStatusUpdate]) extends URLResolver {
+    // weird protected access problems when trying to put this stuff into a trait, so it's duplicated in both of these subclasses.
+
+    private val artifactResourceResolver = new ArtifactResourceResolver() {
+      override def resolve(artifact: Artifact): ResolvedResource =
+        getArtifactRef(NameSpaceHelper.transform(artifact, getNamespace.getFromSystemTransformer), null)
+    }
+
+    private val resourceDownloader = new ResourceDownloader {
+      def download(artifact: Artifact, resource: Resource, dest: File): Unit = {
+        fetchUrl(new URI(resource.getName), dest, statusUpdates) match {
+          case (name, io) => io.unsafeRunSync()
+        }
+      }
+    }
+
+    override def download(artifacts: Array[Artifact], options: DownloadOptions): DownloadReport = {
+      val eventManager = getEventManager
+      val cacheManager = getRepositoryCacheManager
+      clearArtifactAttempts()
+      if (eventManager != null) {
+        getRepository.addTransferListener(eventManager)
+      }
+
+      try {
+        val downloads = artifacts.toList.map {
+          artifact =>
+            IO(cacheManager.download(artifact, artifactResourceResolver, resourceDownloader, getCacheDownloadOptions(options)))
+        }
+        val report = new DownloadReport
+        downloads.parSequence.unsafeRunSync().foreach(report.addArtifactReport)
+        report
+      } finally {
+        if (eventManager != null) {
+          getRepository.removeTransferListener(eventManager)
+        }
+      }
+    }
+  }
+
+  class ParallelIBiblioResolver(statusUpdates: Publish[IO, KernelStatusUpdate]) extends IBiblioResolver {
+    private val artifactResourceResolver = new ArtifactResourceResolver() {
+      override def resolve(artifact: Artifact): ResolvedResource =
+        getArtifactRef(NameSpaceHelper.transform(artifact, getNamespace.getFromSystemTransformer), null)
+    }
+
+    private val resourceDownloader = new ResourceDownloader {
+      def download(artifact: Artifact, resource: Resource, dest: File): Unit = {
+        val uri = resource match {
+          case res: URLResource => Option(res.getURL).map(_.toURI)
+          case res: FileResource => Option(res.getFile).map(_.toURI)
+          case _ => Option(resource.getName).flatMap(name => try Some(new URI(name)) catch { case err: Throwable => None } )
+        }
+        uri.foreach {
+          uri => fetchUrl(uri, dest, statusUpdates) match {
+            case (name, io) => io.unsafeRunSync()
+          }
+        }
+      }
+    }
+
+    override def download(artifacts: Array[Artifact], options: DownloadOptions): DownloadReport = {
+      val eventManager = getEventManager
+      if (eventManager != null) {
+        getRepository.addTransferListener(eventManager)
+      }
+      try {
+        ensureConfigured(getSettings)
+        val cacheManager = getRepositoryCacheManager
+        clearArtifactAttempts()
+        val downloads = artifacts.toList.map {
+          artifact =>
+            IO(cacheManager.download(artifact, artifactResourceResolver, resourceDownloader, getCacheDownloadOptions(options)))
+        }
+        val report = new DownloadReport
+        downloads.parSequence.unsafeRunSync().foreach(report.addArtifactReport)
+        report
+      } finally {
+        if (eventManager != null) {
+          getRepository.removeTransferListener(eventManager)
+        }
+      }
+    }
+  }
+}

--- a/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
+++ b/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
@@ -13,7 +13,6 @@ import polynote.config.{DependencyConfigs, RepositoryConfig}
 import polynote.data.Rope
 import polynote.kernel.util.OptionEither
 import polynote.runtime.{StreamingDataRepr, TableOp}
-import shapeless.Lazy
 
 sealed trait Message
 

--- a/polynote-server/src/main/scala/polynote/server/KernelFactory.scala
+++ b/polynote-server/src/main/scala/polynote/server/KernelFactory.scala
@@ -12,7 +12,6 @@ import polynote.config.PolynoteConfig
 import polynote.kernel.dependency.DependencyFetcher
 import polynote.kernel.lang.LanguageInterpreter
 import polynote.kernel._
-import polynote.kernel.dependency.CoursierFetcher.FileErrorException
 import polynote.kernel.util.{Publish, ReadySignal}
 import polynote.messages.{Notebook, NotebookConfig, TinyMap}
 
@@ -99,9 +98,6 @@ class IOKernelFactory(
   // TODO: ignoring download errors for now, until the weirdness of resolving nonexisting artifacts is solved
   private def downloadFailed(err: Throwable): IO[Option[(String, String, File)]] = IO {
     err match {
-      case _: FileErrorException =>
-        System.err.println(s"Ignoring Coursier download error: ${err.getMessage}")
-        None
       case other =>
         // don't ignore other errors
         throw RuntimeError(new Exception(s"Error while downloading dependencies: ${other.getMessage}", other))

--- a/polynote-server/src/main/scala/polynote/server/KernelLaunching.scala
+++ b/polynote-server/src/main/scala/polynote/server/KernelLaunching.scala
@@ -9,7 +9,7 @@ trait KernelLaunching {
   protected implicit def timer: Timer[IO]
   protected implicit def contextShift: ContextShift[IO]
 
-  protected val dependencyFetcher = new IvyFetcher() //new CoursierFetcher()
+  protected val dependencyFetcher = new CoursierFetcher()
   protected val dependencyFetchers: Map[String, DependencyFetcher[IO]] = Map("scala" -> dependencyFetcher)
 
   protected def kernelFactory: KernelFactory[IO] = new IOKernelFactory(dependencyFetchers)

--- a/polynote-server/src/main/scala/polynote/server/KernelLaunching.scala
+++ b/polynote-server/src/main/scala/polynote/server/KernelLaunching.scala
@@ -1,7 +1,7 @@
 package polynote.server
 
 import cats.effect.{ContextShift, IO, Timer}
-import polynote.kernel.dependency.{CoursierFetcher, DependencyFetcher}
+import polynote.kernel.dependency.{CoursierFetcher, DependencyFetcher, IvyFetcher}
 
 
 trait KernelLaunching {
@@ -9,7 +9,7 @@ trait KernelLaunching {
   protected implicit def timer: Timer[IO]
   protected implicit def contextShift: ContextShift[IO]
 
-  protected val dependencyFetcher = new CoursierFetcher()
+  protected val dependencyFetcher = new IvyFetcher() //new CoursierFetcher()
   protected val dependencyFetchers: Map[String, DependencyFetcher[IO]] = Map("scala" -> dependencyFetcher)
 
   protected def kernelFactory: KernelFactory[IO] = new IOKernelFactory(dependencyFetchers)

--- a/polynote-server/src/main/scala/polynote/server/Server.scala
+++ b/polynote-server/src/main/scala/polynote/server/Server.scala
@@ -11,13 +11,10 @@ import org.http4s.dsl.Http4sDsl
 import org.http4s.server.blaze.BlazeBuilder
 import org.log4s.{Logger, getLogger}
 import polynote.config.PolynoteConfig
-import polynote.kernel.dependency.CoursierFetcher
-import polynote.kernel.lang.{LanguageInterpreter, LanguageInterpreterService}
 import polynote.server.repository.NotebookRepository
 import polynote.server.repository.ipynb.IPythonNotebookRepository
 import polynote.buildinfo.BuildInfo
 
-import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
 trait Server extends IOApp with Http4sDsl[IO] with KernelLaunching {


### PR DESCRIPTION
Added an Ivy fetcher to see if it would have better performance. It was way slower for the first resolution, but way faster after that.

Next, I updated the coursier dependency and rewrote most of the `CoursierFetcher` to use the newer APIs. Deleted a bunch of copypasta and did it the (mostly) "right way". There were a couple things I had to workaround hackily, but it's now *waaaaay* faster to resolve dependencies. No more waiting 4 minutes to resolve them when you restart your kernel.