### PR TITLE
Fix reload-while-running bug

### DIFF
--- a/polynote-server/src/main/scala/polynote/server/SharedNotebook.scala
+++ b/polynote-server/src/main/scala/polynote/server/SharedNotebook.scala
@@ -102,8 +102,6 @@ class IOSharedNotebook(
 
   private val statusUpdates = Publish.PublishTopic(outputMessages).contramap[KernelStatusUpdate](KernelStatus(ShortString(path), _))
 
-  private val queued = Ref.unsafe[IO, Set[CellID]](Set.empty)
-
   def shutdown(): IO[Unit] = for {
     _         <- subscribers.values().asScala.toList.parTraverse(_.close())
     kernelOpt <- kernelRef.get


### PR DESCRIPTION
Moves the cell running logic outside of the subscriber and disconnects its evaluation from the downstream websocket.