### PR TITLE
Fix some Scala interpreter issues

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
@@ -222,7 +222,7 @@ class ScalaInterpreter(
     code: String
   ): IO[Stream[IO, Result]] = {
     val previous = cellContext.collectBack {
-      case c if previousSources contains c.id => previousSources(c.id)
+      case c if c.id != cellContext.id && (previousSources contains c.id) => previousSources(c.id)
     }.reverse
 
     val source = ScalaSource(kernelContext, cellContext, previous, notebookPackageName, code)


### PR DESCRIPTION
1. Fix issue where runtime toolbox can't correctly infer `ReprsOf` (now infers by compiling a module from the interactive compiler)
2. Fix issue where stuff defined in previous cells is intermittently not visible to current cell
3. Fix prioritization of `ReprsOf` (can now get data browse & plot for a list of case class instances)