### PR TITLE
Add google to list of shared python modules

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
@@ -121,7 +121,7 @@ class PythonInterpreter(val kernelContext: KernelContext) extends LanguageInterp
 
   def withJep[T](t: => T): IO[T] = shift.evalOn(executionContext)(IO.delay(t))
 
-  protected def sharedModules: List[String] = List("numpy")
+  protected def sharedModules: List[String] = List("numpy", "google")
 
   protected val jep: Jep = jepExecutor.submit {
     new Callable[Jep] {


### PR DESCRIPTION
According to my research, some google packages don't like to be imported more than once, resulting in `A Message class can only inherit from Message` errors.

I *think* that adding google to the shared module list will fix this problem, and will cause the offending packages to just be shared across Jep instances, thus avoiding the issue.

In the future, maybe we should make this property configurable to the user.