### PR TITLE
Fix streaming data for remote kernels

### DIFF
--- a/polynote-runtime/src/main/scala/polynote/runtime/ValueRepr.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/ValueRepr.scala
@@ -232,7 +232,10 @@ object StreamingDataRepr {
     iter: => Iterator[ByteBuffer]
   ) extends Handle {
     def iterator: Iterator[ByteBuffer] = iter
-    def modify(ops: List[TableOp]): Either[Throwable, Int => Handle] = Left(new UnsupportedOperationException("Table operators are not supported for this data type"))
+    def modify(ops: List[TableOp]): Either[Throwable, Int => Handle] = ops match {
+      case Nil => Right(new DefaultHandle(_, dataType, knownSize, iter))
+      case _   => Left(new UnsupportedOperationException("Table operators are not supported for this data type"))
+    }
   }
 
   private val handles: ConcurrentHashMap[Int, Handle] = new ConcurrentHashMap()

--- a/polynote-runtime/src/main/scala/polynote/runtime/macros/StructDataEncoderMacros.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/macros/StructDataEncoderMacros.scala
@@ -1,0 +1,5 @@
+package polynote.runtime.macros
+
+class StructDataEncoderMacros {
+
+}

--- a/polynote-spark/src/test/scala/polynote/kernel/MockKernel.scala
+++ b/polynote-spark/src/test/scala/polynote/kernel/MockKernel.scala
@@ -65,7 +65,10 @@ class MockKernel(@volatile private var notebook: Notebook) extends KernelAPI[IO]
     case _ => IO.raiseError(new IllegalArgumentException("No handle with that id"))
   }
 
-  def modifyStream(handleId: Int, ops: List[TableOp]): IO[Option[StreamingDataRepr]] = IO.pure(None)
+  def modifyStream(handleId: Int, ops: List[TableOp]): IO[Option[StreamingDataRepr]] = ops match {
+    case Nil => IO.pure(Some(MockKernel.twoStreamRepr))
+    case _ => IO.pure(None)
+  }
 
   def releaseHandle(handleType: HandleType, handleId: Int): IO[Unit] = IO.unit
 


### PR DESCRIPTION
Makes streaming data (plots, etc) work properly with remote kernels enabled.

After this is released I think people could start trying out remote kernels; it would be good to get some feedback on how urgently we need to add fault tolerance (at the transport level) and whatnot.