### PR TITLE
Table ops for seq-of-struct

### DIFF
--- a/polynote-runtime/src/main/scala/polynote/runtime/macros/StructDataEncoderMacros.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/macros/StructDataEncoderMacros.scala
@@ -1,5 +1,83 @@
 package polynote.runtime.macros
 
-class StructDataEncoderMacros {
+import polynote.runtime.{DataEncoder, DataType, StructField, StructType}
+
+import scala.reflect.macros.whitebox
+import polynote.runtime.DataEncoder.StructDataEncoder
+import shapeless.CaseClassMacros
+
+class StructDataEncoderMacros(val c: whitebox.Context) extends CaseClassMacros {
+
+  import c.universe._
+
+  private val DataEncoderTC = weakTypeOf[DataEncoder[_]].typeConstructor
+
+  /**
+    * A macro to materialize a more performant set of getters for [[StructDataEncoder]] over a case class.
+    */
+  def materialize[A <: Product : WeakTypeTag]: Expr[StructDataEncoder[A]] = {
+    val A = weakTypeOf[A].dealias.widen
+    fieldsOf(A) match {
+      case Nil => c.abort(c.enclosingPosition, "Not a case class, or has no fields")
+      case fields =>
+        fields.flatMap {
+          case (name, typ) =>
+            c.inferImplicitValue(appliedType(DataEncoderTC, typ)) match {
+              case EmptyTree => None
+              case tree => Some((name, typ, tree))
+            }
+        } match {
+          case Nil => c.abort(c.enclosingPosition, "No fields with available DataEncoders")
+          case encodableFields =>
+            val (fields, encoderVariables, structFields) = encodableFields.map {
+              case (name, typ, tree) =>
+                val nameStr = name.decodedName.toString
+                val nameStrExpr = c.Expr[String](Literal(Constant(nameStr)))
+                val encoderVariableName = c.freshName(name)
+                val encoderVariable = ValDef(Modifiers(), encoderVariableName, TypeTree(appliedType(DataEncoderTC, typ)), tree)
+                val dataTypeExpr = c.Expr[DataType](Select(Ident(encoderVariableName), TermName("dataType")))
+
+                val structField = reify {
+                  StructField(nameStrExpr.splice, dataTypeExpr.splice)
+                }
+
+                ((name, typ), encoderVariable, structField)
+            }.unzip3
+
+            val structFieldsList = c.Expr[List[StructField]](q"List(..$structFields)")
+            val structType = reify(StructType(structFieldsList.splice))
+
+            val (encodeFields, sizeFields) = fields.zip(encoderVariables).map {
+              case ((name, typ), encoderVariable) =>
+                val encode = q"${encoderVariable.name}.encode(output, value.$name)"
+                val size = q"${encoderVariable.name}.sizeOf(value.$name)"
+
+                (encode, size)
+            }.unzip
+
+            val sizeOf = sizeFields.reduceRight {
+              (nextSize, totalSize) => q"polynote.runtime.DataEncoder.combineSize($nextSize, $totalSize)"
+            }
+
+            val matchFields = fields.zip(encoderVariables).map {
+              case ((name, typ), encoderVariable) =>
+                cq"${name.decodedName.toString} => Some((((value: $A) => value.$name), ${encoderVariable.name}))"
+            } :+ cq"_ => None"
+
+            val result = q"""
+              ..$encoderVariables
+              new _root_.polynote.runtime.DataEncoder.StructDataEncoder[$A]($structType) {
+                def encode(output: java.io.DataOutput, value: $A): Unit = { ..$encodeFields }
+                def sizeOf(value: $A): _root_.scala.Int = $sizeOf
+                def field(name: String): Option[($A => Any, _root_.polynote.runtime.DataEncoder[_])] = name match { case ..$matchFields }
+              }
+            """
+
+
+            c.Expr[StructDataEncoder[A]](result)
+        }
+    }
+
+  }
 
 }

--- a/polynote-runtime/src/test/scala/polynote/runtime/test/StructDataEncoderSpec.scala
+++ b/polynote-runtime/src/test/scala/polynote/runtime/test/StructDataEncoderSpec.scala
@@ -1,0 +1,28 @@
+package polynote.runtime
+package test
+
+import org.scalatest.{FreeSpec, Matchers}
+
+class StructDataEncoderSpec extends FreeSpec with Matchers {
+
+  case class TestAllEncodable(first: Int, second: Double, third: Boolean, fourth: String)
+
+  "can encode a case class" in {
+    val encoder = implicitly[DataEncoder[TestAllEncodable]].asInstanceOf[DataEncoder.StructDataEncoder[TestAllEncodable]]
+
+    encoder.dataType shouldEqual StructType(List(
+      StructField("first", IntType),
+      StructField("second", DoubleType),
+      StructField("third", BoolType),
+      StructField("fourth", StringType)
+    ))
+
+    val inst = TestAllEncodable(22, 2.2, true, "hello")
+
+    val Some((firstGetter, firstEncoder)) = encoder.field("first")
+    firstGetter(inst) shouldEqual 22
+    firstEncoder.dataType shouldEqual IntType
+
+  }
+
+}


### PR DESCRIPTION
* Added table ops for sequences of structs (i.e. case classes)
* Changed `DataEncoder` for case classes to use a direct macro, mainly for performance
* Shuffled the ordering of `ReprsOf` priorities, to make sure external definitions get a first chance