### PR TITLE
Issue 292 cache busting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # UNRELEASED
 
-*
+* Can now bust cache of URL dependencies (e.g., `file:///`, `s3://`, etc) by adding URL parameter `?nocache` to the end of the path [#292]
+
+[#292]: https://github.com/polynote/polynote/issues/292
 
 # 0.1.9 (May 3, 2019)
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/dependency/DependencyFetcher.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/dependency/DependencyFetcher.scala
@@ -89,7 +89,7 @@ trait URLDependencyFetcher extends DependencyFetcher[IO] {
 
       if (inputAsFile.exists()) {
         IO.pure(inputAsFile)
-      } else if (cacheFile.exists()) {
+      } else if (cacheFile.exists() && !Option(uri.getQuery).exists(_.contains("nocache"))) {
         IO.pure(cacheFile)
       } else {
         // ok we actually have to fetch it I guess


### PR DESCRIPTION
Stupid-simple way to solve #292. Adding `?nocache` or `?nocache=true` (or whatever else you want as long as it says `nocache` somewhere...) to the end of a URL dependency bypasses the cache. 