### PR TITLE
add s3n and s3a protocol to HadoopFileProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # UNRELEASED
 
-*
+* Support `s3n` and `s3a` URLs as well (just a config change on our end). 
 
 # 0.1.9 (May 3, 2019)
 

--- a/polynote-spark/src/main/scala/polynote/kernel/util/HadoopFileProvider.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/util/HadoopFileProvider.scala
@@ -7,7 +7,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 
 class HadoopFileProvider extends DownloadableFileProvider {
-  override def protocols: Seq[String] = Seq("hdfs", "hftp", "s3")
+  override def protocols: Seq[String] = Seq("hdfs", "hftp", "s3", "s3n", "s3a")
 
   override def provide: PartialFunction[URI, DownloadableFile] = {
     case Supported(uri) => HadoopFile(uri)


### PR DESCRIPTION
These were just omitted in the original implementation but they should both work fine. 