### PR TITLE
[#301] Python SyntaxErrors as CompileErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # UNRELEASED
 
-*
+* Python `SyntaxError`s raised by parsing cell contents now raised as `CompileErrors` rather than Runtime Errors. [#301]
+
+[#301]: https://github.com/polynote/polynote/issues/301
 
 # 0.1.10 (May 9, 2019)
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
@@ -7,6 +7,7 @@ import java.util.concurrent._
 import java.util.concurrent.atomic.AtomicReference
 
 import cats.effect.{ContextShift, IO}
+import cats.syntax.either._
 import fs2.Stream
 import fs2.concurrent.{Enqueue, Queue}
 import jep.python.{PyCallable, PyObject}
@@ -232,11 +233,11 @@ class PythonInterpreter(val kernelContext: KernelContext) extends LanguageInterp
 
 
         val pyResults = for {
-          _ <- wrapEval("__polynote_parsed__ = ast.parse(__polynote_code__, __polynote_cell__, 'exec')").right
-          _ <- (if (jep.getValue("len(__polynote_parsed__.body)", classOf[java.lang.Integer]) > 0) Right(List.empty[Result]) else Left(List.empty[CompileErrors])).right
-          _ <- wrapEval("__polynote_parsed__ = LastExprAssigner().visit(__polynote_parsed__)").right
-          _ <- wrapEval("__polynote_parsed__ = ast.fix_missing_locations(__polynote_parsed__)").right
-          _ <- wrapEval("__polynote_code__ = compile(__polynote_parsed__, '<ast>', 'exec')").right
+          _ <- wrapEval("__polynote_parsed__ = ast.parse(__polynote_code__, __polynote_cell__, 'exec')")
+          _ <- if (jep.getValue("len(__polynote_parsed__.body)", classOf[java.lang.Integer]) > 0) Right(List.empty[Result]) else Left(List.empty[CompileErrors])
+          _ <- wrapEval("__polynote_parsed__ = LastExprAssigner().visit(__polynote_parsed__)")
+          _ <- wrapEval("__polynote_parsed__ = ast.fix_missing_locations(__polynote_parsed__)")
+          _ <- wrapEval("__polynote_code__ = compile(__polynote_parsed__, '<ast>', 'exec')")
         } yield {
           kernelContext.runInterruptible {
             jep.eval("exec(__polynote_code__, __polynote_globals__, __polynote_locals__)\n")

--- a/polynote-kernel/src/test/scala/polynote/kernel/lang/python/PythonInterpreterSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/lang/python/PythonInterpreterSpec.scala
@@ -304,4 +304,12 @@ class PythonInterpreterSpec extends FlatSpec with Matchers with KernelSpec {
         mixed shouldEqual 6
     }
   }
+
+  "foo" should "bar" in {
+    assertPythonOutput("this is a syntax error") { case (vars, output, displayed) =>
+      vars.toSeq shouldBe empty
+      output shouldBe empty
+      displayed should contain only "text/html" -> "hi"
+    }
+  }
 }

--- a/polynote-kernel/src/test/scala/polynote/kernel/lang/python/PythonInterpreterSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/lang/python/PythonInterpreterSpec.scala
@@ -2,7 +2,7 @@ package polynote.kernel.lang.python
 
 import jep.python.{PyCallable, PyObject}
 import org.scalatest._
-import polynote.kernel.Output
+import polynote.kernel.{CompileErrors, KernelReport, Output, Pos}
 import polynote.kernel.lang.KernelSpec
 import polynote.runtime.MIMERepr
 import polynote.runtime.python.{PythonFunction, PythonObject}
@@ -285,6 +285,16 @@ class PythonInterpreterSpec extends FlatSpec with Matchers with KernelSpec {
     }
   }
 
+  it should "Raise SyntaxErrors as CompileErrors" in {
+    assertPythonOutput("syntax error") { case (vars, output, displayed) =>
+      vars.toSeq shouldBe empty
+      output should contain theSameElementsAs Seq(
+        CompileErrors(List(KernelReport(Pos("Cell0", 12, 13, 12), "invalid syntax", KernelReport.Error)))
+      )
+      displayed shouldBe empty
+    }
+  }
+
   "PythonFunction" should "allow positional and keyword args" in {
 
     val code =
@@ -302,14 +312,6 @@ class PythonInterpreterSpec extends FlatSpec with Matchers with KernelSpec {
 
         val mixed = hello(1, 2, three = 3)
         mixed shouldEqual 6
-    }
-  }
-
-  "foo" should "bar" in {
-    assertPythonOutput("this is a syntax error") { case (vars, output, displayed) =>
-      vars.toSeq shouldBe empty
-      output shouldBe empty
-      displayed should contain only "text/html" -> "hi"
     }
   }
 }


### PR DESCRIPTION
Grabs `SyntaxError`s generated when parsing/compiling the `ast` and lifts them into `CompileErrors`. 

Resolves #301 