### PR TITLE
Handle duplicate names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # UNRELEASED
 
-*
+* Duplicate notebook names now handled gracefully, we'll just increment the filename until there's no conflict [#296]
+
+[#296]: https://github.com/polynote/polynote/issues/296
 
 # 0.1.10 (May 9, 2019)
 

--- a/polynote-server/src/test/scala/polynote/server/repository/FileBasedRepositorySpec.scala
+++ b/polynote-server/src/test/scala/polynote/server/repository/FileBasedRepositorySpec.scala
@@ -26,7 +26,7 @@ class FileBasedRepositorySpec extends FreeSpec with Matchers {
         }
       }
 
-      "should error if the notebook already exists" in {
+      "should add a number to the end of the name if the notebook already exists" in {
 
         val repo = new SimpleFileBasedRepo
 
@@ -36,8 +36,8 @@ class FileBasedRepositorySpec extends FreeSpec with Matchers {
         repo.notebookExists(resultingPath).unsafeRunSync() shouldBe true
         Files.exists(repo.path.resolve(resultingPath)) shouldBe true
 
-        a[FileAlreadyExistsException] should be thrownBy {
-          repo.createNotebook(nbName).unsafeRunSync()
+        (2 to 10) foreach { i =>
+          repo.createNotebook(nbName).unsafeRunSync() shouldEqual s"$nbName$i.${repo.defaultExtension}"
         }
       }
 
@@ -152,7 +152,7 @@ class SimpleFileBasedRepo extends FileBasedRepository {
 
   implicit val contextShift: ContextShift[IO] = IO.contextShift(executionContext)
 
-  override protected def defaultExtension: String = "test"
+  override def defaultExtension: String = "test"
 
   override def loadNotebook(path: String): IO[Notebook] = ???
 


### PR DESCRIPTION
Gracefully handle duplicate nb names  - just increment the filename if a user's trying to create a new notebook rather than being mean and failing.

Resolves #296 