### PR TITLE
Set cell-output-container display to block

### DIFF
--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -1209,7 +1209,7 @@ body {
 
     .cell-output-container {
       grid-area: output;
-      display: inherit;
+      display: block;
     }
 
     .errors, .output {


### PR DESCRIPTION
When cell-output-container display was `grid` (through `inherit`), browser
layout was about 100x slower than if it is set to `block`.

Extremely non-scientific test. Given Notebook with a cell with very long
line output (~20kb of text):

Layout with `grid`: ~200ms
Layout with `block`: ~2ms