### PR TITLE
Fix Python scope issue

### DIFF
--- a/polynote-kernel/src/test/scala/polynote/kernel/lang/python/PythonInterpreterSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/lang/python/PythonInterpreterSpec.scala
@@ -295,6 +295,29 @@ class PythonInterpreterSpec extends FlatSpec with Matchers with KernelSpec {
     }
   }
 
+  it should "properly handle imports in local scopes" in {
+    assertPythonOutput(
+      """
+        |import math
+        |
+        |def func(x):
+        |    result = math.sin(x)  # create a local var to make sure it doesn't appear in the outputs
+        |    return result
+        |
+        |func(math.pi/2)
+      """.stripMargin) {
+      case (vars, output, displayed) =>
+        vars should have size 2
+        val f = vars("func")
+        f shouldBe a[PythonFunction]
+        val fInstance = f.asInstanceOf[PythonFunction]
+        fInstance(Math.PI/2) shouldEqual 1.0
+        vars("Out") shouldEqual 1.0
+        output shouldBe empty
+        displayed shouldBe empty
+      }
+  }
+
   "PythonFunction" should "allow positional and keyword args" in {
 
     val code =

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -17,4 +17,4 @@ jar xf ${polynote_jar} ${scala_jar}
 
 actual_command=$(java -cp ${scala_jar}:${polynote_jar} polynote.server.SparkServer --printCommand 2>&1 | sed -n "s/^.*SparkSubmit: \(.*\).*$/\1/p")
 echo "${actual_command}"
-${actual_command} | tee polynote-server-`date +"%Y-%m-%dT%H:%MZ"`.log
+bash -c "${actual_command}" | tee polynote-server-`date +"%Y-%m-%dT%H:%MZ"`.log


### PR DESCRIPTION
We ran into
https://stackoverflow.com/questions/39647566/why-does-python-3-exec-fail-when-specifying-locals

Looks like when we pass in our own `locals` to exec it won't update the
globals dictionary itself, so references to outer scopes (like from
within a function) didn't work.

This change splits up the code and execs each top-level statement
separately, so that globals is properly updated. This is actually what
IPython seems to do under the hood so we seem to be in good company.