### PR TITLE
Make Runtime.externalValues transient

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,7 @@ val `polynote-server` = project.settings(
     "org.slf4j" % "slf4j-simple" % "1.7.25"
   ),
   unmanagedResourceDirectories in Compile += (ThisBuild / baseDirectory).value / "polynote-frontend" / "dist"
-) dependsOn `polynote-kernel`
+) dependsOn `polynote-kernel` % "compile->compile;test->test"
 
 def copyRuntimeJar(targetDir: File, targetName: String, file: File) = {
     val targetFile = targetDir / targetName
@@ -135,6 +135,6 @@ lazy val `polynote-spark` = project.settings(
   }.taskValue,
   fork in Test := true,
   parallelExecution in Test := false
-) dependsOn (`polynote-server`, `polynote-spark-runtime`)
+) dependsOn (`polynote-server` % "compile->compile;test->test", `polynote-spark-runtime`)
 
 val polynote = project.in(file(".")).aggregate(`polynote-kernel`, `polynote-server`, `polynote-spark`)

--- a/polynote-runtime/src/main/scala/polynote/runtime/Runtime.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/Runtime.scala
@@ -2,14 +2,12 @@ package polynote.runtime
 
 import java.util.concurrent.ConcurrentHashMap
 
-import scala.collection.mutable
-
 // TODO: can we make this a class instantiated per-kernel? Currently we rely on the ClassLoader to prevent cross-contamination
 object Runtime extends Serializable {
 
   def init(): Unit = ()
 
-  private val externalValues = new ConcurrentHashMap[String, Any]()
+  @transient private val externalValues = new ConcurrentHashMap[String, Any]()
 
   def getValue(name: String): Any = externalValues.get(name)
   def putValue(name: String, value: Any): Unit =

--- a/polynote-spark/src/test/scala/polynote/kernel/SparkKernelSpec.scala
+++ b/polynote-spark/src/test/scala/polynote/kernel/SparkKernelSpec.scala
@@ -1,0 +1,27 @@
+package polynote.kernel
+
+import cats.effect.IO
+import fs2.concurrent.Topic
+import polynote.config.PolynoteConfig
+import polynote.kernel.lang.{KernelSpec, SparkLanguages}
+import polynote.kernel.lang.scal.ScalaSparkInterpreter
+import polynote.kernel.util.{KernelContext, Publish}
+import polynote.messages.{Notebook, ShortList}
+
+trait SparkKernelSpec extends KernelSpec {
+  private val interpFactory = ScalaSparkInterpreter.factory()
+
+  override def getKernelContext(updates: Topic[IO, KernelStatusUpdate]): KernelContext = {
+    // we use SparkKernel to get a KernelContext with a proper classpath and to properly set up the session
+    val sparkKernel = SparkPolyKernel(() => IO.pure(Notebook("foo", ShortList(Nil), None)), Map.empty, Map("scala" -> interpFactory), updates, config = PolynoteConfig())
+    sparkKernel.init().unsafeRunSync() // make sure to init the spark session
+    sparkKernel.kernelContext
+  }
+
+  def assertSparkScalaOutput(code: String)(assertion: (Map[String, Any], Seq[Result], Seq[(String, String)]) => Unit): Unit = {
+    assertOutput({ (kernelContext: KernelContext, updates: Topic[IO, KernelStatusUpdate]) =>
+      interpFactory(Nil, kernelContext)
+    }, code)(assertion)
+  }
+
+}

--- a/polynote-spark/src/test/scala/polynote/kernel/lang/ScalaSparkInterpreterSpec.scala
+++ b/polynote-spark/src/test/scala/polynote/kernel/lang/ScalaSparkInterpreterSpec.scala
@@ -1,0 +1,38 @@
+package polynote.kernel.lang
+
+import org.apache.spark.sql.SparkSession
+import org.scalatest.{FlatSpec, Matchers}
+import polynote.kernel.SparkKernelSpec
+
+class ScalaSparkInterpreterSpec extends FlatSpec with Matchers with SparkKernelSpec {
+
+  "The Scala Spark Kernel" should "properly run simple spark jobs" in {
+    val code =
+      """
+        |val x = 1
+        |spark.sparkContext.parallelize(Seq(1,2,3)).map(_ + x).collect.toList
+      """.stripMargin
+    assertSparkScalaOutput(code) { case (vars, output, displayed) =>
+        vars("kernel") shouldEqual polynote.runtime.Runtime
+        vars("spark") shouldBe a[SparkSession]
+        vars("x") shouldEqual 1
+        vars("Out") shouldEqual List(2, 3, 4)
+    }
+  }
+
+  it should "not be affected by unserializable values stored in the Runtime" in {
+    val code =
+      """
+        |val x = 1
+        |kernel.putValue("notSerializable", new {})
+        |spark.sparkContext.parallelize(Seq(1,2,3)).map(_ + x).collect.toList
+      """.stripMargin
+    assertSparkScalaOutput(code) { case (vars, output, displayed) =>
+      vars("kernel") shouldEqual polynote.runtime.Runtime
+      vars("spark") shouldBe a[SparkSession]
+      vars("x") shouldEqual 1
+      vars("Out") shouldEqual List(2, 3, 4)
+    }
+  }
+}
+


### PR DESCRIPTION
Fixes issue where Spark would try to serialize Runtime.externalValues,
causing problems if there was anything unserializable stored there.

Also adds ScalaSparkInterpreter tests.