### PR TITLE
Deep force position for prepended code

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaSource.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaSource.scala
@@ -235,7 +235,7 @@ class ScalaSource[G <: Global](
                     atPos(beginning)(global.noSelfType.copy()),
                     atPos(beginning)(constructor) ::
                       impliedImports.map(atPos(beginning)) :::
-                      prepend.toList.flatten.asInstanceOf[List[global.Tree]].map(atPos(beginning)) :::
+                      prepend.toList.flatten.asInstanceOf[List[global.Tree]].map(forcePos(beginning, _)) :::
                       trees)
                 })
             },


### PR DESCRIPTION
Even after (shallowly) setting position of `OuterScopes` jazz, it can still get confused about positions because the deeper trees still have positions that conflict with the actual code. Force them recursively to the beginning.