### PR TITLE
install jep globally

### DIFF
--- a/scripts/install-jep.sh
+++ b/scripts/install-jep.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-pip3 install --user jep ipython nbconvert jedi
+pip3 uninstall jep
+pip3 install jep ipython nbconvert jedi
 
 # this all assumes that jep was installed to a normal place
 jep_site_packages_path=`pip3 show jep | grep "^Location:" | cut -d ':' -f 2 | cut -d ' ' -f 2`


### PR DESCRIPTION
Fix issues arising from user-installed jep not being able to access some system-installed libraries. 

We'll need to properly deal with Python deps eventually (see #175 ) 