### PR TITLE
ScalaSource overhaul for better serializability

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
@@ -177,7 +177,13 @@ class ScalaInterpreter(
                   // collect term definitions and values from the cell's object, and publish them to the symbol table
                   // TODO: We probably also want to publish some output for types, like "Defined class Foo" or "Defined type alias Bar".
                   //       But the class story is still WIP (i.e. we might want to pull them out of cells into the notebook package)
-                  symType.nonPrivateDecls.filter(d => d.isTerm && !d.isConstructor && !d.isSetter && !d.name.decodedName.toString.contains("$INSTANCE")).collect {
+                  symType.nonPrivateDecls.filter { d =>
+                    d.isTerm &&
+                      !d.isConstructor &&
+                      !d.isSetter &&
+                      !d.name.decodedName.toString.contains("$INSTANCE") &&
+                      !d.name.decodedName.toString.contains("$PROXY$")
+                  }.collect {
 
                     case Val(accessor) =>
                       // if the decl is a val, evaluate it and push it to the symbol table

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
@@ -163,7 +163,8 @@ class ScalaInterpreter(
     interpreterLock.acquire.bracket { _ =>
       IO.fromEither(source.compile).flatMap {
         case global.NoSymbol => IO.pure(Stream.empty)
-        case sym =>
+        case sym if sym.name == source.moduleName =>
+
           val saveSource = IO.delay[Unit](previousSources.put(id, source))
           val setModule = cellContext.module.complete(sym.asModule)
 
@@ -288,6 +289,8 @@ class ScalaInterpreter(
                 ).parJoinUnbounded
             }
           }
+        case userDefinedObject => // TODO: do we want these user-defined objects to show up in the symbol table?
+          IO.pure(Stream.empty)
       }
     }(_ => interpreterLock.release)
   }

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaSource.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaSource.scala
@@ -619,21 +619,17 @@ class ScalaSource[G <: Global](
     for {
       stats <- parsed
     } yield stats.collect {
-      case i @ global.Import(expr, selectors) =>
-        global.Import(reassignThis(moduleInstanceRef)(expr), selectors)
+      case i @ global.Import(expr, selectors) => global.Import(reassignThis(moduleInstanceRef)(expr), selectors)
     }
   }.right.getOrElse(Nil)
 
   lazy val compiledModule: Either[Throwable, global.Symbol] = successfulParse.flatMap {
     _ =>
-//      val run = new global.Run()
       compileUnit.flatMap { unit =>
-//        val x = reporter.attempt(quickTyped)
         val run = new global.Run()
-        val _ = global.newTyperRun()
         withCompiler {
           unit.body = global.resetAttrs(unit.body)
-          reporter.attempt(global.currentRun.compileUnits(List(unit), global.currentRun.namerPhase))
+          reporter.attempt(run.compileUnits(List(unit), run.namerPhase))
         }.flatMap(identity).flatMap {
           _ =>
             withCompiler {

--- a/polynote-kernel/src/main/scala/polynote/kernel/util/KernelReporter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/KernelReporter.scala
@@ -46,6 +46,7 @@ case class KernelReporter(settings: Settings) extends AbstractReporter {
       result
     } catch {
       case err: Throwable =>
+        val x = err
         Left(err)
     } finally {
       restoreState(state)

--- a/polynote-kernel/src/main/scala/polynote/kernel/util/KernelReporter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/KernelReporter.scala
@@ -46,7 +46,6 @@ case class KernelReporter(settings: Settings) extends AbstractReporter {
       result
     } catch {
       case err: Throwable =>
-        val x = err
         Left(err)
     } finally {
       restoreState(state)

--- a/polynote-kernel/src/test/scala/polynote/kernel/lang/python/PythonInterpreterSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/lang/python/PythonInterpreterSpec.scala
@@ -289,7 +289,7 @@ class PythonInterpreterSpec extends FlatSpec with Matchers with KernelSpec {
     assertPythonOutput("syntax error") { case (vars, output, displayed) =>
       vars.toSeq shouldBe empty
       output should contain theSameElementsAs Seq(
-        CompileErrors(List(KernelReport(Pos("Cell0", 12, 13, 12), "invalid syntax", KernelReport.Error)))
+        CompileErrors(List(KernelReport(Pos("Cell1", 12, 13, 12), "invalid syntax", KernelReport.Error)))
       )
       displayed shouldBe empty
     }

--- a/polynote-kernel/src/test/scala/polynote/kernel/lang/scal/ScalaInterpreterSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/lang/scal/ScalaInterpreterSpec.scala
@@ -40,7 +40,7 @@ class ScalaInterpreterSpec extends FlatSpec with Matchers with KernelSpec {
           "hm" -> Map(1 -> "foo", "foo" -> 100, "hey!" ->  List(100, List(1, "foo", Map("sup?" -> "nm"), false))),
           "humm" -> Map(1 -> "foo", "foo" -> 100, "hey!" ->  List(100, List(1, "foo", Map("sup?" -> "nm"), false))))
       )
-      vars("z").toString should (include("$notebook.Eval") and include("$MyNewClass"))
+      vars("z").toString should include("$notebook.MyNewClass")
 
 
       displayed shouldBe empty

--- a/polynote-spark/src/main/scala/polynote/kernel/lang/scal/ScalaSparkInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/lang/scal/ScalaSparkInterpreter.scala
@@ -27,7 +27,7 @@ class ScalaSparkInterpreter(ctx: KernelContext) extends ScalaInterpreter(ctx) {
        |            org.apache.spark.repl.Main.createSparkSession()
        |          }
        |import org.apache.spark.sql.{DataFrame, Dataset}
-       |import this.spark.implicits._
+       |import spark.implicits._
        |import org.apache.spark.sql.functions._
      """.stripMargin
   }

--- a/polynote-spark/src/test/scala/polynote/kernel/SparkKernelSpec.scala
+++ b/polynote-spark/src/test/scala/polynote/kernel/SparkKernelSpec.scala
@@ -18,10 +18,14 @@ trait SparkKernelSpec extends KernelSpec {
     sparkKernel.kernelContext
   }
 
-  def assertSparkScalaOutput(code: String)(assertion: (Map[String, Any], Seq[Result], Seq[(String, String)]) => Unit): Unit = {
+  def assertSparkScalaOutput(code: Seq[String])(assertion: (Map[String, Any], Seq[Result], Seq[(String, String)]) => Unit): Unit = {
     assertOutput({ (kernelContext: KernelContext, updates: Topic[IO, KernelStatusUpdate]) =>
       interpFactory(Nil, kernelContext)
     }, code)(assertion)
+  }
+
+  def assertSparkScalaOutput(code: String)(assertion: (Map[String, Any], Seq[Result], Seq[(String, String)]) => Unit): Unit = {
+    assertSparkScalaOutput(Seq(code))(assertion)
   }
 
 }

--- a/polynote-spark/src/test/scala/polynote/kernel/lang/ScalaSparkInterpreterSpec.scala
+++ b/polynote-spark/src/test/scala/polynote/kernel/lang/ScalaSparkInterpreterSpec.scala
@@ -34,5 +34,73 @@ class ScalaSparkInterpreterSpec extends FlatSpec with Matchers with SparkKernelS
       vars("Out") shouldEqual List(2, 3, 4)
     }
   }
+
+  it should "not be affected by unused unserializable values" in {
+    val code = Seq(
+      "def banana: Int = 1",
+      "val foo = banana",
+      "implicit val i: Int = 10",
+      """
+        |val x = 100
+        |val y = new {}
+        |val z = {
+        |  val foo = 1000
+        |  foo
+        |}
+        |val implicitResult = implicitly[Int]
+      """.stripMargin,
+      "spark.sparkContext.parallelize(Seq(1,2,3)).map(_ + x).collect.toList"
+    )
+    assertSparkScalaOutput(code) { case (vars, output, displayed) =>
+      vars("kernel") shouldEqual polynote.runtime.Runtime
+      vars("spark") shouldBe a[SparkSession]
+      vars("foo") shouldEqual 1
+      vars("i") shouldEqual 10
+      vars("x") shouldEqual 100
+      vars("z") shouldEqual 1000
+      vars("implicitResult") shouldEqual 10
+      vars("Out") shouldEqual List(101, 102, 103)
+    }
+  }
+
+  it should "allow values to be overridden" in {
+    val code = Seq(
+      "val a: Int = 100",
+      "val a: Int = 200",
+      "val b = a"
+    )
+    assertSparkScalaOutput(code) { case (vars, output, displayed) =>
+      vars("kernel") shouldEqual polynote.runtime.Runtime
+      vars("spark") shouldBe a[SparkSession]
+      vars("a") shouldEqual 200
+      vars("b") shouldEqual 200
+    }
+  }
+
+  it should "work with implicits" in {
+    val code = Seq(
+      "implicit val a: Int = 100",
+      "implicit val a: Int = 200", // check implicit override
+      """
+        |def foo(a: Int)(implicit s: Int) = a + s
+        |val b = foo(1)
+      """.stripMargin)
+    assertSparkScalaOutput(code) { case (vars, output, displayed) =>
+      vars("kernel") shouldEqual polynote.runtime.Runtime
+      vars("spark") shouldBe a[SparkSession]
+      vars("a") shouldEqual 200
+      vars("b") shouldEqual 201
+    }
+  }
+
+  it should "work with class defs" in {
+    val code = Seq(
+      "case class Foo(i: Int)",
+      "val foo = Foo(1)")
+    assertSparkScalaOutput(code) { case (vars, output, displayed) =>
+      vars("kernel") shouldEqual polynote.runtime.Runtime
+      vars("spark") shouldBe a[SparkSession]
+    }
+  }
 }
 

--- a/polynote-spark/src/test/scala/polynote/kernel/lang/ScalaSparkInterpreterSpec.scala
+++ b/polynote-spark/src/test/scala/polynote/kernel/lang/ScalaSparkInterpreterSpec.scala
@@ -95,7 +95,10 @@ class ScalaSparkInterpreterSpec extends FlatSpec with Matchers with SparkKernelS
 
   it should "work with class defs" in {
     val code = Seq(
-      "case class Foo(i: Int)",
+      """
+        |case class Foo(i: Int)
+        |val fooInstance = Foo(1)
+        |""".stripMargin,
       """class Bar(j: Int) {
         |  def i: Int = j
         |}
@@ -118,7 +121,7 @@ class ScalaSparkInterpreterSpec extends FlatSpec with Matchers with SparkKernelS
         |""".stripMargin,
       "object Bop { val i = Foo(4).i + 1 }",
       """
-        |val foo = Foo(1).i
+        |val foo = Foo(0).i + fooInstance.i
         |val bar = new Bar(2).i
         |val baz = new BazImpl(3).i
         |val quux = new QuuxImpl()

--- a/polynote-spark/src/test/scala/polynote/server/NotebookRunningSpec.scala
+++ b/polynote-spark/src/test/scala/polynote/server/NotebookRunningSpec.scala
@@ -27,7 +27,7 @@ class NotebookRunningSpec extends FreeSpec with Matchers  {
     new IONotebookManager(config, repository, SparkServer.kernelFactory)
   }
 
-  "test.ipynb should run prooperly" in {
+  "test.ipynb should run properly" in {
     val path = "test.ipynb"
     val run = for {
       sharedNB <- nbManager.getNotebook(path)
@@ -50,14 +50,14 @@ class NotebookRunningSpec extends FreeSpec with Matchers  {
       1 -> List(ResultValue("Out","Int",List(StringRepr("2"), DataRepr(IntType,null)),1.toShort,2,null,Some((0,0)))),
       2 -> List(Output("text/plain; rel=stdout","three\n")),
       3 -> List(Output("text/html","<strong>HTML!</strong>")),
-      4 -> List(ResultValue("x","Int",List(StringRepr("2"), DataRepr(IntType,null)),4.toShort,2,null,Some((4,4)))),
+      4 -> List(ResultValue("x","Int",List(StringRepr("2"), DataRepr(IntType,null)),4.toShort,2,null,Some((0,0)))),
       5 -> List(ResultValue("y","String",List(StringRepr("hi!"), DataRepr(StringType,null)),5.toShort,"hi!",null,None)),
       6 -> List(
         ResultValue("y","String",List(StringRepr("bye"), DataRepr(StringType,null)),6.toShort,"bye",null,None),
         ResultValue("x","Long",List(StringRepr("3"), DataRepr(LongType,null)),6.toShort,3,null,None),
         ResultValue("z","List[Long]",List(StringRepr("List(1, 2, 3, 4)"), StreamingDataRepr(0,LongType,Some(4))),6.toShort,List(1, 2, 3, 4),null,None)
       ),
-      7 -> List(ResultValue("Out","List[Int]",List(StringRepr("List(2, 3, 4, 5)"), StreamingDataRepr(0,IntType,Some(4))),7.toShort,List(2, 3, 4, 5),null,Some((68,68))))
+      7 -> List(ResultValue("Out","List[Int]",List(StringRepr("List(2, 3, 4, 5)"), StreamingDataRepr(0,IntType,Some(4))),7.toShort,List(2, 3, 4, 5),null,Some((0,0))))
     )
 
     cellResults.size shouldEqual expectedCellResults.size

--- a/polynote-spark/src/test/scala/polynote/server/NotebookRunningSpec.scala
+++ b/polynote-spark/src/test/scala/polynote/server/NotebookRunningSpec.scala
@@ -50,14 +50,14 @@ class NotebookRunningSpec extends FreeSpec with Matchers  {
       1 -> List(ResultValue("Out","Int",List(StringRepr("2"), DataRepr(IntType,null)),1.toShort,2,null,Some((0,0)))),
       2 -> List(Output("text/plain; rel=stdout","three\n")),
       3 -> List(Output("text/html","<strong>HTML!</strong>")),
-      4 -> List(ResultValue("x","Int",List(StringRepr("2"), DataRepr(IntType,null)),4.toShort,2,null,Some((0,0)))),
+      4 -> List(ResultValue("x","Int",List(StringRepr("2"), DataRepr(IntType,null)),4.toShort,2,null,Some((4,4)))),
       5 -> List(ResultValue("y","String",List(StringRepr("hi!"), DataRepr(StringType,null)),5.toShort,"hi!",null,None)),
       6 -> List(
         ResultValue("y","String",List(StringRepr("bye"), DataRepr(StringType,null)),6.toShort,"bye",null,None),
         ResultValue("x","Long",List(StringRepr("3"), DataRepr(LongType,null)),6.toShort,3,null,None),
         ResultValue("z","List[Long]",List(StringRepr("List(1, 2, 3, 4)"), StreamingDataRepr(0,LongType,Some(4))),6.toShort,List(1, 2, 3, 4),null,None)
       ),
-      7 -> List(ResultValue("Out","List[Int]",List(StringRepr("List(2, 3, 4, 5)"), StreamingDataRepr(0,IntType,Some(4))),7.toShort,List(2, 3, 4, 5),null,Some((0,0))))
+      7 -> List(ResultValue("Out","List[Int]",List(StringRepr("List(2, 3, 4, 5)"), StreamingDataRepr(0,IntType,Some(4))),7.toShort,List(2, 3, 4, 5),null,Some((68,68))))
     )
 
     cellResults.size shouldEqual expectedCellResults.size


### PR DESCRIPTION
Do a lot more manglin' of the cell code in order to: 

* Lift up classes, traits, etc. to the package namespace (no inner classes, yay!) (note: this means classes must be pure - no closing over the world in your classes)
* Only import necessary values from previous cells (rather than everything in it). Additionally, imports are replaced with proxy values when possible. 

These changes should reduce the chance that an entire cell is closed over when something defined in it is referenced in another cell. 

Hopefully all this will help fight some of the annoying spark serialization issues people have run into. 

Completions seem like they're working ok. Position info might be a little off for lifted trees and for ResultValues. 