### PR TITLE
[#333] fix wide output overflow

### DIFF
--- a/polynote-frontend/polynote/cell.js
+++ b/polynote-frontend/polynote/cell.js
@@ -121,8 +121,11 @@ export class Cell extends UIEventTarget {
             ]),
             this.cellOutput = div(['cell-output'], [
                 div(['cell-output-margin'], []),
-                div(['cell-output-container'], [
-                    this.cellOutputDisplay = div(['cell-output-display'], []),
+                // unfortunately we need this extra div for perf reasons (has to be a block)
+                div(['cell-output-block'], [
+                    div(['cell-output-container'], [
+                        this.cellOutputDisplay = div(['cell-output-display'], []),
+                    ])
                 ]),
                 // TODO: maybe a progress bar here?
                 this.cellResultMargin = div(['cell-result-margin']),

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -1216,9 +1216,13 @@ body {
       border-right: 1px solid @ui-border;
     }
 
-    .cell-output-container {
+    .cell-output-block {
       grid-area: output;
-      display: block;
+      display: block; // must be block for performance reasons.
+    }
+
+    .cell-output-container {
+      display: grid;
     }
 
     .errors, .output {


### PR DESCRIPTION
For some reason, setting `cell-output-container` to `display: block`
fixed the pane resize performance issue. However, it broke overflow.

The solution is to add another pane to hold `cell-output-container`.
This pane will be `display: block` so `cell-output-container` can
stay `display: grid` and thus overflow properly.

This is slightly less performant (still much better than without the
outer div) but hopefully good enough.