### PR TITLE
don't run server with spark-submit if using remote kernels

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,7 +129,9 @@ lazy val `polynote-spark` = project.settings(
     Seq(
       copyRuntimeJar((resourceManaged in Compile).value, "polynote-runtime.jar", (packageBin in (`polynote-runtime`, Compile)).value),
       copyRuntimeJar((resourceManaged in Compile).value, "polynote-spark-runtime.jar", (packageBin in (`polynote-spark-runtime`, Compile)).value),
-      copyRuntimeJar((resourceManaged in Compile).value, "scala-library.jar", (dependencyClasspath in Compile).value.files.find(_.getName.contains("scala-library")).get) // sneak scala-lang jar into the assembly
+      // sneak these scala dependency jars into the assembly so we have them if we need them (but they won't conflict with environment-provided jars)
+      copyRuntimeJar((resourceManaged in Compile).value, "scala-library.jar", (dependencyClasspath in Compile).value.files.find(_.getName.contains("scala-library")).get), 
+      copyRuntimeJar((resourceManaged in Compile).value, "scala-reflect.jar", (dependencyClasspath in Compile).value.files.find(_.getName.contains("scala-reflect")).get)
     )
   }.taskValue,
   fork in Test := true,

--- a/polynote-spark/src/main/scala/polynote/kernel/util/PlainServerCommand.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/util/PlainServerCommand.scala
@@ -1,0 +1,23 @@
+package polynote.kernel.util
+
+import java.nio.file.{Path, Paths}
+
+object PlainServerCommand {
+
+  def apply(
+    sparkConfig: Map[String, String],
+    mainClass: String = "polynote.server.SparkServer"
+  ): Seq[String] = {
+
+    val allDriverOptions =
+      sparkConfig.get("spark.driver.extraJavaOptions").toList :+ "-Dlog4j.configuration=log4j.properties"
+
+    val javaCommand = sys.props.get("java.home").map { sysJava =>
+      Paths.get(sysJava, "bin", "java").toString
+    }.getOrElse("java")
+
+    val cp = sys.props.get("java.class.path").toList.flatMap(Seq("-cp", _))
+
+    Seq(javaCommand) ++ allDriverOptions ++ cp :+ mainClass
+  }
+}


### PR DESCRIPTION
If we're using remote kernels it doesn't make sense for Polynote to launch itself under Spark Submit. 

Not too happy with the whole `--printCommand` approach but at least it means we don't need the run script to parse the config file.