### PR TITLE
Move cell controls

### DIFF
--- a/polynote-frontend/polynote/cell.js
+++ b/polynote-frontend/polynote/cell.js
@@ -9,7 +9,7 @@ import {details, dropdown} from "./tags";
 import {ClientResult, ExecutionInfo} from "./result";
 import {prefs} from "./prefs";
 import {createVim} from "./vim";
-import {DeleteCell} from "./messages";
+import {CellMetadata, DeleteCell} from "./messages";
 import {KeyPress} from "./keypress";
 import {clientInterpreters} from "./client_interpreter";
 import {valueInspector} from "./value_inspector";
@@ -46,12 +46,11 @@ export class BeforeCellRunEvent extends CellEvent {
 }
 
 export class ContentChangeEvent extends CellEvent {
-    constructor(cellId, edits, newContent) {
-        super('ContentChange', cellId, {edits: edits, newContent: newContent});
+    constructor(cellId, edits, metadata) {
+        super('ContentChange', cellId, {edits: edits, metadata: metadata || null });
     }
 
     get edits() { return this.detail.edits }
-    get newContent() { return this.detail.newContent }
 }
 
 export class AdvanceCellEvent extends CellEvent {
@@ -256,6 +255,10 @@ export class Cell extends UIEventTarget {
         throw "applyEdits not implemented for this cell type";
     }
 
+    setMetadata(metadata) {
+        this.metadata = metadata;
+    }
+
     updateKeyHandler(key, handler) {
         const prevHandler = this.keyMap.get(key);
         this.keyMap.set(key, handler(prevHandler));
@@ -359,14 +362,24 @@ export class CodeCell extends Cell {
 
         this.cellInputTools.appendChild(
             div(['options'], [
-                button(['toggle-code'], {title: 'Show/Hide Code'}, ['{}']),
-                iconButton(['toggle-output'], 'Show/Hide Output', '', 'Show/Hide Output')
+                button(['toggle-code'], {title: 'Show/Hide Code'}, ['{}']).click(evt => this.toggleCode()),
+                iconButton(['toggle-output'], 'Show/Hide Output', '', 'Show/Hide Output').click(evt => this.toggleOutput())
             ])
         );
 
+        if (metadata) {
+            if (metadata.hideOutput) {
+                this.container.classList.add('hide-output');
+            }
+
+            if (metadata.hideSource) {
+                this.container.classList.add('hide-code');
+            }
+        }
+
         const highlightLanguage = (clientInterpreters[language] && clientInterpreters[language].highlightLanguage) || language;
         this.highlightLanguage = highlightLanguage;
-        this.contentWidgets = {};
+
 
         // set up editor and content
         this.editor = monaco.editor.create(this.editorEl, {
@@ -411,7 +424,11 @@ export class CodeCell extends Cell {
 
         });
 
-        this.lastLineCount = this.editor.getModel().getLineCount();
+        this.editor.getContribution('editor.contrib.folding').getFoldingModel().then(
+            foldingModel => foldingModel.onDidChange(() => this.updateEditorHeight())
+        );
+
+        this.lastLineTop = this.editor.getTopForLineNumber(this.editor.getModel().getLineCount());
         this.lineHeight = this.editor.getConfiguration().lineHeight;
 
         this.editListener = this.editor.onDidChangeModelContent(event => this.onChangeModelContent(event));
@@ -462,6 +479,37 @@ export class CodeCell extends Cell {
         }
     }
 
+    setMetadata(metadata) {
+        const prevMetadata = this.metadata;
+        super.setMetadata(metadata);
+        if (metadata.hideSource) {
+            this.container.classList.add('hide-code');
+        } else if (prevMetadata.hideSource) {
+            this.container.classList.remove('hide-code');
+            this.updateEditorHeight();
+            this.editor.layout();
+        }
+
+        if (metadata.hideOutput) {
+            this.container.classList.add('hide-output');
+        } else {
+            this.container.classList.remove('hide-output');
+        }
+    }
+
+    toggleCode() {
+        const prevMetadata = this.metadata || new CellMetadata();
+        this.setMetadata(prevMetadata.copy({hideSource: !prevMetadata.hideSource}));
+        this.dispatchEvent(new ContentChangeEvent(this.id, [], this.metadata));
+    }
+
+    toggleOutput() {
+        this.container.classList.toggle('hide-output');
+        const prevMetadata = this.metadata || new CellMetadata();
+        this.setMetadata(prevMetadata.copy({hideOutput: !prevMetadata.hideOutput}));
+        this.dispatchEvent(new ContentChangeEvent(this.id, [], this.metadata));
+    }
+
     onChangeModelContent(event) {
         this.updateEditorHeight();
         if (this.applyingServerEdits)
@@ -479,14 +527,16 @@ export class CodeCell extends Cell {
                 return [new messages.Insert(contentChange.rangeOffset, contentChange.text)];
             } else return [];
         });
-        this.dispatchEvent(new ContentChangeEvent(this.id, edits, this.editor.getValue()));
+        this.dispatchEvent(new ContentChangeEvent(this.id, edits));
     }
 
     updateEditorHeight() {
+        this.editor.getModel().get
         const lineCount = this.editor.getModel().getLineCount();
-        if (lineCount !== this.lastLineCount) {
-            this.lastLineCount = lineCount;
-            this.editorEl.style.height = (this.lineHeight * lineCount) + "px";
+        const lastPos = this.editor.getTopForLineNumber(lineCount);
+        if (lastPos !== this.lastLineTop) {
+            this.lastLineTop = lastPos;
+            this.editorEl.style.height = (lastPos + this.lineHeight) + "px";
             this.editor.layout();
         }
     }
@@ -1066,7 +1116,7 @@ export class TextCell extends Cell {
 
         if (edits.length > 0) {
             //console.log(edits);
-            this.dispatchEvent(new ContentChangeEvent(this.id, edits, newContent));
+            this.dispatchEvent(new ContentChangeEvent(this.id, edits));
         }
     }
 

--- a/polynote-frontend/polynote/main.js
+++ b/polynote-frontend/polynote/main.js
@@ -6,6 +6,7 @@ import { MainUI } from './ui.js'
 import { scala, vega } from './languages.js'
 import { theme } from './theme.js'
 import * as monaco from "monaco-editor";
+import {prefs} from "./prefs";
 
 const md = require('markdown-it');
 
@@ -270,6 +271,10 @@ const socket = new SocketSession();
 const mainUI = new MainUI(socket);
 document.getElementById('Main').appendChild(mainUI.el);
 const path = unescape(window.location.pathname);
+
+if (prefs.get('VIM')) {
+    document.body.classList.add('vim-enabled');
+}
 
 if (path.startsWith('/notebook/')) {
   mainUI.loadNotebook(path.replace(/^\/notebook\//, ''));

--- a/polynote-frontend/polynote/messages.js
+++ b/polynote-frontend/polynote/messages.js
@@ -85,11 +85,19 @@ export class CellMetadata {
     }
 
     constructor(disableRun, hideSource, hideOutput, executionInfo) {
-        this.disableRun = disableRun;
-        this.hideSource = hideSource;
-        this.hideOutput = hideOutput;
-        this.executionInfo = executionInfo;
+        this.disableRun = disableRun || false;
+        this.hideSource = hideSource || false;
+        this.hideOutput = hideOutput || false;
+        this.executionInfo = executionInfo || null;
         Object.freeze(this);
+    }
+
+    copy(props) {
+        const disableRun = typeof props.disableRun !== 'undefined' ? props.disableRun : this.disableRun;
+        const hideSource = typeof props.hideSource !== 'undefined' ? props.hideSource : this.hideSource;
+        const hideOutput = typeof props.hideOutput !== 'undefined' ? props.hideOutput : this.hideOutput;
+        const executionInfo = typeof props.executionInfo !== 'undefined' ? props.executionInfo : this.executionInfo;
+        return new CellMetadata(disableRun, hideSource, hideOutput, executionInfo);
     }
 }
 
@@ -410,21 +418,22 @@ export class UpdateCell extends NotebookUpdate {
     static get msgTypeId() { return 5; }
 
     static unapply(inst) {
-        return [inst.path, inst.globalVersion, inst.localVersion, inst.id, inst.edits];
+        return [inst.path, inst.globalVersion, inst.localVersion, inst.id, inst.edits, inst.metadata];
     }
 
-    constructor(path, globalVersion, localVersion, id, edits) {
+    constructor(path, globalVersion, localVersion, id, edits, metadata) {
         super(path, globalVersion, localVersion, id, edits);
         this.path = path;
         this.globalVersion = globalVersion;
         this.localVersion = localVersion;
         this.id = id;
         this.edits = edits;
+        this.metadata = metadata;
         Object.freeze(this);
     }
 }
 
-UpdateCell.codec = combined(shortStr, uint32, uint32, int16, arrayCodec(uint16, ContentEdit.codec)).to(UpdateCell);
+UpdateCell.codec = combined(shortStr, uint32, uint32, int16, arrayCodec(uint16, ContentEdit.codec), optional(CellMetadata.codec)).to(UpdateCell);
 
 export class InsertCell extends NotebookUpdate {
     static get msgTypeId() { return 6; }

--- a/polynote-frontend/polynote/tags.js
+++ b/polynote-frontend/polynote/tags.js
@@ -132,7 +132,15 @@ export function dropdown(classes, options) {
         }
     }
 
-    return tag('select', classes, {}, opts);
+    const select = tag('select', classes, {}, opts);
+    select.setSelectedValue = (value) => {
+        const index = opts.findIndex(opt => opt.value === value);
+        if (index !== -1) {
+            select.selectedIndex = index;
+        }
+    };
+    select.getSelectedValue = () => select.options[select.selectedIndex].value;
+    return select;
 }
 
 // create element that goes into a FakeSelect (but not the FakeSelect itself)

--- a/polynote-frontend/polynote/theme.js
+++ b/polynote-frontend/polynote/theme.js
@@ -7,7 +7,7 @@ export const theme = {
     { token: 'number', foreground: '0000FF' }
   ],
   colors: {
-    'editor.lineHighlightBackground': '#f3f3f3',
+    'editor.lineHighlightBackground': '#FFFAE3',
     'editor.lineHighlightBorder': '#00000000',
     'editorOverviewRuler.border': "#00000000"
   }

--- a/polynote-frontend/polynote/ui.js
+++ b/polynote-frontend/polynote/ui.js
@@ -1238,7 +1238,7 @@ export class NotebookUI extends UIEventTarget {
         });
 
         this.cellUI.addEventListener('ContentChange', (evt) => {
-            const update = new messages.UpdateCell(path, this.globalVersion, ++this.localVersion, evt.detail.cellId, evt.detail.edits);
+            const update = new messages.UpdateCell(path, this.globalVersion, ++this.localVersion, evt.detail.cellId, evt.detail.edits, evt.detail.metadata || null);
             this.socket.send(update);
             this.editBuffer.push(this.localVersion, update);
         });
@@ -1392,11 +1392,14 @@ export class NotebookUI extends UIEventTarget {
                     this.localVersion++;
 
                     match(update)
-                        .when(messages.UpdateCell, (p, g, l, id, edits) => {
+                        .when(messages.UpdateCell, (p, g, l, id, edits, metadata) => {
                             const cell = this.cellUI.getCell(id);
                             if (cell) {
                                 cell.applyEdits(edits);
                                 this.editBuffer.push(this.localVersion, messages);
+                                if (metadata) {
+                                    cell.setMetadata(metadata);
+                                }
                             }
                         })
                         .when(messages.InsertCell, (p, g, l, cell, after) => {

--- a/polynote-frontend/polynote/ui.js
+++ b/polynote-frontend/polynote/ui.js
@@ -32,8 +32,9 @@ export class MainToolbar extends EventTarget {
     }
 }
 
-export class KernelSymbolsUI {
+export class KernelSymbolsUI extends UIEventTarget {
     constructor(path) {
+        super();
         this.symbols = {};
         this.presentedCell = 0;
         this.visibleCells = [];
@@ -421,7 +422,7 @@ export class KernelUI extends UIEventTarget {
     constructor(socket, path) {
         super();
         this.info = new KernelInfoUI();
-        this.symbols = new KernelSymbolsUI(path);
+        this.symbols = new KernelSymbolsUI(path).setEventParent(this);
         this.tasks = new KernelTasksUI();
         this.socket = socket;
         this.path = path;
@@ -1062,6 +1063,8 @@ export class NotebookUI extends UIEventTarget {
 
         this.editBuffer = new EditBuffer();
 
+        this.addEventListener('SetCellLanguage', evt => this.onCellLanguageSelected(evt.detail.language, this.path, evt.detail.cellId));
+
         this.cellUI.addEventListener('UpdatedConfig', evt => {
             const update = new messages.UpdateConfig(path, this.globalVersion, ++this.localVersion, evt.detail.config);
             this.editBuffer.push(this.localVersion, update);
@@ -1124,7 +1127,7 @@ export class NotebookUI extends UIEventTarget {
             }
         });
 
-        this.cellUI.addEventListener('InsertCellAfter', evt => {
+        this.addEventListener('InsertCellAfter', evt => {
            const current = this.cellUI.getCell(evt.detail.cellId) || this.cellUI.getCell(this.cellUI.firstCell().id);
            const nextId = maxId(this.cellUI.getCells()) + 1;
            let newCell = evt.detail.mkCell;
@@ -1566,12 +1569,20 @@ export class NotebookUI extends UIEventTarget {
         this.socket.send(new messages.RunCell(this.path, serverRunCells));
     }
 
-    onCellLanguageSelected(setLanguage, path) {
-        if (Cell.currentFocus && this.cellUI.getCell(Cell.currentFocus.id) && this.cellUI.getCell(Cell.currentFocus.id).language !== setLanguage) {
-            const id = Cell.currentFocus.id;
-            this.cellUI.setCellLanguage(Cell.currentFocus, setLanguage);
-            this.socket.send(new messages.SetCellLanguage(path, this.globalVersion, this.localVersion++, id, setLanguage));
+    onCellLanguageSelected(setLanguage, path, id) {
+        if (path !== this.path) {
+            return;
         }
+
+        id = id || Cell.currentFocus.id;
+        if (id) {
+            const cell = this.cellUI.getCell(id);
+            if (cell.language !== setLanguage) {
+                this.cellUI.setCellLanguage(cell, setLanguage);
+                this.socket.send(new messages.SetCellLanguage(path, this.globalVersion, this.localVersion++, id, setLanguage));
+            }
+        }
+
     }
     
     onCellsLoaded(path, cells, config) {
@@ -1959,6 +1970,8 @@ export class WelcomeUI extends UIEventTarget {
     }
 }
 
+export const Interpreters = {};
+
 export class MainUI extends EventTarget {
     constructor(socket) {
         super();
@@ -1991,14 +2004,14 @@ export class MainUI extends EventTarget {
         socket.send(new messages.ListNotebooks([]));
 
         socket.listenOnceFor(messages.ServerHandshake, (interpreters) => {
-            const allInterpreters = {};
             for (let interp of Object.keys(interpreters)) {
-                allInterpreters[interp] = interpreters[interp];
+                Interpreters[interp] = interpreters[interp];
             }
             for (let interp of Object.keys(clientInterpreters)) {
-                allInterpreters[interp] = clientInterpreters[interp].languageTitle;
+                Interpreters[interp] = clientInterpreters[interp].languageTitle;
             }
-            this.toolbarUI.cellToolbar.setInterpreters(allInterpreters);
+
+            this.toolbarUI.cellToolbar.setInterpreters(Interpreters);
         });
 
         window.addEventListener('popstate', evt => {
@@ -2029,7 +2042,7 @@ export class MainUI extends EventTarget {
                 this.currentNotebook = this.tabUI.getTab(tab.name).content.notebook.cellsUI;
                 this.currentNotebook.notebookUI.cellUI.forceLayout(evt)
             } else if (tab.type === 'home') {
-                const title = 'Polynote'
+                const title = 'Polynote';
                 window.history.pushState({notebook: tab.name}, title, '/');
                 document.title = title
             }
@@ -2150,8 +2163,10 @@ export class MainUI extends EventTarget {
             const currentVim = prefs.get('VIM');
             if (currentVim) {
                 prefs.set('VIM', false);
+                document.body.classList.remove('vim-enabled');
             } else {
                 prefs.set('VIM', true);
+                document.body.classList.add('vim-enabled');
             }
 
             this.toolbarUI.settingsToolbar.colorVim();

--- a/polynote-frontend/polynote/ui_event.js
+++ b/polynote-frontend/polynote/ui_event.js
@@ -39,6 +39,10 @@ export class UIEventTarget extends EventTarget {
         event.originalTarget = event.originalTarget || this;
         super.dispatchEvent(event);
         if(this.eventParent && !event.propagationStopped) {
+            if (!this.eventParent.dispatchEvent) {
+                console.log('Event parent is not an event target!', this.eventParent);
+                return;
+            }
             this.eventParent.dispatchEvent(event.copy());
         }
     }

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -382,7 +382,6 @@ body {
         grid-area: options;
         text-align: left;
         padding-left: 1em;
-        display: none;
 
         .toggle-code {
           font-weight: 900;
@@ -476,6 +475,28 @@ body {
 
   &.python .cell-input .cell-input-tools button.run-cell {
     background-image: url(icons/python.png);
+  }
+
+  &.hide-code .cell-input {
+    .cell-input-editor {
+      display: none;
+    }
+
+    .toggle-code {
+      border: 1px solid @ui-border;
+      background-color: white;
+    }
+  }
+
+  &.hide-output .cell-output {
+    .cell-output-block {
+      display: none;
+    }
+
+    .toggle-output {
+      border: 1px solid @ui-border;
+      background-color: white;
+    }
   }
 
   &.text-cell {

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -304,10 +304,6 @@ body {
   border-left-width: @cell-left-border-width;
   position: relative;
 
-  display: grid;
-  grid-template-areas: "input"
-                       "output";
-
   &.selected, &.active {
     border-radius: 6px;
     border: 1px solid @ui-selected;
@@ -332,28 +328,24 @@ body {
 
     grid-area: input;
 
-    display: grid;
-    grid-template-areas: "tools content"
-                         "tools footer";
-    grid-template-columns: @cell-margin-width auto;
 
     .cell-input-tools {
       background: @ui-background;
       box-sizing: border-box;
-      grid-area: tools;
-
       display: grid;
-      grid-template-areas: "button label"
-                           ". .";
-      grid-template-columns: auto auto;
+      font-size: 11pt;
+      grid-template-areas: "button label lang options exec-info";
+      grid-template-columns: min-content 9ch min-content 2fr 1fr;
       grid-template-rows: min-content;
       border-right: 1px solid @ui-border;
+      border-bottom: 1px solid @ui-border;
 
       button {
-        display: block;
         line-height: 1;
-        background-size: 20px 20px;
-        font-size: 24px;
+        background-size: 12px 12px;
+        background-position: 90% 90%;
+        font-size: inherit;
+        padding: .5em 1ch;
       }
 
       .run-cell {
@@ -367,72 +359,88 @@ body {
 
       .cell-label {
         font-family: @code-fonts;
-        text-align: right;
-        font-size: 11pt;
-        grid-column: label;
-        padding: 0.5em;
+        text-align: left;
+        font-size: inherit;
+        grid-area: label;
+        padding: .5em 1ch;
 
+        &:before {
+          content: 'In(';
+        }
         &:after {
-          content: ':';
+          content: '):';
+        }
+      }
+
+      .lang-selector {
+        grid-area: lang;
+        display: flex;
+        align-items: center;
+      }
+
+      .options {
+        grid-area: options;
+        text-align: left;
+        padding-left: 1em;
+        display: none;
+
+        .toggle-code {
+          font-weight: 900;
+          font-family: @code-fonts;
+          padding: .5em;
+        }
+      }
+
+      .exec-info {
+        text-align: right;
+        font-style: italic;
+        font-size: 8pt;
+        color: #808080;
+        padding: 5.5pt;
+        line-height: 11pt;
+        display: none;
+        grid-area: exec-info;
+
+        &.output {
+          display: block;
+        }
+
+        .exec-start::before {
+          content: "Ran on ";
+        }
+        .exec-start::after {
+          content: " took ";
+        }
+
+        &.running {
+          .exec-start::before {
+            content: "Started at ";
+          }
+          .exec-start::after {
+            content: " running for ";
+          }
         }
       }
     }
 
     .cell-input-editor {
-      border-bottom: 1px dashed @ui-border;
-
       padding: 3pt;
-      min-height: 3em;
       overflow: hidden;
-      grid-area: content;
     }
 
     .cell-footer {
-      display: grid;
+      display: none;
       grid-template-columns: [vim] auto [exec-info] max-content;
       grid-template-rows: auto;
-      grid-area: footer;
       padding: 2px 4px 2px 4px;
       line-height: 1.5;
       font-size: 11pt;
-      min-height: 1.5em; // remove jumpiness due to vim statusbar
-
-    }
-
-    .exec-info {
-      text-align: right;
-      font-style: italic;
-      font-size: 0.8em;
-      color: #808080;
-      padding: 4px;
-      display: none;
-      grid-area: exec-info;
-
-      &.output {
-        display: block;
-      }
-
-      .exec-start::before {
-        content: "Ran on ";
-      }
-      .exec-start::after {
-        content: " took ";
-      }
-
-      &.running {
-        .exec-start::before {
-          content: "Started at ";
-        }
-        .exec-start::after {
-          content: " running for ";
-        }
-      }
+      border-top: 1px dashed @ui-border;
     }
 
     .vim-status {
       white-space: pre;
       font-family: 'Hasklig', 'Fira Code', 'Menlo', fixed;
-      grid-area: vim;
 
       &.hide {
         display: none !important;
@@ -440,20 +448,22 @@ body {
     }
   }
 
+  &.code-cell:hover .cell-input-tools .options {
+    display: block;
+  }
+
   &.code-cell .exec-info {
     display: block;
   }
 
   &.code-cell .cell-input {
-    border-left: 1px solid @ui-border-light;
-    border-right: 1px solid @ui-border-light;
-    border-top: 1px solid @ui-border-light;
+    border-left: 1px solid @ui-border;
+    border-right: 1px solid @ui-border;
+    border-top: 1px solid @ui-border;
   }
 
   &.code-cell .cell-output {
-    border-left: 1px solid @ui-border-light;
-    border-right: 1px solid @ui-border-light;
-    border-bottom: 1px solid @ui-border-light;
+    border: 1px solid @ui-border;
   }
 
   &.code-cell .cell-input .cell-input-editor {
@@ -479,7 +489,7 @@ body {
       }
 
       .cell-input-tools {
-        display: block;
+        display: none;
         * {
           display: none;
         }
@@ -517,7 +527,6 @@ body {
       color: #24292e;
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
       font-size: 16px;
-      line-height: 1.5;
       word-wrap: break-word;
       border-left: 1px solid transparent;
       outline: none;
@@ -1208,23 +1217,15 @@ body {
   .cell-output {
     grid-area: output;
 
-    display: grid;
-    grid-template-areas: "margin output"
-                         "results-margin results";
-    grid-template-columns: @cell-margin-width auto;
-
     .cell-output-margin {
       background: @ui-background;
-      border-right: 1px solid @ui-border;
     }
 
     .cell-output-block {
-      grid-area: output;
       display: block; // must be block for performance reasons.
     }
 
     .cell-output-container {
-      display: grid;
     }
 
     .errors, .output {
@@ -1281,12 +1282,10 @@ body {
 
     .cell-result-margin {
       background: @ui-background;
-      border-right: 1px solid @ui-border;
     }
 
     .cell-output-tools {
       display: none;
-      padding: 0.1em;
       position: relative;
       min-height: @tab-view-height;
       overflow: auto;
@@ -1306,13 +1305,19 @@ body {
         padding-left: 2em;
       }
 
+      .output {
+        padding: 1em 2em;
+      }
+
     }
 
     .out-ident {
       color: #D84315;
       font-family: @code-fonts;
       font-size: 11pt;
-      text-align: right;
+      border-bottom: 1px solid @ui-border;
+      padding: .25em 0 .25em 32pt;
+      position: relative;
     }
 
     .cell-output-display {
@@ -1320,7 +1325,6 @@ body {
       padding-top: 0.5em;
       padding-bottom: 0.5em;
       margin-bottom: 1em;
-      border-bottom: 1px dashed @ui-border;
       overflow: auto;
       resize: vertical;
       position: relative;
@@ -1385,6 +1389,10 @@ body {
   }
 }
 
+.vim-enabled .cell-container.code-cell .cell-input .cell-footer {
+  display: grid;
+  height: 1.5em;
+}
 
 button {
 
@@ -1427,6 +1435,8 @@ button.inspect.icon-button {
   padding: 0;
   background: transparent !important;
   border: none !important;
+  position: absolute;
+  left: 14pt;
 }
 
 .monaco-editor button.inspect.icon-button {

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -335,9 +335,8 @@ body {
       display: grid;
       font-size: 11pt;
       grid-template-areas: "button label lang options exec-info";
-      grid-template-columns: min-content 9ch min-content 2fr 1fr;
+      grid-template-columns: min-content 10ch min-content 2fr 1fr;
       grid-template-rows: min-content;
-      border-right: 1px solid @ui-border;
       border-bottom: 1px solid @ui-border;
 
       button {
@@ -531,7 +530,7 @@ body {
 
     .cell-input-editor {
       margin: 0;
-      padding: 1.5em;
+      padding: 12pt 24pt;
       border: none;
       min-height: 1em;
     }
@@ -1453,7 +1452,7 @@ button {
 }
 
 button.inspect.icon-button {
-  padding: 0;
+  padding: 1pt 0 0;
   background: transparent !important;
   border: none !important;
   position: absolute;
@@ -2198,6 +2197,7 @@ button {
 
 .notebook-cells {
   position: relative;
+  padding: 12pt;
 }
 
 .latex-editor {

--- a/polynote-spark/src/test/scala/polynote/kernel/remote/RemoteSparkKernelSpec.scala
+++ b/polynote-spark/src/test/scala/polynote/kernel/remote/RemoteSparkKernelSpec.scala
@@ -146,7 +146,7 @@ class RemoteSparkKernelSpec extends FreeSpec with Matchers {
           ready           <- subscriber.init().start
           runRemoteClient <- remoteClient.run().start
           _               <- ready.join
-          update = UpdateCell(path, 0, 0, 0.toShort, ContentEdits(Insert(2, "insert")))
+          update = UpdateCell(path, 0, 0, 0.toShort, ContentEdits(Insert(2, "insert")), None)
           _               <- subscriber.update(update)
           _ = kernelFactory.kernel.currentNotebook shouldEqual update.applyTo(initialNotebook)
           _ <- sharedNotebook.shutdown()


### PR DESCRIPTION
- Move cell controls to the top of the cell rather than the margin
- Add a per-cell dropdown for cell language
- Add show/hide buttons for code and output (these persist)
- Update cell height after code folding/unfolding (folding state does not persist)

Fixes #236 and #320 