### PR TITLE
Python dep support!

### DIFF
--- a/config-template.yml
+++ b/config-template.yml
@@ -3,9 +3,11 @@
 #  host: 0.0.0.0
 #  port: 8192
 
-# The location Polynote looks for your notebooks in
 #storage:
+#  # The location Polynote looks for your notebooks in
 #  dir: notebooks
+#  # The location Polynote puts various caches, such as virtual environments created for your notebooks.
+#  cache: tmp
 
 # Default repositories can be specified. Uncommenting the following lines would add four default repositories which are inherited by new notebooks.
 #repositories:
@@ -22,11 +24,14 @@
 #      base: http://oss.sonatype.org/content/repositories/snapshots
 #      changing: true
 
-# Default dependencies can be specified. Uncommenting the following lines would add default dependencies for the Scala interpreter, which are inherited by new notebooks.
+# Default dependencies can be specified. Uncommenting the following lines would add some default dependencies which are inherited by new notebooks.
 #dependencies:
 #  scala:
 #    - org.typelevel:cats-core_2.11:1.6.0
 #    - com.mycompany:my-library:jar:all:1.0.0
+#  python:
+#    - requests
+#    - urllib3==1.25.3
 
 #exclusions:
 #  - com.google.guava:guava  # spark, update your guava already!!!

--- a/polynote-frontend/polynote/messages.js
+++ b/polynote-frontend/polynote/messages.js
@@ -120,9 +120,7 @@ export class NotebookCell {
 
 NotebookCell.codec = combined(int16, tinyStr, str, arrayCodec(int16, Result.codec), CellMetadata.codec).to(NotebookCell);
 
-export class RepositoryConfig {
-
-}
+export class RepositoryConfig {}
 
 export class IvyRepository extends RepositoryConfig {
     static unapply(inst) {
@@ -159,9 +157,25 @@ export class MavenRepository extends RepositoryConfig {
 
 MavenRepository.codec = combined(str, optional(bool)).to(MavenRepository);
 
+export class PipRepository extends RepositoryConfig {
+    static unapply(inst) {
+        return [inst.url];
+    }
+
+    static get msgTypeId() { return 2; }
+
+    constructor(url) {
+        super();
+        this.url = url;
+    }
+}
+
+PipRepository.codec = combined(str).to(PipRepository);
+
 RepositoryConfig.codecs = [
-    IvyRepository,  // 0
-    MavenRepository // 1
+    IvyRepository,   // 0
+    MavenRepository, // 1
+    PipRepository    // 2
 ];
 
 RepositoryConfig.codec = discriminated(

--- a/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
@@ -18,7 +18,7 @@ object Listen {
   implicit val decoder: Decoder[Listen] = deriveDecoder
 }
 
-final case class Storage(dir: String = "notebooks")
+final case class Storage(dir: String = "notebooks", cache: String = "tmp")
 
 object Storage {
   implicit val encoder: ObjectEncoder[Storage] = deriveEncoder

--- a/polynote-kernel/src/main/scala/polynote/config/package.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/package.scala
@@ -12,6 +12,7 @@ import cats.instances.list._
 import cats.instances.either._
 
 package object config {
+  //                               lang      , deps
   type DependencyConfigs = TinyMap[TinyString, TinyList[TinyString]]
 
   sealed trait RepositoryConfig

--- a/polynote-kernel/src/main/scala/polynote/config/package.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/package.scala
@@ -26,7 +26,6 @@ package object config {
     def artifactPattern: String = artifactPatternOpt.getOrElse("[orgPath]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]")
     def metadataPattern: String = metadataPatternOpt.getOrElse("[orgPath]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[module](_[scalaVersion])(_[sbtVersion])-[revision]-ivy.xml")
 
-
   }
 
   object ivy {
@@ -40,6 +39,14 @@ package object config {
 
   object maven {
     implicit val discriminator: Discriminator[RepositoryConfig, maven, Byte] = Discriminator(1)
+  }
+
+  final case class pip(
+    url: String
+  ) extends RepositoryConfig
+
+  object pip {
+    implicit val discriminator: Discriminator[RepositoryConfig, pip, Byte] = Discriminator(2)
   }
 
   object RepositoryConfig {

--- a/polynote-kernel/src/main/scala/polynote/kernel/dependency/DependencyManager.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/dependency/DependencyManager.scala
@@ -3,9 +3,9 @@ package polynote.kernel.dependency
 import java.io.File
 import java.net.{URL, URLClassLoader}
 
-import polynote.config.{DependencyConfigs, RepositoryConfig}
-import polynote.kernel.{KernelStatusUpdate, TaskInfo}
+import polynote.config.RepositoryConfig
 import polynote.kernel.util.{LimitedSharingClassLoader, Publish}
+import polynote.kernel.{KernelStatusUpdate, TaskInfo}
 
 import scala.reflect.ClassTag
 import scala.reflect.internal.util.AbstractFileClassLoader
@@ -27,7 +27,7 @@ trait DependencyManager[F[_]] {
 
   def getDependencyProvider(
     repositories: List[RepositoryConfig],
-    dependencies: List[DependencyConfigs],
+    dependencies: List[String],
     exclusions: List[String]
   ): F[DependencyProvider]
 }

--- a/polynote-kernel/src/main/scala/polynote/kernel/dependency/DependencyManager.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/dependency/DependencyManager.scala
@@ -1,0 +1,77 @@
+package polynote.kernel.dependency
+
+import java.io.File
+import java.net.{URL, URLClassLoader}
+
+import polynote.config.{DependencyConfigs, RepositoryConfig}
+import polynote.kernel.{KernelStatusUpdate, TaskInfo}
+import polynote.kernel.util.{LimitedSharingClassLoader, Publish}
+
+import scala.reflect.ClassTag
+import scala.reflect.internal.util.AbstractFileClassLoader
+import scala.reflect.io.AbstractFile
+
+/**
+  * A [[DependencyManager]] handles the fetching and provision of dependencies.
+  *
+  * In this case, dependency *fetching* refers to bringing (e.g., downloading) the dependencies to this machine, and
+  * dependency *providing* refers to making these dependencies available to the runtime (e.g., with a ClassLoader).
+  *
+  */
+trait DependencyManager[F[_]] {
+  // taskInfo to describe fetching the dependencies
+  val taskInfo: TaskInfo
+
+  // where to sent status updates
+  val statusUpdates: Publish[F, KernelStatusUpdate]
+
+  def getDependencyProvider(
+    repositories: List[RepositoryConfig],
+    dependencies: List[DependencyConfigs],
+    exclusions: List[String]
+  ): F[DependencyProvider]
+}
+
+trait DependencyManagerFactory[F[_]] {
+  def apply(
+    path: String,
+    taskInfo: TaskInfo,
+    statusUpdates: Publish[F, KernelStatusUpdate]
+  ): DependencyManager[F]
+}
+
+trait DependencyProvider {
+  val dependencies: List[(String, File)]
+
+  def as[T <: DependencyProvider](implicit tag: ClassTag[T]): Either[Throwable, T] = this match {
+    case d: T => Right(d)
+    case other => Left(new IllegalArgumentException(s"A ${tag.toString()} was expected but found $other"))
+  }
+}
+
+class ClassLoaderDependencyProvider(val dependencies: List[(String, File)]) extends DependencyProvider {
+
+  def genNotebookClassLoader(
+    extraClassPath: List[File],
+    outputDir: AbstractFile,
+    parentClassLoader: ClassLoader
+  ): AbstractFileClassLoader = {
+
+    def dependencyClassPath: Seq[URL] = dependencies.collect {
+      case (_, file) if (file.getName endsWith ".jar") && file.exists() => file.toURI.toURL
+    }
+
+    /**
+      * The class loader which loads the dependencies
+      */
+    val dependencyClassLoader: URLClassLoader = new LimitedSharingClassLoader(
+      "^(scala|javax?|jdk|sun|com.sun|com.oracle|polynote|org.w3c|org.xml|org.omg|org.ietf|org.jcp|org.apache.spark|org.apache.hadoop|org.codehaus|org.slf4j|org.log4j)\\.",
+      dependencyClassPath,
+      parentClassLoader)
+
+    /**
+      * The class loader which loads the JVM-based notebook cell classes
+      */
+    new AbstractFileClassLoader(outputDir, dependencyClassLoader)
+  }
+}

--- a/polynote-kernel/src/main/scala/polynote/kernel/dependency/DependencyManager.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/dependency/DependencyManager.scala
@@ -12,11 +12,16 @@ import scala.reflect.internal.util.AbstractFileClassLoader
 import scala.reflect.io.AbstractFile
 
 /**
-  * A [[DependencyManager]] handles the fetching and provision of dependencies.
+  * A [[DependencyManager]] handles the fetching and setting up the provision of those dependencies (with a [[DependencyProvider]]).
   *
-  * In this case, dependency *fetching* refers to bringing (e.g., downloading) the dependencies to this machine, and
-  * dependency *providing* refers to making these dependencies available to the runtime (e.g., with a ClassLoader).
+  * The idea is that when we want some dependencies to be available to our code, we typically need to do two things.
+  * First, we need to get those dependencies (and _their_ dependencies, too) from somewhere and (usually) download them
+  * as files onto our machine.
+  * Second, we need to somehow link those dependencies on our filesystem with our running code.
   *
+  * An example of the former would be something like Coursier which download jars from remote repos onto our machine
+  * (in fact, we have a [[CoursierFetcher]]), while an example of the latter would be a classloader that provides the
+  * classes in said jars to our code (e.g., [[ClassLoaderDependencyProvider]]).
   */
 trait DependencyManager[F[_]] {
   // taskInfo to describe fetching the dependencies
@@ -40,6 +45,13 @@ trait DependencyManagerFactory[F[_]] {
   ): DependencyManager[F]
 }
 
+/**
+  * A [[DependencyProvider]] handles actually linking the fetched dependencies with the interpreter itself.
+  *
+  * The idea is similar to how a classloader works (indeed, we even have a [[ClassLoaderDependencyProvider]])
+  *
+  * @see [[DependencyManager]]
+  */
 trait DependencyProvider {
   val dependencies: List[(String, File)]
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/dependency/IvyFetcher.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/dependency/IvyFetcher.scala
@@ -30,7 +30,7 @@ import polynote.kernel.{KernelStatusUpdate, TaskInfo, TaskStatus, UpdatedTasks}
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
-class IvyFetcher extends URLDependencyFetcher {
+class IvyFetcher(val path: String, val taskInfo: TaskInfo, val statusUpdates: Publish[IO, KernelStatusUpdate]) extends ScalaDependencyFetcher {
   protected implicit val executionContext: ExecutionContext = ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
   protected implicit val contextShift: ContextShift[IO] =  IO.contextShift(executionContext)
 
@@ -42,9 +42,7 @@ class IvyFetcher extends URLDependencyFetcher {
   override protected def resolveDependencies(
     repositories: List[RepositoryConfig],
     dependencies: List[DependencyConfigs],
-    exclusions: List[String],
-    taskInfo: TaskInfo,
-    statusUpdates: Publish[IO, KernelStatusUpdate]
+    exclusions: List[String]
   ): IO[List[(String, IO[File])]] = {
 
     val settings = createSettings(repositories, statusUpdates)
@@ -297,5 +295,11 @@ class IvyFetcher extends URLDependencyFetcher {
         }
       }
     }
+  }
+}
+object IvyFetcher {
+
+  object Factory extends DependencyManagerFactory[IO] {
+    override def apply(path: String, taskInfo: TaskInfo, statusUpdates: Publish[IO, KernelStatusUpdate]): DependencyManager[IO] = new IvyFetcher(path, taskInfo, statusUpdates)
   }
 }

--- a/polynote-kernel/src/main/scala/polynote/kernel/dependency/ScalaDependencyFetcher.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/dependency/ScalaDependencyFetcher.scala
@@ -5,12 +5,14 @@ import java.net.URI
 import java.nio.file.{Files, Path, Paths}
 import java.util.concurrent.Executors
 
+import cats.effect.concurrent.Ref
 import cats.effect.{ContextShift, IO}
 import cats.syntax.alternative._
 import cats.syntax.apply._
 import cats.syntax.either._
 import cats.instances.either._
 import cats.instances.list._
+import cats.syntax.parallel._
 import polynote.config.{DependencyConfigs, RepositoryConfig}
 import polynote.kernel._
 import polynote.kernel.util.{DownloadableFileProvider, Publish}
@@ -18,19 +20,7 @@ import polynote.messages.{TinyList, TinyMap}
 
 import scala.concurrent.ExecutionContext
 
-trait DependencyFetcher[F[_]] {
-
-  def fetchDependencyList(
-    repositories: List[RepositoryConfig],
-    dependencies: List[DependencyConfigs],
-    exclusions: List[String],
-    taskInfo: TaskInfo,
-    statusUpdates: Publish[F, KernelStatusUpdate]
-  ): F[List[(String, F[File])]]
-
-}
-
-trait URLDependencyFetcher extends DependencyFetcher[IO] {
+trait ScalaDependencyFetcher extends DependencyManager[IO] {
   protected implicit def executionContext: ExecutionContext
   protected implicit def contextShift: ContextShift[IO]
 
@@ -134,23 +124,51 @@ trait URLDependencyFetcher extends DependencyFetcher[IO] {
   protected def resolveDependencies(
     repositories: List[RepositoryConfig],
     dependencies: List[DependencyConfigs],
-    exclusions: List[String],
-    taskInfo: TaskInfo,
-    statusUpdates: Publish[IO, KernelStatusUpdate]
+    exclusions: List[String]
   ): IO[List[(String, IO[File])]]
+
+  def getDependencyProvider(
+    repositories: List[RepositoryConfig],
+    dependencies: List[DependencyConfigs],
+    exclusions: List[String]
+  ): IO[DependencyProvider] = for {
+    deps <- fetchDependencyList(repositories, dependencies, exclusions)
+    fetched <- downloadDependencies(deps)
+  } yield new ClassLoaderDependencyProvider(fetched)
 
   def fetchDependencyList(
     repositories: List[RepositoryConfig],
     dependencies: List[DependencyConfigs],
-    exclusions: List[String],
-    taskInfo: TaskInfo,
-    statusUpdates: Publish[IO, KernelStatusUpdate]
+    exclusions: List[String]
   ): IO[List[(String, IO[File])]] = {
     val (deps, urls) = splitDependencies(dependencies)
     val downloadFiles = fetchUrls(urls, statusUpdates)
-    resolveDependencies(repositories, deps, exclusions, taskInfo, statusUpdates).map {
+    resolveDependencies(repositories, deps, exclusions).map {
       resolved => downloadFiles ::: resolved
     }
   }
 
+  def downloadDependencies(deps: List[(String, IO[File])]): IO[List[(String, File)]] = {
+    val completedCounter = Ref.unsafe[IO, Int](0)
+    val numDeps = deps.size
+    deps.map {
+      case (name, ioFile) => for {
+        download     <- ioFile.start
+        file         <- download.join
+        _            <- completedCounter.update(_ + 1)
+        numCompleted <- completedCounter.get
+        statusUpdate  = taskInfo.copy(detail = s"Downloaded $numCompleted / $numDeps", progress = ((numCompleted.toDouble * 255) / numDeps).toByte)
+        _            <- statusUpdates.publish1(UpdatedTasks(statusUpdate :: Nil))
+      } yield (name, file)
+    }.map(_.map(Some(_)).handleErrorWith(downloadFailed)).parSequence.map(_.flatten)
+  }
+
+  // TODO: ignoring download errors for now, until the weirdness of resolving nonexisting artifacts is solved
+  private def downloadFailed(err: Throwable): IO[Option[(String, File)]] = IO {
+    err match {
+      case other =>
+        // don't ignore other errors
+        throw RuntimeError(new Exception(s"Error while downloading dependencies: ${other.getMessage}", other))
+    }
+  }
 }

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/LanguageInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/LanguageInterpreter.scala
@@ -7,6 +7,7 @@ import cats.effect.IO
 import fs2.Stream
 import fs2.concurrent.{Enqueue, Queue}
 import polynote.kernel._
+import polynote.kernel.dependency.DependencyProvider
 import polynote.kernel.util.{CellContext, KernelContext, Publish}
 import polynote.messages.CellID
 
@@ -63,7 +64,7 @@ object LanguageInterpreter {
 
   trait Factory[F[_]] {
     def languageName: String
-    def apply(dependencies: List[(String, File)], kernelContext: KernelContext): LanguageInterpreter[F]
+    def apply(kernelContext: KernelContext, dependencies: DependencyProvider): LanguageInterpreter[F]
   }
 
   lazy val factories: Map[String, Factory[IO]] = ServiceLoader.load(classOf[LanguageInterpreterService]).iterator.asScala.toSeq

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/LanguageInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/LanguageInterpreter.scala
@@ -7,7 +7,7 @@ import cats.effect.IO
 import fs2.Stream
 import fs2.concurrent.{Enqueue, Queue}
 import polynote.kernel._
-import polynote.kernel.dependency.DependencyProvider
+import polynote.kernel.dependency.{DependencyManagerFactory, DependencyProvider}
 import polynote.kernel.util.{CellContext, KernelContext, Publish}
 import polynote.messages.CellID
 
@@ -63,6 +63,7 @@ trait LanguageInterpreter[F[_]] {
 object LanguageInterpreter {
 
   trait Factory[F[_]] {
+    def depManagerFactory: DependencyManagerFactory[F]
     def languageName: String
     def apply(kernelContext: KernelContext, dependencies: DependencyProvider): LanguageInterpreter[F]
   }
@@ -72,5 +73,4 @@ object LanguageInterpreter {
     .foldLeft(Map.empty[String, LanguageInterpreter.Factory[IO]]) {
       (accum, next) => accum ++ next.interpreters
     }
-
 }

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/LanguageInterpreterService.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/LanguageInterpreterService.scala
@@ -1,13 +1,15 @@
 package polynote.kernel.lang
 
 import cats.effect.IO
-import polynote.kernel.lang.python.PythonInterpreter
+import polynote.kernel.dependency.{CoursierFetcher, DependencyManagerFactory, DependencyProvider}
+import polynote.kernel.lang.python.{PythonInterpreter, VirtualEnvManager}
 import polynote.kernel.lang.scal.ScalaInterpreter
 
 
 trait LanguageInterpreterService {
   def priority: Int
   def interpreters: Map[String, LanguageInterpreter.Factory[IO]]
+  def dependencyManagers: Map[String, DependencyManagerFactory[IO]]
 }
 
 class CoreLanguages extends LanguageInterpreterService {
@@ -15,4 +17,8 @@ class CoreLanguages extends LanguageInterpreterService {
   override def interpreters: Map[String, LanguageInterpreter.Factory[IO]] = Map(
     "scala" -> ScalaInterpreter.factory(),
     "python" -> PythonInterpreter.factory())
+
+  override def dependencyManagers: Map[String, DependencyManagerFactory[IO]] = Map(
+    "scala" -> CoursierFetcher.Factory,
+    "python" -> VirtualEnvManager.Factory)
 }

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
@@ -162,7 +162,7 @@ class PythonInterpreter(val kernelContext: KernelContext, dependencyProvider: De
   val preInit: IO[Unit] = IO.fromEither(dependencyProvider.as[VirtualEnvDependencyProvider]).map {
     p =>
       withJep {
-        jep.eval(p.beforeInit)
+        jep.eval(p.runBeforeInit)
       }
   }
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/python/VirtualEnvManager.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/python/VirtualEnvManager.scala
@@ -1,0 +1,77 @@
+package polynote.kernel.lang.python
+
+import java.io.File
+
+import sys.process._
+import cats.effect.{ContextShift, IO}
+import jep.Jep
+import polynote.kernel.util.Memoize
+
+// TODO:
+//    Pip dependencies need to be threaded all the way through from the UI to the interpreter.
+//    Right now all 'Dependencies' are presumed to be Scala, so we should probably fix that
+//      Maybe dependencies should be keyed by their interpreter, and there should be some way for interpreters to
+//      register some config that'll get to the UI. Maybe some message that gets sent (like interpreters in the handshake)
+
+case class PipDependency(name: String, version: Option[String]) {
+  def toPipDepString: String = version.map(v => s"$name==$v").getOrElse(name)
+}
+
+object PipDependency {
+  def apply(pipDepString: String): PipDependency = {
+    pipDepString.split("==") match {
+      case Array(name, version) =>
+        PipDependency(name, Option(version))
+      case Array(name) =>
+        PipDependency(name, None)
+      case _ => throw new Exception(s"Unable to parse pip dependency $pipDepString")
+    }
+  }
+}
+
+/**
+  * Class handling interaction with the virtualenv.
+  *
+  * @param pathPrefix where to put the virtualenv. Generally the notebook name.
+  * @param dependencies pip dependencies to install in the virtualenv.
+  */
+class VirtualEnvManager(pathPrefix: String, dependencies: Seq[PipDependency])(implicit contextShift: ContextShift[IO]) {
+
+  lazy val venv: Memoize[File] = Memoize.unsafe(IO {
+
+    // I added the `--system-site-packages` flag so that we can rely on system packages in the majority of cases where
+    // users don't need a specific version. That way, e.g., it won't take many minutes to compile numpy every time
+    // the kernel starts up...
+    Seq("virtualenv", "--system-site-packages", "--python=python3", pathPrefix).!
+
+    dependencies.foreach {
+      dep =>
+        Seq(s"$pathPrefix/bin/pip", "install", dep.toPipDepString).!
+    }
+
+    new File(pathPrefix)
+  })
+
+  // call this on Jep initialization to set the venv properly
+  lazy val activate: IO[String] = venv.get.map {
+    path =>
+      s"""exec(open("${path.getAbsolutePath}/bin/activate_this.py").read(), {'__file__': "${path.getAbsolutePath}/bin/activate_this.py"}) """
+  }
+
+  /**
+    * Defines a command to be used to add dependencies to Spark.
+    *
+    * TODO: maybe this should go somewhere else?
+    */
+  val pyDepCommand: String =
+    """
+      |import sys, shutil
+      |
+      |# sc is the PySpark Context
+      |def archive(sc):
+      |    loc = next(x for x in sys.path if sys.prefix in x and "site-packages" in x)
+      |    out_file = "./deps.zip"
+      |    shutil.make_archive(out_file, 'zip', loc) # make_archive isn't thread safe (https://bugs.python.org/issue30511) but that should be ok here, right?
+      |    sc.addPyFile(out_file)
+      |""".stripMargin
+}

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/python/VirtualEnvManager.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/python/VirtualEnvManager.scala
@@ -17,7 +17,7 @@ class VirtualEnvManager(val path: String, val taskInfo: TaskInfo, val statusUpda
 
   lazy val venv = IO {
 
-    val venvFile = new File(path)
+    val venvFile = new File(path).toPath.resolve("venv").toFile
 
     if (!venvFile.exists()) {
       // I added the `--system-site-packages` flag so that we can rely on system packages in the majority of cases where

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/python/VirtualEnvManager.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/python/VirtualEnvManager.scala
@@ -17,7 +17,8 @@ class VirtualEnvManager(val path: String, val taskInfo: TaskInfo, val statusUpda
 
   lazy val venv = IO {
 
-    val venvFile = new File(path).toPath.resolve("venv").toFile
+    // replace spaces with underscore because pyspark can't load files from directories with spaces... sigh.
+    val venvFile = new File(path.replace(' ', '_')).toPath.resolve("venv").toFile
 
     if (!venvFile.exists()) {
       // I added the `--system-site-packages` flag so that we can rely on system packages in the majority of cases where

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
@@ -13,6 +13,7 @@ import fs2.concurrent.{Enqueue, Queue, Topic}
 import polynote.config.PolyLogger
 import polynote.kernel.PolyKernel.EnqueueSome
 import polynote.kernel._
+import polynote.kernel.dependency.DependencyProvider
 import polynote.kernel.lang.LanguageInterpreter
 import polynote.kernel.util._
 import polynote.messages.{CellID, CellResult, ShortList, ShortString, TinyList, TinyString}
@@ -399,7 +400,7 @@ class ScalaInterpreter(
 object ScalaInterpreter {
   class Factory() extends LanguageInterpreter.Factory[IO] {
     override val languageName: String = "Scala"
-    override def apply(dependencies: List[(String, File)], kernelContext: KernelContext): LanguageInterpreter[IO] =
+    override def apply(kernelContext: KernelContext, dependencies: DependencyProvider): LanguageInterpreter[IO] =
       new ScalaInterpreter(kernelContext)
   }
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaInterpreter.scala
@@ -13,7 +13,7 @@ import fs2.concurrent.{Enqueue, Queue, Topic}
 import polynote.config.PolyLogger
 import polynote.kernel.PolyKernel.EnqueueSome
 import polynote.kernel._
-import polynote.kernel.dependency.DependencyProvider
+import polynote.kernel.dependency.{ClassLoaderDependencyProvider, CoursierFetcher, DependencyManagerFactory, DependencyProvider}
 import polynote.kernel.lang.LanguageInterpreter
 import polynote.kernel.util._
 import polynote.messages.{CellID, CellResult, ShortList, ShortString, TinyList, TinyString}
@@ -399,8 +399,9 @@ class ScalaInterpreter(
 
 object ScalaInterpreter {
   class Factory() extends LanguageInterpreter.Factory[IO] {
-    override val languageName: String = "Scala"
-    override def apply(kernelContext: KernelContext, dependencies: DependencyProvider): LanguageInterpreter[IO] =
+    override def depManagerFactory: DependencyManagerFactory[IO] = CoursierFetcher.Factory
+    override def languageName: String = "Scala"
+    override def apply(kernelContext: KernelContext, dependencies: DependencyProvider): ScalaInterpreter =
       new ScalaInterpreter(kernelContext)
   }
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/util/Memoize.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/Memoize.scala
@@ -1,9 +1,9 @@
-package polynote.util
+package polynote.kernel.util
 
 import java.util.concurrent.atomic.AtomicBoolean
 
-import cats.effect.{Concurrent, IO}
 import cats.effect.concurrent.{Deferred, Semaphore}
+import cats.effect.{Concurrent, IO}
 import cats.syntax.apply._
 import cats.syntax.functor._
 

--- a/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
+++ b/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
@@ -9,7 +9,7 @@ import scodec.bits.{BitVector, ByteVector}
 import scodec.codecs._
 import scodec.codecs.implicits._
 import io.circe.generic.semiauto._
-import polynote.config.{DependencyConfigs, RepositoryConfig}
+import polynote.config.{DependencyConfigs, PolynoteConfig, RepositoryConfig}
 import polynote.data.Rope
 import polynote.kernel.util.OptionEither
 import polynote.runtime.{StreamingDataRepr, TableOp}
@@ -83,13 +83,39 @@ final case class NotebookConfig(
   exclusions: Option[TinyList[TinyString]],
   repositories: Option[TinyList[RepositoryConfig]],
   sparkConfig: Option[ShortMap[String, String]]
-)
+) {
+
+  def asPolynoteConfig: PolynoteConfig = {
+    val unTinyDependencies = dependencies.map(_.map {
+      case (k, v) => k.toString -> v//.map(_.toString)
+    }).getOrElse(Map.empty)
+    PolynoteConfig(
+      repositories = repositories.getOrElse(Nil),
+      dependencies = unTinyDependencies,
+      exclusions = exclusions.getOrElse(Nil).map(_.toString),
+      spark = sparkConfig.getOrElse(Map.empty)
+    )
+  }
+}
 
 object NotebookConfig {
   implicit val encoder: Encoder[NotebookConfig] = deriveEncoder[NotebookConfig]
   implicit val decoder: Decoder[NotebookConfig] = deriveDecoder[NotebookConfig]
 
   def empty = NotebookConfig(None, None, None, None)
+
+  def fromPolynoteConfig(config: PolynoteConfig): NotebookConfig = {
+    val veryTinyDependencies: DependencyConfigs = TinyMap(config.dependencies.map {
+      case (lang, deps) =>
+        TinyString(lang) -> TinyList(deps.map(TinyString(_)))
+    })
+    NotebookConfig(
+      dependencies = Option(veryTinyDependencies),
+      exclusions = Option(config.exclusions),
+      repositories = Option(config.repositories),
+      sparkConfig = Option(config.spark)
+    )
+  }
 }
 
 final case class Notebook(path: ShortString, cells: ShortList[NotebookCell], config: Option[NotebookConfig]) extends Message {

--- a/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
+++ b/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
@@ -87,7 +87,7 @@ final case class NotebookConfig(
 
   def asPolynoteConfig: PolynoteConfig = {
     val unTinyDependencies = dependencies.map(_.map {
-      case (k, v) => k.toString -> v//.map(_.toString)
+      case (k, v) => k.toString -> v
     }).getOrElse(Map.empty)
     PolynoteConfig(
       repositories = repositories.getOrElse(Nil),

--- a/polynote-kernel/src/main/scala/polynote/messages/package.scala
+++ b/polynote-kernel/src/main/scala/polynote/messages/package.scala
@@ -55,6 +55,8 @@ package object messages {
   implicit def shortListEncoder[A](implicit listEncoder: Encoder[List[A]]): Encoder[ShortList[A]] = listEncoder.contramap(l => l)
   implicit def shortListDecoder[A](implicit listDecoder: Decoder[List[A]]): Decoder[ShortList[A]] = listDecoder.map(l => ShortList(l))
 
+  implicit def listString2ShortListTinyString(ls: List[String]): TinyList[TinyString] = TinyList(ls.map(TinyString(_)))
+
   trait TinyTag // denotes that the value is expected to be < 256 elements in length
 
   type TinyString = String @@ TinyTag

--- a/polynote-kernel/src/test/scala/polynote/kernel/lang/KernelSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/lang/KernelSpec.scala
@@ -109,9 +109,6 @@ trait KernelSpec {
   }
 }
 
-class MockVenvDepProvider extends VirtualEnvDependencyProvider(new File("."), Nil) {
-  override def beforeInit: String = ""
-  override def afterInit: String = ""
-}
+class MockVenvDepProvider extends VirtualEnvDependencyProvider(Nil, None)
 class MockCLDepProvider extends ClassLoaderDependencyProvider(Nil)
 

--- a/polynote-kernel/src/test/scala/polynote/kernel/lang/KernelSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/lang/KernelSpec.scala
@@ -1,31 +1,26 @@
 package polynote.kernel.lang
 
-import java.io.{BufferedReader, InputStreamReader, PrintWriter}
+import java.io.File
 import java.util.concurrent.Executors
 
-import cats.effect.internals.IOContextShift
 import cats.effect.{ContextShift, IO}
-import cats.instances.vector._
 import cats.instances.either._
-import cats.syntax.apply._
+import cats.instances.vector._
 import cats.syntax.alternative._
+import cats.syntax.apply._
 import cats.syntax.either._
 import fs2.Stream
-import fs2.concurrent.{Queue, Topic}
-import polynote.config.PolynoteConfig
-import polynote.kernel.PolyKernel.EnqueueSome
-import polynote.kernel.lang.python.PythonInterpreter
+import fs2.concurrent.Topic
+import polynote.kernel._
+import polynote.kernel.dependency.ClassLoaderDependencyProvider
+import polynote.kernel.lang.python.{PythonInterpreter, VirtualEnvDependencyProvider, VirtualEnvManager}
 import polynote.kernel.lang.scal.ScalaInterpreter
 import polynote.kernel.util._
-import polynote.kernel._
 
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.tools.nsc.Settings
-import scala.tools.nsc.interactive.Global
-import scala.tools.nsc.reporters.ConsoleReporter
 
-// TODO: make PythonInterpreterSpec a KernelSpec once it gets merged in
 trait KernelSpec {
   val settings = new Settings()
   settings.classpath.append(System.getProperty("java.class.path"))
@@ -39,13 +34,13 @@ trait KernelSpec {
   }
 
   def assertPythonOutput(code: Seq[String])(assertion: (Map[String, Any], Seq[Result], Seq[(String, String)]) => Unit): Unit = {
-    assertOutputWith((kernelContext: KernelContext, _) => PythonInterpreter.factory()(Nil, kernelContext), code) {
+    assertOutputWith((kernelContext: KernelContext, _) => PythonInterpreter.factory()(kernelContext, new MockVenvDepProvider), code) {
       (interp, vars, output, displayed) => interp.withJep(assertion(vars, output, displayed))
     }
   }
 
   def assertScalaOutput(code: Seq[String])(assertion: (Map[String, Any], Seq[Result], Seq[(String, String)]) => Unit): Unit = {
-    assertOutput((kernelContext: KernelContext, _) => ScalaInterpreter.factory()(Nil, kernelContext), code)(assertion)
+    assertOutput((kernelContext: KernelContext, _) => ScalaInterpreter.factory()(kernelContext, new MockCLDepProvider), code)(assertion)
   }
 
   def assertScalaOutput(code: String)(assertion: (Map[String, Any], Seq[Result], Seq[(String, String)]) => Unit): Unit = {
@@ -57,7 +52,10 @@ trait KernelSpec {
       (_, vars, output, displayed) => IO(assertion(vars, output, displayed))
     }
 
-  def getKernelContext(updates: Topic[IO, KernelStatusUpdate]): KernelContext = KernelContext.default(Map.empty, updates, Nil)
+  def getKernelContext(updates: Topic[IO, KernelStatusUpdate]): KernelContext = KernelContext.default(Map(
+    "scala" -> new MockCLDepProvider,
+    "python" -> new MockVenvDepProvider
+  ), updates, Nil)
 
   // TODO: for unit tests we'd ideally want to hook directly to runCode without needing all this!
   def assertOutputWith[K <: LanguageInterpreter[IO]](mkInterp: (KernelContext, Topic[IO, KernelStatusUpdate]) => K, code: Seq[String])(assertion: (K, Map[String, Any], Seq[Result], Seq[(String, String)]) => IO[Unit]): Unit = {
@@ -110,3 +108,10 @@ trait KernelSpec {
     }.unsafeRunSync()
   }
 }
+
+class MockVenvDepProvider extends VirtualEnvDependencyProvider(new File("."), Nil) {
+  override def beforeInit: String = ""
+  override def afterInit: String = ""
+}
+class MockCLDepProvider extends ClassLoaderDependencyProvider(Nil)
+

--- a/polynote-server/src/main/scala/polynote/server/KernelFactory.scala
+++ b/polynote-server/src/main/scala/polynote/server/KernelFactory.scala
@@ -1,6 +1,7 @@
 package polynote.server
 
 import java.io.File
+import java.nio.file.Paths
 
 import cats.effect.{ContextShift, IO, Timer}
 import cats.instances.list._
@@ -49,8 +50,8 @@ class IOKernelFactory(implicit
 
   override def launchKernel(getNotebook: () => IO[Notebook], statusUpdates: Publish[IO, KernelStatusUpdate], polynoteConfig: PolynoteConfig): IO[KernelAPI[IO]] = for {
     notebook <- getNotebook()
-    path      = notebook.path
     config    = notebook.config.getOrElse(NotebookConfig.empty)
+    path      = Paths.get(polynoteConfig.storage.cache, notebook.path).toString
     taskInfo  = TaskInfo("kernel", "Start", "Kernel starting", TaskStatus.Running)
     deps     <- fetchDependencyProviders(config, path, statusUpdates)
     numDeps   = deps.values.map(_.dependencies.size).sum

--- a/polynote-server/src/main/scala/polynote/server/KernelLaunching.scala
+++ b/polynote-server/src/main/scala/polynote/server/KernelLaunching.scala
@@ -1,7 +1,8 @@
 package polynote.server
 
 import cats.effect.{ContextShift, IO, Timer}
-import polynote.kernel.dependency.{CoursierFetcher, DependencyFetcher}
+import polynote.kernel.dependency.{CoursierFetcher, DependencyManagerFactory}
+import polynote.kernel.lang.python.VirtualEnvManager
 
 
 trait KernelLaunching {
@@ -9,9 +10,13 @@ trait KernelLaunching {
   protected implicit def timer: Timer[IO]
   protected implicit def contextShift: ContextShift[IO]
 
-  protected val dependencyFetcher = new CoursierFetcher()
-  protected val dependencyFetchers: Map[String, DependencyFetcher[IO]] = Map("scala" -> dependencyFetcher)
+  protected val scalaDep = CoursierFetcher.Factory
+  protected val pythonDep = VirtualEnvManager.Factory
+  protected val dependencyManagers: Map[String, DependencyManagerFactory[IO]] = Map(
+    "scala" -> scalaDep,
+    "python" -> pythonDep
+  )
 
-  protected def kernelFactory: KernelFactory[IO] = new IOKernelFactory(dependencyFetchers)
+  protected def kernelFactory: KernelFactory[IO] = new IOKernelFactory(dependencyManagers)
 
 }

--- a/polynote-server/src/main/scala/polynote/server/KernelLaunching.scala
+++ b/polynote-server/src/main/scala/polynote/server/KernelLaunching.scala
@@ -1,8 +1,6 @@
 package polynote.server
 
 import cats.effect.{ContextShift, IO, Timer}
-import polynote.kernel.dependency.{CoursierFetcher, DependencyManagerFactory}
-import polynote.kernel.lang.python.VirtualEnvManager
 
 
 trait KernelLaunching {
@@ -10,13 +8,6 @@ trait KernelLaunching {
   protected implicit def timer: Timer[IO]
   protected implicit def contextShift: ContextShift[IO]
 
-  protected val scalaDep = CoursierFetcher.Factory
-  protected val pythonDep = VirtualEnvManager.Factory
-  protected val dependencyManagers: Map[String, DependencyManagerFactory[IO]] = Map(
-    "scala" -> scalaDep,
-    "python" -> pythonDep
-  )
-
-  protected def kernelFactory: KernelFactory[IO] = new IOKernelFactory(dependencyManagers)
+  protected def kernelFactory: KernelFactory[IO] = new IOKernelFactory()
 
 }

--- a/polynote-spark/src/main/scala/polynote/kernel/SparkPolyKernel.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/SparkPolyKernel.scala
@@ -68,9 +68,8 @@ class SparkPolyKernel(
     val tmp = Files.createTempDirectory("dependencies")
     tmp.toFile.deleteOnExit()
 
-
     val jars = for {
-      namedFiles <- dependencyProviders.get("spark").map(_.dependencies).toList
+      namedFiles <- dependencyProviders.get("scala").map(_.dependencies).toList
       (_, file) <- namedFiles if file.getName endsWith ".jar"
     } yield file -> tmp.resolve(URLDecoder.decode(file.getName, "utf-8"))
 

--- a/polynote-spark/src/main/scala/polynote/kernel/lang/SparkLanguages.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/lang/SparkLanguages.scala
@@ -1,6 +1,7 @@
 package polynote.kernel.lang
 import cats.effect.IO
-import polynote.kernel.lang.python.PySparkInterpreter
+import polynote.kernel.dependency.{CoursierFetcher, DependencyManagerFactory}
+import polynote.kernel.lang.python.{PySparkInterpreter, VirtualEnvManager}
 import polynote.kernel.lang.scal.ScalaSparkInterpreter
 import polynote.kernel.lang.sql.SparkSqlInterpreter
 
@@ -11,4 +12,8 @@ class SparkLanguages extends LanguageInterpreterService {
     "sql" -> SparkSqlInterpreter.factory(),
     "python" -> PySparkInterpreter.factory()
   )
+  def dependencyManagers: Map[String, DependencyManagerFactory[IO]] = Map(
+    "scala" -> CoursierFetcher.Factory,
+    "sql" -> CoursierFetcher.Factory,
+    "python" -> VirtualEnvManager.Factory)
 }

--- a/polynote-spark/src/main/scala/polynote/kernel/lang/python/PySparkInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/lang/python/PySparkInterpreter.scala
@@ -15,7 +15,7 @@ class PySparkInterpreter(ctx: KernelContext, dependencyProvider: DependencyProvi
   val postInit: IO[Unit] = IO.fromEither(dependencyProvider.as[PySparkVirtualEnvDependencyProvider]).map {
     p =>
       withJep {
-        jep.eval(p.afterInit)
+        jep.eval(p.runAfterInit)
       }
   }
 

--- a/polynote-spark/src/main/scala/polynote/kernel/lang/python/PySparkInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/lang/python/PySparkInterpreter.scala
@@ -18,6 +18,13 @@ class PySparkInterpreter(ctx: KernelContext, dependencyProvider: DependencyProvi
       // initialize py4j and pyspark in the way they expect
 
       val spark = SparkSession.builder().getOrCreate()
+
+      // if we are running in local mode we need to set this so the executors can find the venv's python
+      if (spark.sparkContext.master.contains("local")) {
+        jep.eval("""os.environ["PYSPARK_PYTHON"] = os.environ["PYSPARK_DRIVER_PYTHON"]""")
+      } else {
+        jep.eval("""os.environ["PYSPARK_PYTHON"] = "python3" """)
+      }
       jep.eval("from py4j.java_gateway import java_import, JavaGateway, JavaObject, GatewayParameters, CallbackServerParameters")
       jep.eval("from pyspark.conf import SparkConf")
       jep.eval("from pyspark.context import SparkContext")

--- a/polynote-spark/src/main/scala/polynote/kernel/lang/python/PySparkVirtualEnvManager.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/lang/python/PySparkVirtualEnvManager.scala
@@ -1,0 +1,43 @@
+package polynote.kernel.lang.python
+
+import java.io.File
+
+import cats.effect.IO
+import polynote.kernel.{KernelStatusUpdate, TaskInfo}
+import polynote.kernel.dependency.{DependencyManager, DependencyManagerFactory}
+import polynote.kernel.util.Publish
+
+class PySparkVirtualEnvManager(path: String, taskInfo: TaskInfo, statusUpdates: Publish[IO, KernelStatusUpdate])
+  extends VirtualEnvManager(path, taskInfo, statusUpdates) {
+
+  override def mkDependencyProvider(venv: File, dependencies: List[(String, File)]): VirtualEnvDependencyProvider =
+    new PySparkVirtualEnvDependencyProvider(venv, dependencies)
+}
+
+class PySparkVirtualEnvDependencyProvider(
+  venv: File,
+  override val dependencies: scala.List[(String, File)]
+) extends VirtualEnvDependencyProvider(venv, dependencies) {
+
+  override def beforeInit: String =
+    s"""
+       |${super.beforeInit}
+       |
+       |import sys, shutil
+       |
+       |# sc is the PySpark Context
+       |def archive(sc):
+       |    loc = next(x for x in sys.path if sys.prefix in x and "site-packages" in x)
+       |    out_file = "./deps.zip"
+       |    shutil.make_archive(out_file, 'zip', loc) # make_archive isn't thread safe (https://bugs.python.org/issue30511) but that should be ok here, right?
+       |    sc.addPyFile(out_file)
+     """.stripMargin
+
+  override val afterInit: String = "archive(sc)"
+}
+
+object PySparkVirtualEnvManager {
+  object Factory extends DependencyManagerFactory[IO] {
+    override def apply(path: String, taskInfo: TaskInfo, statusUpdates: Publish[IO, KernelStatusUpdate]): DependencyManager[IO] = new PySparkVirtualEnvManager(path, taskInfo, statusUpdates)
+  }
+}

--- a/polynote-spark/src/main/scala/polynote/kernel/lang/python/PySparkVirtualEnvManager.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/lang/python/PySparkVirtualEnvManager.scala
@@ -38,7 +38,7 @@ class PySparkVirtualEnvDependencyProvider(
       |import shutil
       |
       |# archive venv and send to Spark cluster
-      |for dep in Path('$path', 'deps').glob('*.whl'):
+      |for dep in Path('$path', 'deps').resolve().glob('*.whl'):
       |    # we need to rename the wheels to zips because that's what spark wants... sigh
       |    as_zip = dep.with_suffix('.zip')
       |    if not as_zip.exists():

--- a/polynote-spark/src/main/scala/polynote/kernel/lang/python/PySparkVirtualEnvManager.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/lang/python/PySparkVirtualEnvManager.scala
@@ -10,18 +10,18 @@ import polynote.kernel.util.Publish
 class PySparkVirtualEnvManager(path: String, taskInfo: TaskInfo, statusUpdates: Publish[IO, KernelStatusUpdate])
   extends VirtualEnvManager(path, taskInfo, statusUpdates) {
 
-  override def mkDependencyProvider(venv: File, dependencies: List[(String, File)]): VirtualEnvDependencyProvider =
-    new PySparkVirtualEnvDependencyProvider(venv, dependencies)
+  override def mkDependencyProvider(dependencies: List[(String, File)], venv: Option[File]): VirtualEnvDependencyProvider =
+    new PySparkVirtualEnvDependencyProvider(dependencies, venv)
 }
 
 class PySparkVirtualEnvDependencyProvider(
-  venv: File,
-  override val dependencies: scala.List[(String, File)]
-) extends VirtualEnvDependencyProvider(venv, dependencies) {
+  override val dependencies: scala.List[(String, File)],
+  venv: Option[File]
+) extends VirtualEnvDependencyProvider(dependencies, venv) {
 
-  override def beforeInit: String =
+  override def beforeInit(path: String): String =
     s"""
-       |${super.beforeInit}
+       |${super.beforeInit(path)}
        |
        |import sys, shutil
        |
@@ -33,7 +33,7 @@ class PySparkVirtualEnvDependencyProvider(
        |    sc.addPyFile(out_file)
      """.stripMargin
 
-  override val afterInit: String = "archive(sc)"
+  override def afterInit(path: String): String = "archive(sc)"
 }
 
 object PySparkVirtualEnvManager {

--- a/polynote-spark/src/main/scala/polynote/kernel/lang/scal/ScalaSparkInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/lang/scal/ScalaSparkInterpreter.scala
@@ -4,6 +4,7 @@ import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 
 import cats.effect.IO
+import polynote.kernel.dependency.DependencyProvider
 import polynote.kernel.lang.LanguageInterpreter
 import polynote.kernel.util.{CellContext, KernelContext}
 
@@ -41,7 +42,7 @@ object ScalaSparkInterpreter {
 
   class Factory extends LanguageInterpreter.Factory[IO] {
     override val languageName: String = "Scala"
-    override def apply(dependencies: List[(String, File)], kernelContext: KernelContext): LanguageInterpreter[IO] =
+    override def apply(kernelContext: KernelContext, dependencies: DependencyProvider): LanguageInterpreter[IO] =
       new ScalaSparkInterpreter(kernelContext)
   }
 

--- a/polynote-spark/src/main/scala/polynote/kernel/lang/scal/ScalaSparkInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/lang/scal/ScalaSparkInterpreter.scala
@@ -4,7 +4,7 @@ import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 
 import cats.effect.IO
-import polynote.kernel.dependency.DependencyProvider
+import polynote.kernel.dependency.{ClassLoaderDependencyProvider, CoursierFetcher, DependencyManagerFactory, DependencyProvider}
 import polynote.kernel.lang.LanguageInterpreter
 import polynote.kernel.util.{CellContext, KernelContext}
 
@@ -40,9 +40,8 @@ object ScalaSparkInterpreter {
   private val notebookCounter = new AtomicInteger(0)
   private def nextNotebookId = notebookCounter.getAndIncrement()
 
-  class Factory extends LanguageInterpreter.Factory[IO] {
-    override val languageName: String = "Scala"
-    override def apply(kernelContext: KernelContext, dependencies: DependencyProvider): LanguageInterpreter[IO] =
+  class Factory extends ScalaInterpreter.Factory {
+    override def apply(kernelContext: KernelContext, dependencies: DependencyProvider): ScalaInterpreter =
       new ScalaSparkInterpreter(kernelContext)
   }
 

--- a/polynote-spark/src/main/scala/polynote/kernel/lang/sql/SparkSqlInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/lang/sql/SparkSqlInterpreter.scala
@@ -14,6 +14,7 @@ import org.apache.spark.sql.thief.SessionStateThief
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 import polynote.config.PolyLogger
 import polynote.kernel._
+import polynote.kernel.dependency.DependencyProvider
 import polynote.kernel.lang.LanguageInterpreter
 import polynote.kernel.util.{CellContext, KernelContext, Publish}
 import polynote.messages.{CellID, ShortString, TinyList, TinyString}
@@ -182,7 +183,7 @@ class SparkSqlInterpreter(val kernelContext: KernelContext) extends LanguageInte
 object SparkSqlInterpreter {
   class Factory extends LanguageInterpreter.Factory[IO] {
     def languageName: String = "SQL"
-    def apply(dependencies: List[(String, File)], kernelContext: KernelContext): LanguageInterpreter[IO] = new SparkSqlInterpreter(kernelContext)
+    def apply(kernelContext: KernelContext, dependencies: DependencyProvider): LanguageInterpreter[IO] = new SparkSqlInterpreter(kernelContext)
   }
 
   def factory(): Factory = new Factory

--- a/polynote-spark/src/main/scala/polynote/kernel/lang/sql/SparkSqlInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/lang/sql/SparkSqlInterpreter.scala
@@ -13,9 +13,10 @@ import org.apache.spark.sql.catalyst.parser.SqlBaseParser.SingleStatementContext
 import org.apache.spark.sql.thief.SessionStateThief
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 import polynote.config.PolyLogger
-import polynote.kernel._
-import polynote.kernel.dependency.DependencyProvider
+import polynote.kernel.{lang, _}
+import polynote.kernel.dependency.{ClassLoaderDependencyProvider, CoursierFetcher, DependencyManagerFactory, DependencyProvider}
 import polynote.kernel.lang.LanguageInterpreter
+import polynote.kernel.lang.scal.ScalaInterpreter
 import polynote.kernel.util.{CellContext, KernelContext, Publish}
 import polynote.messages.{CellID, ShortString, TinyList, TinyString}
 
@@ -182,8 +183,10 @@ class SparkSqlInterpreter(val kernelContext: KernelContext) extends LanguageInte
 
 object SparkSqlInterpreter {
   class Factory extends LanguageInterpreter.Factory[IO] {
-    def languageName: String = "SQL"
-    def apply(kernelContext: KernelContext, dependencies: DependencyProvider): LanguageInterpreter[IO] = new SparkSqlInterpreter(kernelContext)
+    override def depManagerFactory: DependencyManagerFactory[IO] = CoursierFetcher.Factory
+    override def languageName: String = "SQL"
+    override def apply(kernelContext: KernelContext, dependencies: DependencyProvider): LanguageInterpreter[IO] =
+      new SparkSqlInterpreter(kernelContext)
   }
 
   def factory(): Factory = new Factory

--- a/polynote-spark/src/main/scala/polynote/kernel/remote/RemoteSparkKernel.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/remote/RemoteSparkKernel.scala
@@ -18,10 +18,9 @@ import fs2.{Chunk, Stream}
 import fs2.concurrent.Queue
 import polynote.config.{PolyLogger, PolynoteConfig}
 import polynote.kernel._
-import polynote.kernel.util.{Publish, ReadySignal}
+import polynote.kernel.util.{Memoize, Publish, ReadySignal}
 import polynote.messages.{ByteVector32, CellID, CellResult, HandleType, Lazy, Notebook, NotebookUpdate, ShortString, Streaming, Updating}
 import polynote.runtime._
-import polynote.util.Memoize
 import scodec.bits.ByteVector
 
 import scala.concurrent.duration.{Duration, MINUTES}

--- a/polynote-spark/src/main/scala/polynote/kernel/remote/RemoteSparkKernelClient.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/remote/RemoteSparkKernelClient.scala
@@ -152,7 +152,7 @@ object RemoteSparkKernelClient extends IOApp with KernelLaunching {
 
   private val logger = new PolyLogger
 
-  override protected def kernelFactory: KernelFactory[IO] = new SparkKernelFactory(dependencyFetchers)
+  override protected def kernelFactory: KernelFactory[IO] = new SparkKernelFactory(dependencyManagers)
 
   @tailrec
   private def getArgs(remaining: List[String]): IO[InetSocketAddress] = remaining match {

--- a/polynote-spark/src/main/scala/polynote/kernel/remote/RemoteSparkKernelClient.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/remote/RemoteSparkKernelClient.scala
@@ -9,7 +9,7 @@ import cats.syntax.either._
 import cats.syntax.functor._
 import fs2.{Chunk, Pipe, Stream}
 import fs2.concurrent.Queue
-import polynote.config.{PolyLogger, PolynoteConfig}
+import polynote.config.PolyLogger
 import polynote.kernel.util.{Publish, ReadySignal}
 import Publish.enqueueToPublish
 import polynote.kernel._
@@ -51,16 +51,6 @@ class RemoteSparkKernelClient(
       case other => IO.raiseError(new IllegalStateException(s"Initial message was ${other.getClass.getSimpleName} rather than InitialNotebook"))
     }
   } yield notebookReq
-
-  private def configFromNotebookConfig(notebookConfig: NotebookConfig): PolynoteConfig = notebookConfig match {
-    case NotebookConfig(dependencies, exclusions, repositories, spark) =>
-      PolynoteConfig(
-        repositories = repositories.getOrElse(Nil),
-        dependencies = dependencies.map(_.asInstanceOf[Map[String, List[String]]]).getOrElse(Map.empty),
-        exclusions = exclusions.getOrElse(Nil),
-        spark = spark.getOrElse(Map.empty)
-      )
-  }
 
   private def respondResultStream(reqId: Int, resultStream: Stream[IO, Result]) =
     Stream.emit(StreamStarted(reqId)) ++ resultStream.mapChunks {
@@ -128,7 +118,7 @@ class RemoteSparkKernelClient(
     notebook        = notebookReq.notebook
     nbConfig        = notebook.config.getOrElse(NotebookConfig.empty)
     notebookRef    <- Ref[IO].of(notebook)
-    conf            = configFromNotebookConfig(nbConfig)
+    conf            = nbConfig.asPolynoteConfig
     statusUpdates   = outputMessages.contramap[KernelStatusUpdate](update => KernelStatusResponse(update))
     _              <- IO(logger.info("Launching kernel"))
     kernel         <- kernelFactory.launchKernel(notebookRef.get _, statusUpdates, conf)
@@ -152,7 +142,7 @@ object RemoteSparkKernelClient extends IOApp with KernelLaunching {
 
   private val logger = new PolyLogger
 
-  override protected def kernelFactory: KernelFactory[IO] = new SparkKernelFactory(dependencyManagers)
+  override protected def kernelFactory: KernelFactory[IO] = new SparkKernelFactory()
 
   @tailrec
   private def getArgs(remaining: List[String]): IO[InetSocketAddress] = remaining match {

--- a/polynote-spark/src/main/scala/polynote/server/SparkServer.scala
+++ b/polynote-spark/src/main/scala/polynote/server/SparkServer.scala
@@ -42,8 +42,7 @@ object SparkServer extends Server {
   }
 
   // visible for testing
-  override protected[server] def kernelFactory: KernelFactory[IO] =
-    new SparkKernelFactory(dependencyManagers = Map("scala" -> scalaDep, "python" -> PySparkVirtualEnvManager.Factory))
+  override protected[server] def kernelFactory: KernelFactory[IO] = new SparkKernelFactory
 }
 
 case class SparkServerArgs(
@@ -56,11 +55,10 @@ object SparkServerArgs {
   def apply(printCommand: Boolean, args: ServerArgs): SparkServerArgs = SparkServerArgs(printCommand, args.configFile, args.watchUI)
 }
 
-class SparkKernelFactory(
-  dependencyManagers: Map[String, DependencyManagerFactory[IO]])(implicit
+class SparkKernelFactory(implicit
   contextShift: ContextShift[IO],
   timer: Timer[IO]
-) extends IOKernelFactory(dependencyManagers) {
+) extends IOKernelFactory {
   override protected def mkKernel(
     getNotebook: () => IO[Notebook],
     deps: Map[String, DependencyProvider],

--- a/polynote-spark/src/test/scala/polynote/kernel/SparkKernelSpec.scala
+++ b/polynote-spark/src/test/scala/polynote/kernel/SparkKernelSpec.scala
@@ -3,7 +3,7 @@ package polynote.kernel
 import cats.effect.IO
 import fs2.concurrent.Topic
 import polynote.config.PolynoteConfig
-import polynote.kernel.lang.{KernelSpec, SparkLanguages}
+import polynote.kernel.lang.{KernelSpec, MockCLDepProvider, SparkLanguages}
 import polynote.kernel.lang.scal.ScalaSparkInterpreter
 import polynote.kernel.util.{KernelContext, Publish}
 import polynote.messages.{Notebook, ShortList}
@@ -13,14 +13,14 @@ trait SparkKernelSpec extends KernelSpec {
 
   override def getKernelContext(updates: Topic[IO, KernelStatusUpdate]): KernelContext = {
     // we use SparkKernel to get a KernelContext with a proper classpath and to properly set up the session
-    val sparkKernel = SparkPolyKernel(() => IO.pure(Notebook("foo", ShortList(Nil), None)), Map.empty, Map("scala" -> interpFactory), updates, config = PolynoteConfig())
+    val sparkKernel = SparkPolyKernel(() => IO.pure(Notebook("foo", ShortList(Nil), None)), Map("scala" -> new MockCLDepProvider), Map("scala" -> interpFactory), updates, config = PolynoteConfig())
     sparkKernel.init().unsafeRunSync() // make sure to init the spark session
     sparkKernel.kernelContext
   }
 
   def assertSparkScalaOutput(code: Seq[String])(assertion: (Map[String, Any], Seq[Result], Seq[(String, String)]) => Unit): Unit = {
     assertOutput({ (kernelContext: KernelContext, updates: Topic[IO, KernelStatusUpdate]) =>
-      interpFactory(Nil, kernelContext)
+      interpFactory(kernelContext, new MockCLDepProvider)
     }, code)(assertion)
   }
 

--- a/polynote-spark/src/test/scala/polynote/server/NotebookRunningSpec.scala
+++ b/polynote-spark/src/test/scala/polynote/server/NotebookRunningSpec.scala
@@ -7,6 +7,7 @@ import cats.effect.{ContextShift, ExitCode, IO, Timer}
 import fs2.concurrent.Queue
 import org.scalatest.{FreeSpec, Matchers}
 import polynote.config.PolynoteConfig
+import polynote.kernel.lang.MockVenvDepProvider
 import polynote.kernel.{ClearResults, ExecutionInfo, Output, ResultValue}
 import polynote.messages.{CellResult, LoadNotebook, Message, ShortString}
 import polynote.runtime._


### PR DESCRIPTION
Adds support for specifying Python dependencies. When you specify these dependencies, Polynote will create a notebook-specific virtual environment and install those dependencies inside it. 

The virtual environment is configured to delegate to the system python environment so packages that already exist won't be installed again. This is actually necessary to support `jep` shared modules since they can only be initialized once per JVM, so they need to be installed globally as long as we share a `jep` instance across multiple notebooks (i.e., if we aren't using remote kernels). 

The virtual environment is persisted into a cache directory namespaced by the notebook name so as long as that doesn't change it won't have to download deps every time you start the notebook. 

We also attempt to make your dependencies available on spark executor machines by downloading the dependencies as `wheels` and adding them to PySpark. This works in simple cases (like pure Python packages) but might not work on packages with C extensions (those will need to be installed onto the Spark executor nodes). 

Internally the major changes are the introduction of a `DependencyManager` which handles fetching and provisioning of dependencies (e.g., fetch a jar from a repo / pip install) and a `DependencyProvider` which provides those dependencies to the actual interpreter (e.g., a classloader / adding a location to `sys.path`). 