### PR TITLE
Handle hash in notebook import URL

### DIFF
--- a/polynote-frontend/polynote/ui.js
+++ b/polynote-frontend/polynote/ui.js
@@ -2292,12 +2292,13 @@ export class MainUI extends EventTarget {
         if (evt.detail && evt.detail.name) { // the evt has all we need
             this.socket.send(new messages.CreateNotebook(evt.detail.name, Either.right(evt.detail.content)));
         } else {
-            const notebookPath = prompt("Enter the full URL of another Polynote instance.");
+            const notebookURL = new URL(prompt("Enter the full URL of another Polynote instance."));
 
-            if (notebookPath && notebookPath.startsWith("http")) {
-                const nbFile = decodeURI(notebookPath.split("/").pop());
-                const targetPath = notebookPath + "?download=true";
-                this.socket.send(new messages.CreateNotebook(nbFile, Either.left(targetPath)));
+            if (notebookURL && notebookURL.protocol.startsWith("http")) {
+                const nbFile = decodeURI(notebookURL.pathname);
+                notebookURL.search = "download=true";
+                notebookURL.hash = "";
+                this.socket.send(new messages.CreateNotebook(nbFile, Either.left(notebookURL.href)));
             }
         }
     }

--- a/polynote-frontend/polynote/ui.js
+++ b/polynote-frontend/polynote/ui.js
@@ -2295,7 +2295,7 @@ export class MainUI extends EventTarget {
             const notebookURL = new URL(prompt("Enter the full URL of another Polynote instance."));
 
             if (notebookURL && notebookURL.protocol.startsWith("http")) {
-                const nbFile = decodeURI(notebookURL.pathname);
+                const nbFile = decodeURI(notebookURL.pathname.split("/").pop());
                 notebookURL.search = "download=true";
                 notebookURL.hash = "";
                 this.socket.send(new messages.CreateNotebook(nbFile, Either.left(notebookURL.href)));


### PR DESCRIPTION
Now that URLs often have a hash we should handle that gracefully when importing. 