### PR TITLE
More double-typecheck issues (lazy vals and default function args)

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaSource.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaSource.scala
@@ -205,7 +205,6 @@ class ScalaSource[G <: Global](
       }
 
       //... and also import all public declarations from previous cells
-      val x = previousSources
       val impliedImports = previousSources.foldLeft(ListMap.empty[String, (global.ModuleSymbol, global.Symbol)]) {
         (accum, next) =>
           // grab this source's compiled module
@@ -437,11 +436,10 @@ class ScalaSource[G <: Global](
 
             // we only want to insert the module proxy if it's needed. We'd rather not if we can help it, because that
             // way we avoid closing over that entire cell.
-            def getSymFromModuleProxy(sym: global.Symbol): Boolean =
-              (
-                sym.isSourceMethod // make sure it's a real method and not synthetic
-                  || sym.isClass   // if it's a class we need the module proxy
-              ) && !sym.isAccessor // if it's just an accessor we don't need the proxy (surprised that isSourceMethod is true for these actually).
+            def getSymFromModuleProxy(sym: global.Symbol): Boolean = (
+              sym.isSourceMethod // make sure it's a real method and not synthetic
+                || sym.isClass   // if it's a class we need the module proxy
+            )
 
             val moduleProxyNeeded = imports.exists {
               case (_, (_, sym)) => getSymFromModuleProxy(sym)

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaSource.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/scal/ScalaSource.scala
@@ -9,6 +9,7 @@ import polynote.kernel.util.{CellContext, KernelContext, KernelReporter}
 import scala.annotation.tailrec
 import scala.collection.immutable.ListMap
 import scala.reflect.internal.util.{ListOfNil, Position, RangePosition, SourceFile}
+import scala.reflect.internal.ModifierFlags
 import scala.tools.nsc.interactive.Global
 
 /**
@@ -204,6 +205,7 @@ class ScalaSource[G <: Global](
       }
 
       //... and also import all public declarations from previous cells
+      val x = previousSources
       val impliedImports = previousSources.foldLeft(ListMap.empty[String, (global.ModuleSymbol, global.Symbol)]) {
         (accum, next) =>
           // grab this source's compiled module
@@ -361,17 +363,31 @@ class ScalaSource[G <: Global](
         unit.body = liftedTree
         global.unitOfFile.put(unit.source.file, unit) // make sure to update
 
-        // so there's one more thing we need to consider. Apparently, case classes can't handle being put through the
-        // typer twice (and we can't roll back the changes that the typer does to them...) so, what we'll do here is
-        // copy any case classes we have in the tree before we type it.
-        // later, we'll sub the typed case class for the untyped case class so it can go through the typer again happily.
-        // we have to do the same thing for their companion objects as well.
+        // so there's one more thing we need to consider. It turns out that some output from the typechecker can't be
+        // reversed, such as case classes and lazy vals, which can't handle being put through the typer twice (and we
+        // can't roll back the changes that the typer does to them...) so, what we'll do here is copy 'em before we type
+        // the trees. later, we'll substitute the typed trees for the fresh, untyped ones so they can go through
+        // the typer again without causing problems.
+
+        // first, case classes. (we have to do the same thing for their companion objects as well).
         val caseClasses = classes.collect {
           case (k, cls: global.ClassDef) if cls.mods.isCase => k -> deepCopyTree(cls)
         }
         // we also need to keep track of any user-defined companion objects there might be, so that we can substitute them too.
         val caseClassCompanionObjects = companionObjects.collect {
           case (k, o: global.ModuleDef) if caseClasses.contains(o.name.toString) => k -> deepCopyTree(o)
+        }
+
+        // now, lazy vals
+        val lazyVals = liftedTree match {
+          case global.PackageDef(_, stats) =>
+            stats.collect {
+              case global.ClassDef(_, _, _, impl) =>
+                impl.body.collect {
+                  case v @ global.ValDef(mods, _, _, _) if mods.hasFlag(ModifierFlags.LAZY) =>
+                    v.name.toString -> v
+                }
+            }.flatten.toMap
         }
 
         // type the tree so we can reify implicits and all that nice stuff.
@@ -421,7 +437,11 @@ class ScalaSource[G <: Global](
 
             // we only want to insert the module proxy if it's needed. We'd rather not if we can help it, because that
             // way we avoid closing over that entire cell.
-            def getSymFromModuleProxy(sym: global.Symbol): Boolean = sym.isSourceMethod || sym.isClass
+            def getSymFromModuleProxy(sym: global.Symbol): Boolean =
+              (
+                sym.isSourceMethod // make sure it's a real method and not synthetic
+                  || sym.isClass   // if it's a class we need the module proxy
+              ) && !sym.isAccessor // if it's just an accessor we don't need the proxy (surprised that isSourceMethod is true for these actually).
 
             val moduleProxyNeeded = imports.exists {
               case (_, (_, sym)) => getSymFromModuleProxy(sym)
@@ -469,16 +489,23 @@ class ScalaSource[G <: Global](
         //   * remove the cell imports we added in the wrapping stage and replace them with our proxies.
         //   * replace the typed case class definitions with the original, fresh defs
         //   * remove the auto-generated companion object (if there was a user-defined companion object, we replace it)
+        //   * replace the auto-generated lazy val accessor with our 'fixed' lazy val def
         // the whole thing is a little ugly because we lose position information when we use copy()
         val cleanedPkg = proxiedPkg match {
           case pkg @ global.PackageDef(_, stats) =>
             pkg.copy(stats = stats.flatMap {
-              // clean the cell imports
-              case cls @ global.ClassDef(_, name, _, tmpl) if name.toString == moduleName.toString =>
+              case cls @ global.ClassDef(_, name, _, tmpl) if name.toString.trim == moduleName.toString.trim =>
                 List(cls.copy(impl = tmpl match {
                   case global.Template(_, _, body) =>
                     val cleanedBody = body.flatMap {
+                      // remove cell imports we added during the wrapping stage
                       case global.Import(global.Select(_, global.TermName("INSTANCE")), _) => Nil
+                      // throw away the lazy val def because we will substitute its accessor
+                      case global.ValDef(_, n, _, _) if lazyVals.contains(n.toString.trim) => Nil
+                      // substitute the lazy val accessor with the untyped val def, but make sure to grab the (possible) substituted rhs
+                      case global.DefDef(_, n, _, _, _, global.Block(List(global.Assign(_, rhs)), _)) if lazyVals.contains(n.toString) =>
+                        val clean = lazyVals(n.toString).copy(rhs = rhs)
+                        List(clean)
                       case other => List(other)
                     }
                     tmpl.copy(body = newProxyTrees ++ cleanedBody).setPos(tmpl.pos)

--- a/polynote-spark/src/test/scala/polynote/kernel/lang/ScalaSparkInterpreterSpec.scala
+++ b/polynote-spark/src/test/scala/polynote/kernel/lang/ScalaSparkInterpreterSpec.scala
@@ -144,5 +144,18 @@ class ScalaSparkInterpreterSpec extends FlatSpec with Matchers with SparkKernelS
       vars("bop") shouldEqual 5
     }
   }
+
+  it should "work with lazy vals and vars" in {
+    val code = Seq(
+      "var a = 100",
+      "lazy val b = a"
+    )
+    assertSparkScalaOutput(code) { case (vars, output, displayed) =>
+      vars("kernel") shouldEqual polynote.runtime.Runtime
+      vars("spark") shouldBe a[SparkSession]
+      vars("a") shouldEqual 100
+      vars("b") shouldEqual 100
+    }
+  }
 }
 

--- a/polynote-spark/src/test/scala/polynote/kernel/lang/ScalaSparkInterpreterSpec.scala
+++ b/polynote-spark/src/test/scala/polynote/kernel/lang/ScalaSparkInterpreterSpec.scala
@@ -157,5 +157,20 @@ class ScalaSparkInterpreterSpec extends FlatSpec with Matchers with SparkKernelS
       vars("b") shouldEqual 100
     }
   }
+
+  it should "work with functions that have default values" in {
+    val code = Seq(
+      """def foo(a: Int, b: Int = 1) = a + b
+        |foo(1)
+      """.stripMargin,
+      "val a = foo(2, 3)",
+      "val b = foo(2)"
+    )
+    assertSparkScalaOutput(code) { case (vars, output, displayed) =>
+      vars("Out") shouldEqual 2
+      vars("a") shouldEqual 5
+      vars("b") shouldEqual 3
+    }
+  }
 }
 

--- a/polynote-spark/src/test/scala/polynote/kernel/lang/ScalaSparkInterpreterSpec.scala
+++ b/polynote-spark/src/test/scala/polynote/kernel/lang/ScalaSparkInterpreterSpec.scala
@@ -158,18 +158,21 @@ class ScalaSparkInterpreterSpec extends FlatSpec with Matchers with SparkKernelS
     }
   }
 
-  it should "work with functions that have default values" in {
+  it should "work with default values" in {
     val code = Seq(
-      """def foo(a: Int, b: Int = 1) = a + b
+      """case class Foo(a: Int, b: Int, c: Int = 1) { def sum: Int = a + b + c }""".stripMargin,
+      """def foo(a: Int, b: Int = 1) = Foo(a, b).sum
         |foo(1)
       """.stripMargin,
       "val a = foo(2, 3)",
-      "val b = foo(2)"
+      "val b = foo(2)",
+      "val c = Foo(2, 3).sum"
     )
     assertSparkScalaOutput(code) { case (vars, output, displayed) =>
-      vars("Out") shouldEqual 2
-      vars("a") shouldEqual 5
-      vars("b") shouldEqual 3
+      vars("Out") shouldEqual 3
+      vars("a") shouldEqual 6
+      vars("b") shouldEqual 4
+      vars("c") shouldEqual 6
     }
   }
 }


### PR DESCRIPTION
Resolves #370 (lazy vals) and also an issue where the `f$default$n` method generated for default function arguments was being generated twice. 