### PR TITLE
Prefer the `key` field of keyboard events

### DIFF
--- a/polynote-frontend/polynote/keypress.js
+++ b/polynote-frontend/polynote/keypress.js
@@ -29,7 +29,8 @@ export class KeyPress {
     }
 
     matches(keyPressEvent) {
-        return (this.key === keyPressEvent.code) || (this.key === keyPressEvent.key) &&
+        const key = (keyPressEvent.browserEvent && keyPressEvent.browserEvent.key) || keyPressEvent.key || keyPressEvent.code;
+        return this.key === key &&
             this.ctrl === keyPressEvent.ctrlKey &&
             this.shift === keyPressEvent.shiftKey &&
             this.alt === keyPressEvent.altKey &&
@@ -38,8 +39,9 @@ export class KeyPress {
     }
 
     static fromEvent(keyPressEvent) {
+        const key = (keyPressEvent.browserEvent && keyPressEvent.browserEvent.key) || keyPressEvent.key || keyPressEvent.code;
         return new KeyPress(
-            keyPressEvent.code || keyPressEvent.key,
+            key,
             keyPressEvent.ctrlKey,
             keyPressEvent.shiftKey,
             keyPressEvent.altKey,


### PR DESCRIPTION
This is because the `code` field of keyboard events is not as useful:

* It doesn't know about the user's keyboard layout, so it will be wrong for people with different layouts from US QUERTY
* It treats keys positionally, e.g. `NumpadEnter` vs `Enter` or `LeftShift` vs `Shift`

Therefore we should use the `key` field, which is semantically useful. Unfortunately it seems the events we get from Monaco don't have this, and it's hidden behind `browserEvent`. I'm not sure why that is, but at least `browserEvent` is there.

Fixes #383