### PR TITLE
Use daemon threads, remote kernel waits for subprocess exit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ libjep.dylib
 scripts/dist-config.yml
 *.zip
 tmp/
+config.yml
+metastore_db
+*.log
+tmp

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 name := "polynote"
 
 lazy val buildUI: TaskKey[Unit] = taskKey[Unit]("Building UI...")
+lazy val runAssembly: TaskKey[Unit] = taskKey[Unit]("Running spark server from assembly...")
 
 val versions = new {
   val http4s     = "0.20.6"
@@ -12,6 +13,8 @@ val versions = new {
   val spark      = "2.1.1"
 }
 
+def nativeLibraryPath = s"${sys.env.get("JAVA_LIBRARY_PATH") orElse sys.env.get("LD_LIBRARY_PATH") orElse sys.env.get("DYLD_LIBRARY_PATH") getOrElse "."}:."
+
 val commonSettings = Seq(
   version := "0.1.19-SNAPSHOT",
   scalaVersion := "2.11.11",
@@ -21,7 +24,7 @@ val commonSettings = Seq(
     "-unchecked"
   ),
   fork in Test := true,
-  javaOptions in Test += s"-Djava.library.path=${sys.env.get("JAVA_LIBRARY_PATH") orElse sys.env.get("LD_LIBRARY_PATH") orElse sys.env.get("DYLD_LIBRARY_PATH") getOrElse "."}",
+  javaOptions in Test += s"-Djava.library.path=$nativeLibraryPath",
   libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest" % "3.0.5" % "test",
     "org.scalacheck" %% "scalacheck" % "1.14.0" % "test"
@@ -33,6 +36,7 @@ val commonSettings = Seq(
       val oldStrategy = (assemblyMergeStrategy in assembly).value
       oldStrategy(x)
   },
+  cancelable in Global := true,
   addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.7"),
   buildUI := {
     sys.process.Process(Seq("npm", "run", "build"), new java.io.File("./polynote-frontend/")) ! streams.value.log
@@ -140,7 +144,23 @@ lazy val `polynote-spark` = project.settings(
     )
   }.taskValue,
   fork in Test := true,
-  parallelExecution in Test := false
+  parallelExecution in Test := false,
+  mainClass in (runAssembly in Compile) := None,
+  test in assembly := {},
+  javaOptions in runAssembly := Seq(s"-Djava.library.path=$nativeLibraryPath"),
+  runAssembly := {
+    val assemblyJar = assembly.value
+    val mainClassName = (mainClass in runAssembly).value.getOrElse("polynote.server.SparkServer")
+    val log = streams.value.log
+    val deps = (dependencyClasspath in Compile).value.files
+    val scalaDeps = deps.filter(_.getName.matches(".*scala-(library|reflect|compiler|collection-compat|xml).*")).toList
+    println(scalaDeps)
+    val fo = ForkOptions()
+      .withRunJVMOptions((javaOptions in runAssembly).value.toVector)
+      .withWorkingDirectory(baseDirectory.value.getParentFile)
+    val exit = new ForkRun(fo).fork(mainClassName, assemblyJar :: scalaDeps, Nil, log).exitValue()
+    log.info(s"Assembly run exited with $exit")
+  }
 ) dependsOn (`polynote-server` % "compile->compile;test->test", `polynote-spark-runtime`)
 
-val polynote = project.in(file(".")).aggregate(`polynote-kernel`, `polynote-server`, `polynote-spark`)
+lazy val polynote = project.in(file(".")).aggregate(`polynote-kernel`, `polynote-server`, `polynote-spark`)

--- a/polynote-kernel/src/main/scala/polynote/kernel/PolyKernel.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/PolyKernel.scala
@@ -43,7 +43,7 @@ class PolyKernel private[kernel] (
 
   protected val logger: PolyLogger = new PolyLogger
 
-  protected implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.fromExecutorService(Executors.newCachedThreadPool()))
+  protected implicit val contextShift: ContextShift[IO] = IO.contextShift(kernelContext.executionContext)
 
   private val launchingInterpreter = Semaphore[IO](1).unsafeRunSync()
   private val interpreters = new ConcurrentHashMap[String, LanguageInterpreter[IO]]()

--- a/polynote-kernel/src/main/scala/polynote/kernel/dependency/CoursierFetcher.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/dependency/CoursierFetcher.scala
@@ -18,7 +18,7 @@ import coursier.params.ResolutionParams
 import coursier.{Artifacts, Attributes, Dependency, MavenRepository, Module, ModuleName, Organization, Repository, Resolution, Resolve}
 import polynote.config.{RepositoryConfig, ivy, maven}
 import polynote.kernel._
-import polynote.kernel.util.Publish
+import polynote.kernel.util.{Publish, newDaemonThreadPool}
 import polynote.messages.TinyString
 
 import scala.concurrent.ExecutionContext
@@ -27,7 +27,7 @@ import scala.concurrent.ExecutionContext
 // Fetches only Scala dependencies
 class CoursierFetcher(val path: String, val taskInfo: TaskInfo, val statusUpdates: Publish[IO, KernelStatusUpdate]) extends ScalaDependencyFetcher {
 
-  protected implicit val executionContext: ExecutionContext = ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
+  protected implicit val executionContext: ExecutionContext = ExecutionContext.fromExecutorService(newDaemonThreadPool("coursier"))
   protected implicit val contextShift: ContextShift[IO] =  IO.contextShift(executionContext)
 
   private val excludedOrgs = Set(Organization("org.scala-lang"), Organization("org.apache.spark"))

--- a/polynote-kernel/src/main/scala/polynote/kernel/dependency/IvyFetcher.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/dependency/IvyFetcher.scala
@@ -24,14 +24,14 @@ import org.apache.ivy.plugins.resolver.util.ResolvedResource
 import org.apache.ivy.plugins.resolver.{CacheResolver, ChainResolver, IBiblioResolver, URLResolver}
 import org.apache.ivy.util.filter.{Filter => IvyFilter}
 import polynote.config.{PolyLogger, RepositoryConfig, ivy, maven}
-import polynote.kernel.util.Publish
+import polynote.kernel.util.{Publish, newDaemonThreadPool}
 import polynote.kernel.{KernelStatusUpdate, TaskInfo, TaskStatus, UpdatedTasks}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
 class IvyFetcher(val path: String, val taskInfo: TaskInfo, val statusUpdates: Publish[IO, KernelStatusUpdate]) extends ScalaDependencyFetcher {
-  protected implicit val executionContext: ExecutionContext = ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
+  protected implicit val executionContext: ExecutionContext = ExecutionContext.fromExecutorService(newDaemonThreadPool("ivy"))
   protected implicit val contextShift: ContextShift[IO] =  IO.contextShift(executionContext)
 
   private val logger = new PolyLogger

--- a/polynote-kernel/src/main/scala/polynote/kernel/util/KernelContext.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/KernelContext.scala
@@ -39,13 +39,7 @@ final case class KernelContext(global: Global, classPath: List[File], classLoade
 
   val runtimeTools: ToolBox[ru.type] = runtimeMirror.mkToolBox()
 
-  val executor: ExecutorService = Executors.newCachedThreadPool(new ThreadFactory {
-    def newThread(r: Runnable): Thread = {
-      val thread = new Thread(r)
-      thread.setContextClassLoader(classLoader)
-      thread
-    }
-  })
+  val executor: ExecutorService = newDaemonThreadPool("kernel", Some(classLoader))
 
   val executionContext: ExecutionContext = ExecutionContext.fromExecutorService(executor)
 

--- a/polynote-spark/src/main/scala/polynote/kernel/remote/RemoteSparkKernel.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/remote/RemoteSparkKernel.scala
@@ -143,13 +143,13 @@ class RemoteSparkKernel(
   } yield ()
 
   def shutdown(): IO[Unit] =
-    initialize.tryCancel() *>
-      (IO(logger.info("Shutting down remote kernel")) *>
-        request1[UnitResponse](Shutdown(_)) *>
+    initialize.tryCancel() >>
+      (IO(logger.info("Shutting down remote kernel")) >>
+        request1[UnitResponse](Shutdown(_)) >>
         IO(logger.info("Remote kernel notified of shutdown"))).guarantee(
-          cancelRequests() *>
-          shutdownSignal.complete *>
-          transport.close() *>
+          cancelRequests() >>
+          shutdownSignal.complete >>
+          transport.close() >>
           IO(logger.info("Kernel server stopped")))
 
   def startInterpreterFor(cell: CellID): IO[Stream[IO, Result]] = for {

--- a/polynote-spark/src/main/scala/polynote/server/SparkServer.scala
+++ b/polynote-spark/src/main/scala/polynote/server/SparkServer.scala
@@ -76,7 +76,9 @@ class SparkKernelFactory(implicit
     statusUpdates: Publish[IO, KernelStatusUpdate],
     polynoteConfig: PolynoteConfig
   ): IO[KernelAPI[IO]] = if (polynoteConfig.spark.get("polynote.kernel.remote") contains "true") {
-    new SparkRemoteKernelFactory(new SocketTransport).launchKernel(getNotebook, statusUpdates, polynoteConfig)
+    new SparkRemoteKernelFactory(
+      new SocketTransport(forceServerAddress = polynoteConfig.spark.get("polynote.kernel.forceRemoteAddress"))
+    ).launchKernel(getNotebook, statusUpdates, polynoteConfig)
   } else {
     super.launchKernel(getNotebook, statusUpdates, polynoteConfig)
   }


### PR DESCRIPTION
- Use daemon threads everywhere. Otherwise we won't shut down when our main is done.
- Remote kernel transport waits for subprocess to exit before reporting itself as closed. This fixes an issue with restarting remote kernels (trying to start the new one before the old one is really shut down)

Together these make remote kernel killing and restarting work, which previously it didn't.