### PR TITLE
Support a shading-friendly configuration option

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
@@ -25,13 +25,23 @@ object Storage {
   implicit val decoder: Decoder[Storage] = deriveDecoder
 }
 
+final case class Behavior(
+  dependencyIsolation: Boolean = true
+)
+
+object Behavior {
+  implicit val encoder: ObjectEncoder[Behavior] = deriveEncoder
+  implicit val decoder: Decoder[Behavior] = deriveDecoder
+}
+
 final case class PolynoteConfig(
   listen: Listen = Listen(),
   storage: Storage = Storage(),
   repositories: List[RepositoryConfig] = Nil,
   exclusions: List[String] = Nil,
   dependencies: Map[String, List[String]] = Map.empty,
-  spark: Map[String, String] = Map.empty
+  spark: Map[String, String] = Map.empty,
+  behavior: Behavior = Behavior()
 )
 
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/PolyKernel.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/PolyKernel.scala
@@ -342,7 +342,7 @@ object PolyKernel {
     config: PolynoteConfig
   ): PolyKernel = {
 
-    val kernelContext = KernelContext(dependencies, statusUpdates, baseSettings, extraClassPath, outputDir, parentClassLoader)
+    val kernelContext = KernelContext(config, dependencies, statusUpdates, baseSettings, extraClassPath, outputDir, parentClassLoader)
 
     new PolyKernel(
       getNotebook,

--- a/polynote-kernel/src/main/scala/polynote/kernel/util/KernelContext.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/KernelContext.scala
@@ -203,38 +203,15 @@ object KernelContext {
   def defaultOutputDir: AbstractFile = new VirtualDirectory("(memory)", None)
   def defaultParentClassLoader: ClassLoader = getClass.getClassLoader
 
-  def genNotebookClassLoader(
-    dependencies: Map[String, List[(String, File)]],
-    extraClassPath: List[File],
-    outputDir: AbstractFile,
-    parentClassLoader: ClassLoader
-  ): AbstractFileClassLoader = {
-
-    def dependencyClassPath: Seq[URL] = dependencies.toSeq.flatMap(_._2).collect {
-      case (_, file) if (file.getName endsWith ".jar") && file.exists() => file.toURI.toURL
-    }
-
-    /**
-      * The class loader which loads the dependencies
-      */
-    val dependencyClassLoader: URLClassLoader = new LimitedSharingClassLoader(
-      "^(scala|javax?|jdk|sun|com.sun|com.oracle|polynote|org.w3c|org.xml|org.omg|org.ietf|org.jcp|org.apache.spark|org.apache.hadoop|org.codehaus|org.slf4j|org.log4j)\\.",
-      dependencyClassPath,
-      parentClassLoader)
-
-    /**
-      * The class loader which loads the JVM-based notebook cell classes
-      */
-    new AbstractFileClassLoader(outputDir, dependencyClassLoader)
-  }
-
   def default(
+    config: PolynoteConfig,
     dependencies: Map[String, DependencyProvider],
     statusUpdates: Publish[IO, KernelStatusUpdate],
     extraClassPath: List[File]
-  ): KernelContext = apply(dependencies, statusUpdates, defaultBaseSettings, extraClassPath, defaultOutputDir, defaultParentClassLoader)
+  ): KernelContext = apply(config, dependencies, statusUpdates, defaultBaseSettings, extraClassPath, defaultOutputDir, defaultParentClassLoader)
 
   def apply(
+    config: PolynoteConfig,
     dependencyProviders: Map[String, DependencyProvider],
     statusUpdates: Publish[IO, KernelStatusUpdate],
     baseSettings: Settings,
@@ -283,7 +260,7 @@ object KernelContext {
 
     val notebookClassLoader = dependencyProviders.get("scala")
       .flatMap(_.as[ClassLoaderDependencyProvider].toOption)
-      .map(_.genNotebookClassLoader(extraClassPath, outputDir, parentClassLoader))
+      .map(_.genNotebookClassLoader(config, extraClassPath, outputDir, parentClassLoader))
       .getOrElse(throw new IllegalArgumentException(s"Couldn't find `scala` dependency provider! Available providers: $dependencyProviders"))
 
     KernelContext(global, classPath, notebookClassLoader)

--- a/polynote-kernel/src/test/scala/polynote/kernel/lang/KernelSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/lang/KernelSpec.scala
@@ -13,6 +13,7 @@ import cats.syntax.apply._
 import cats.syntax.either._
 import fs2.Stream
 import fs2.concurrent.Topic
+import polynote.config.PolynoteConfig
 import polynote.kernel._
 import polynote.kernel.dependency.{ClassLoaderDependencyProvider, DependencyManager, DependencyProvider}
 import polynote.kernel.lang.python.{PythonInterpreter, VirtualEnvDependencyProvider, VirtualEnvManager}
@@ -54,10 +55,14 @@ trait KernelSpec {
       (_, vars, output, displayed) => IO(assertion(vars, output, displayed))
     }
 
-  def getKernelContext(updates: Topic[IO, KernelStatusUpdate]): KernelContext = KernelContext.default(Map(
-    "scala" -> new MockCLDepProvider,
-    "python" -> MockVenvDepProvider(updates)
-  ), updates, Nil)
+  def getKernelContext(updates: Topic[IO, KernelStatusUpdate]): KernelContext = KernelContext.default(
+    PolynoteConfig(),
+    Map(
+      "scala" -> new MockCLDepProvider,
+      "python" -> MockVenvDepProvider(updates)
+    ),
+    updates,
+    Nil)
 
   // TODO: for unit tests we'd ideally want to hook directly to runCode without needing all this!
   def assertOutputWith[K <: LanguageInterpreter[IO]](mkInterp: (KernelContext, Topic[IO, KernelStatusUpdate]) => K, code: Seq[String])(assertion: (K, Map[String, Any], Seq[Result], Seq[(String, String)]) => IO[Unit]): Unit = {

--- a/polynote-spark/src/main/scala/polynote/kernel/SparkPolyKernel.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/SparkPolyKernel.scala
@@ -184,7 +184,7 @@ object SparkPolyKernel {
       .map(new File(_))
       .filter(file => io.AbstractFile.getURL(file.toURI.toURL) != null)
 
-    val kernelContext = KernelContext(dependencies, statusUpdates, baseSettings, extraClassPath ++ sparkClasspath, outputDir, parentClassLoader)
+    val kernelContext = KernelContext(config, dependencies, statusUpdates, baseSettings, extraClassPath ++ sparkClasspath, outputDir, parentClassLoader)
 
     val kernel = new SparkPolyKernel(
       getNotebook,


### PR DESCRIPTION
Adds an option `dependency_isolation` to allow you to disable this feature of polynote. It doesn't seem to play nice with shading, which is necessary when there's no dependency isolation, so we need to be able to disable dependency isolation for when there's shading due to no dependency isolation GAAAAAAAHHHHHHHHH!