### PR TITLE
fix pyspark restart issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk:
 
 before_install:
   - pyenv global 3.7.1
-  - pip install virtualenv ipython nbconvert jedi numpy scipy pyspark==2.1.2 jep
+  - pip install virtualenv ipython nbconvert jedi numpy scipy pyspark==2.1.2 jep==3.8.2
   - jep_site_packages_path=`pip show jep | grep "^Location:" | cut -d ':' -f 2 | cut -d ' ' -f 2`
   - jep_path=${jep_site_packages_path}/jep
   - jep_lib_path=`realpath ${jep_site_packages_path}/../../`

--- a/polynote-kernel/src/main/scala/polynote/kernel/PolyKernel.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/PolyKernel.scala
@@ -26,6 +26,7 @@ import polynote.runtime.{LazyDataRepr, StreamingDataRepr, TableOp, UpdatingDataR
 import scodec.bits.ByteVector
 
 import scala.concurrent.ExecutionContext
+import scala.collection.JavaConverters._
 import scala.concurrent.duration.MILLISECONDS
 import scala.collection.immutable.SortedMap
 import scala.reflect.io.{AbstractFile, VirtualDirectory}
@@ -258,7 +259,9 @@ class PolyKernel private[kernel] (
     }
   }
 
-  def shutdown(): IO[Unit] = taskManager.shutdown()
+  def shutdown(): IO[Unit] = {
+      interpreters.values.asScala.toList.map(_.shutdown()).sequence >> taskManager.shutdown()
+  }
 
   def info: IO[Option[KernelInfo]] = IO.pure(
     // TODO: This should really be in the ServerHandshake as it isn't a Kernel-level thing...

--- a/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/lang/python/PythonInterpreter.scala
@@ -30,8 +30,9 @@ class PythonInterpreter(val kernelContext: KernelContext, dependencyProvider: De
 
   val predefCode: Option[String] = None
 
-  override def shutdown(): IO[Unit] = shutdownSignal.complete.flatMap(_ => withJep(jep.close()))
-
+  override def shutdown(): IO[Unit] = shutdownSignal.complete
+    .flatMap(_ => withJep(jep.close()))
+    .start.as(()) // this is probably a bad thing. Since jep.close seems to hang, we just punt for now and let that thread do whatever it's trying to do on its own time.
 
   override def init(): IO[Unit] = preInit >> setup() >> postInit
 
@@ -160,6 +161,7 @@ class PythonInterpreter(val kernelContext: KernelContext, dependencyProvider: De
       def call(): Jep = {
         // TODO: this is how to use jep installed inside a venv. it would only work for remote kernels though.
         //       if we ever decide to move towards remote kernels being the only option then we can use this approach
+        //       **** we'd need to load the jep library though ****
 //        venvProvider.right.toOption.flatMap(_.venvPath).foreach {
 //          path =>
 //            MainInterpreter.setInitParams(new PyConfig().setPythonHome(path))

--- a/polynote-spark/src/main/scala/polynote/kernel/SparkPolyKernel.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/SparkPolyKernel.scala
@@ -158,7 +158,7 @@ class SparkPolyKernel(
 
   override def cancelTasks(): IO[Unit] = super.cancelTasks() >> IO(DAGSchedulerThief(session).foreach(_.cancelAllJobs()))
 
-  override def shutdown(): IO[Unit] = super.shutdown() >> cancelTasks() >> contextShift.evalOn(ctx.executionContext)(IO(session.stop())) >> IO(logger.info("Stopped spark session"))
+  override def shutdown(): IO[Unit] = cancelTasks() >> contextShift.evalOn(ctx.executionContext)(IO(session.stop())) >> super.shutdown() >> IO(logger.info("Stopped spark session"))
 }
 
 object SparkPolyKernel {


### PR DESCRIPTION
Resolves #433 

Also hooks up interpreter's `shutdown` methods, which weren't called anywhere (but they haven't really done anything until now). 

Unfortunately I had to do quite a bit of hacking around annoying jep/pyspark related things :( 