### PR TITLE
Fix issue with blank executors page in spark UI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val versions = new {
 def nativeLibraryPath = s"${sys.env.get("JAVA_LIBRARY_PATH") orElse sys.env.get("LD_LIBRARY_PATH") orElse sys.env.get("DYLD_LIBRARY_PATH") getOrElse "."}:."
 
 val commonSettings = Seq(
-  version := "0.1.24-SNAPSHOT",
+  version := "0.2.1-SNAPSHOT",
   scalaVersion := "2.11.11",
   scalacOptions ++= Seq(
     "-Ypartial-unification",

--- a/polynote-frontend/package-lock.json
+++ b/polynote-frontend/package-lock.json
@@ -19,9 +19,9 @@
       "integrity": "sha512-mky/O83TXmGY39P1H9YbUpjV6l6voRYlufqfFCvel8l1phuy8HRjdWc1rrPuN53ITBJlbyMSV6z3niOySO5pgQ=="
     },
     "@types/katex": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.10.2.tgz",
-      "integrity": "sha512-QYTNuhuDU22gouVoL5kLmBTguu2rPvtp7wL5U5fTFsQkM1ojfUgxFPMFrqOSUofrdWwnZEmblcobdlLXj1lVOw=="
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.10.1.tgz",
+      "integrity": "sha512-jU8eRIZQGUEU/M+IUB4/3vA68EjJJhuMGxrTFBKssNphM1mMfnoDp9abrMFYRR0ECjBdaE0p8hCk7vmhJ4l1gw=="
     },
     "@types/node": {
       "version": "10.12.18",
@@ -3216,9 +3216,9 @@
       }
     },
     "linkify-it": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.1.0.tgz",
-      "integrity": "sha512-4REs8/062kV2DSHxNfq5183zrqXMl7WP0WzABH9IeJI+NLm429FgE1PDecltYfnOoFDFlZGh2T8PfZn0r+GTRg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
       "requires": {
         "uc.micro": "^1.0.1"
       }
@@ -3309,9 +3309,9 @@
       }
     },
     "markdown-it": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-9.0.0.tgz",
-      "integrity": "sha512-bUVTYGt/K/mYr3HlE+PBe6TOTyWghcpSZqOD9t+NFRlwJMhp9Kp6WQ8fJ26I6v1Xo71UmPYt1S4Hc9Lq8GZx2Q==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-9.0.1.tgz",
+      "integrity": "sha512-XC9dMBHg28Xi7y5dPuLjM61upIGPJG8AiHNHYqIaXER2KNnn7eKnM5/sF0ImNnyoV224Ogn9b1Pck8VH4k0bxw==",
       "requires": {
         "argparse": "^1.0.7",
         "entities": "~1.1.1",
@@ -5821,9 +5821,9 @@
       }
     },
     "webpack-cli": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.5.tgz",
-      "integrity": "sha512-w0j/s42c5UhchwTmV/45MLQnTVwRoaUTu9fM5LuyOd/8lFoCNCELDogFoecx5NzRUndO0yD/gF2b02XKMnmAWQ==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.6.tgz",
+      "integrity": "sha512-0vEa83M7kJtxK/jUhlpZ27WHIOndz5mghWL2O53kiDoA9DIxSKnfqB92LoqEn77cT4f3H2cZm1BMEat/6AZz3A==",
       "dev": true,
       "requires": {
         "chalk": "2.4.2",

--- a/polynote-kernel/src/main/scala/polynote/kernel/Kernel.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/Kernel.scala
@@ -11,24 +11,24 @@ trait Kernel {
     * Enqueues a cell to be run with its appropriate interpreter. Evaluating the outer task causes the cell to be
     * queued, and evaluating the inner task blocks until it is finished evaluating.
     */
-  def queueCell(id: CellID): TaskR[BaseEnv with GlobalEnv with CellEnv, Task[Unit]]
+  def queueCell(id: CellID): TaskC[Task[Unit]]
 
   def cancelAll(): TaskR[BaseEnv with TaskManager, Unit] = TaskManager.access.flatMap(_.cancelAll())
 
   /**
     * Provide completions for the given position in the given cell
     */
-  def completionsAt(id: CellID, pos: Int): TaskR[BaseEnv with GlobalEnv with CellEnv, List[Completion]]
+  def completionsAt(id: CellID, pos: Int): TaskC[List[Completion]]
 
   /**
     * Provide parameter hints for the given position in the given cell
     */
-  def parametersAt(id: CellID, pos: Int): TaskR[BaseEnv with GlobalEnv with CellEnv, Option[Signatures]]
+  def parametersAt(id: CellID, pos: Int): TaskC[Option[Signatures]]
 
   /**
     * Perform any initialization for the kernel
     */
-  def init(): TaskR[BaseEnv with GlobalEnv with CellEnv, Unit]
+  def init(): TaskC[Unit]
 
   /**
     * Shut down this kernel and its interpreters, releasing their resources and ending any internally managed tasks or processes

--- a/polynote-kernel/src/main/scala/polynote/kernel/LocalKernel.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/LocalKernel.scala
@@ -164,7 +164,7 @@ class LocalKernel private[kernel] (
       cell        <- CurrentNotebook.getCell(id)
       state       <- interpreterState.get.orDie
       prevCells    = notebook.cells.takeWhile(_.id != cell.id)
-      prevState    = prevCells.reverse.map(_.id).flatMap(state.at).headOption.getOrElse(State.Root)
+      prevState    = prevCells.reverse.map(_.id).flatMap(state.at).headOption.getOrElse(latestPredef(state))
       interpreter <-
         if (forceStart)
           getOrLaunch(cell.language, id).provideSomeM(Env.enrichM[BaseEnv with GlobalEnv with CellEnv](

--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/protocol.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/protocol.scala
@@ -3,7 +3,7 @@ package polynote.kernel.remote
 import java.nio.charset.StandardCharsets
 
 import polynote.config.PolynoteConfig
-import polynote.kernel.{Completion, KernelBusyState, KernelStatusUpdate, Result, ResultValue, Signatures}
+import polynote.kernel.{Completion, KernelBusyState, KernelInfo, KernelStatusUpdate, Result, ResultValue, Signatures}
 import polynote.messages._
 import polynote.runtime.{StreamingDataRepr, TableOp}
 import scodec.codecs.{Discriminated, Discriminator, byte}
@@ -76,6 +76,9 @@ object UpdateNotebookRequest extends RemoteRequestCompanion[UpdateNotebookReques
 final case class CancelAllRequest(reqId: Int) extends RemoteRequest
 object CancelAllRequest extends RemoteRequestCompanion[CancelAllRequest](12)
 
+final case class KernelInfoRequest(reqId: Int) extends RemoteRequest
+object KernelInfoRequest extends RemoteRequestCompanion[KernelInfoRequest](13)
+
 object RemoteRequest {
   implicit val discriminated: Discriminated[RemoteRequest, Byte] = Discriminated(byte)
   implicit val codec: Codec[RemoteRequest] = cachedImplicit
@@ -134,6 +137,8 @@ object GetHandleDataResponse extends RemoteResponseCompanion[GetHandleDataRespon
 final case class ModifyStreamResponse(reqId: Int, result: Option[StreamingDataRepr]) extends RemoteRequestResponse
 object ModifyStreamResponse extends RemoteResponseCompanion[ModifyStreamResponse](9)
 
+final case class KernelInfoResponse(reqId: Int, info: KernelInfo) extends RemoteRequestResponse
+object KernelInfoResponse extends RemoteResponseCompanion[KernelInfoResponse](13)
 
 object RemoteResponse {
   implicit val discriminated: Discriminated[RemoteResponse, Byte] = Discriminated(byte)

--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/transport.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/transport.scala
@@ -231,6 +231,7 @@ object SocketTransport {
 
         val processBuilder = new ProcessBuilder(command: _*).inheritIO()
         for {
+          _       <- Logging.info(s"Deploying with command:\n$displayCommand")
           process <- effectBlocking(processBuilder.start())
         } yield new DeploySubprocess.Subprocess(process)
     }

--- a/polynote-kernel/src/test/scala/polynote/kernel/remote/RemoteKernelSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/remote/RemoteKernelSpec.scala
@@ -4,7 +4,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FreeSpec, Matchers}
 import polynote.kernel.Kernel.Factory
 import polynote.kernel.environment.{NotebookUpdates, PublishResult, PublishStatus}
-import polynote.kernel.{BaseEnv, CellEnv, Completion, CompletionType, GlobalEnv, Kernel, KernelBusyState, Output, ParameterHint, ParameterHints, ResultValue, Signatures, TaskInfo, UpdatedTasks}
+import polynote.kernel.{BaseEnv, CellEnv, Completion, CompletionType, GlobalEnv, Kernel, KernelBusyState, KernelInfo, Output, ParameterHint, ParameterHints, ResultValue, Signatures, TaskInfo, UpdatedTasks}
 import polynote.kernel.logging.Logging
 import polynote.messages._
 import polynote.runtime.ReprsOf.DataReprsOf
@@ -67,6 +67,12 @@ class RemoteKernelSpec extends FreeSpec with Matchers with ZIOSpec with BeforeAn
         val status = KernelBusyState(busy = false, alive = true)
         (kernel.status _).expects().returning(ZIO.succeed(status))
         unsafeRun(remoteKernel.status()) shouldEqual status
+      }
+
+      "info" in {
+        val info = KernelInfo("foo" -> "bar", "baz" -> "buzz")
+        (kernel.info _).expects().returning(ZIO.succeed(info))
+        unsafeRun(remoteKernel.info().provide(env)) shouldEqual info
       }
 
       "values" in {

--- a/polynote-spark/src/main/scala/polynote/kernel/remote/DeploySparkSubmit.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/remote/DeploySparkSubmit.scala
@@ -31,8 +31,12 @@ object DeploySparkSubmit extends DeployCommand {
     val sparkSubmitArgs = sparkConfig.get("sparkSubmitArgs").toList.flatMap(parseQuotedArgs)
 
     val isRemote = sparkConfig.get("spark.submit.deployMode") contains "cluster"
-    val libraryPath = List(sys.props.get("java.library.path"), sys.env.get("LD_LIBRARY_PATH")).flatten.mkString(File.pathSeparator)
-    val javaOptions = sys.props.toMap ++ Map(
+    val libraryPath = List(sys.props.get("java.library.path"), sys.env.get("LD_LIBRARY_PATH"))
+      .flatten
+      .map(_.trim().stripPrefix(File.pathSeparator).stripSuffix(File.pathSeparator))
+      .mkString(File.pathSeparator)
+    
+    val javaOptions = Map(
       "log4j.configuration" -> "log4j.properties",
       "java.library.path"   -> libraryPath
     )


### PR DESCRIPTION
- Don't give scala jars to spark; it has its own already
- Don't start spark session in the notebook classloader; this breaks its ui by screwing up the runtime dependency injection.
- Remote kernel properly provides kernel info
- Add `LD_LIBRARY_PATH` to `java.library.path` when deploying `spark-submit`