### PR TITLE
Fix spark output path

### DIFF
--- a/polynote-server/src/main/scala/polynote/server/SocketSession.scala
+++ b/polynote-server/src/main/scala/polynote/server/SocketSession.scala
@@ -15,7 +15,7 @@ import org.http4s.websocket.WebSocketFrame.Binary
 import polynote.buildinfo.BuildInfo
 import polynote.kernel
 import polynote.kernel.util.{Publish, RefMap}
-import polynote.kernel.{BaseEnv, ClearResults, GlobalEnv, StreamOps, StreamingHandles, TaskG, UpdatedTasks}
+import polynote.kernel.{BaseEnv, ClearResults, GlobalEnv, Kernel, StreamOps, StreamingHandles, TaskG, UpdatedTasks}
 import polynote.kernel.environment.{Env, PublishMessage}
 import polynote.kernel.interpreter.Interpreter
 import polynote.kernel.logging.Logging
@@ -90,6 +90,12 @@ class SocketSession(
       }
 
     case LoadNotebook(path) =>
+      def publishRunningKernelState(publisher: KernelPublisher) = for {
+        kernel <- publisher.kernel
+        _      <- kernel.values().flatMap(_.map(rv => PublishMessage(CellResult(path, rv.sourceCell, rv))).sequence)
+        _      <- kernel.info().map(KernelStatus(path, _)) >>= PublishMessage.apply
+      } yield ()
+
       subscribe(path).flatMap {
         subscriber =>
           for {
@@ -97,9 +103,7 @@ class SocketSession(
             _        <- PublishMessage(notebook)
             status   <- subscriber.publisher.kernelStatus()
             _        <- PublishMessage(KernelStatus(path, status))
-            values   <- if (status.alive) subscriber.publisher.kernel.flatMap(_.values()) else ZIO.succeed(Nil)
-            _        <- values.map(rv => CellResult(path, rv.sourceCell, rv)).map(PublishMessage.apply).sequence
-            _        <- if (status.alive) subscriber.publisher.kernel.flatMap(_.info()).map(KernelStatus(path, _)).flatMap(PublishMessage.apply) else ZIO.unit
+            _        <- if (status.alive) publishRunningKernelState(subscriber.publisher) else ZIO.unit
             tasks    <- subscriber.publisher.taskManager.list
             _        <- PublishMessage(KernelStatus(path, UpdatedTasks(tasks)))
           } yield ()

--- a/polynote-spark/src/main/scala/polynote/kernel/LocalSparkKernel.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/LocalSparkKernel.scala
@@ -131,7 +131,6 @@ class LocalSparkKernelFactory extends Kernel.Factory.Service {
           thread.setName("Spark session")
           thread.setDaemon(true)
           thread.setContextClassLoader(classLoader)
-          thread.getThreadGroup
           thread
         }
       }


### PR DESCRIPTION
- When creating the spark kernel, the settings were being updated to use Spark's output path, but those settings weren't actually getting used in constructing the compiler. Refactoring fail.
- Also have the socket session give you the `KernelInfo` on loading a notebook if the kernel is already running (otherwise when you refresh you lose the kernel info)