### PR TITLE
More completion fix

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/ScalaCompleter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/ScalaCompleter.scala
@@ -159,13 +159,13 @@ class ScalaCompleter[Compiler <: ScalaCompiler](val compiler: Compiler) {
   private def isVisibleSymbol(sym: Symbol) =
     sym.isPublic && !sym.isSynthetic && !sym.isConstructor && !sym.isOmittablePrefix && !sym.name.decodedName.containsChar('$')
 
-  private def deepestSubtreeEndingAt(tree: Tree, offset: Int): Tree = {
-    var deepest: Tree = tree
+  private def deepestSubtreeEndingAt(topTree: Tree, offset: Int): Tree = {
+    var deepest: Tree = topTree
     val traverser: Traverser = new Traverser {
       private var depth = 0
       private var deepestDepth = -1
       override def traverse(tree: compiler.global.Tree): Unit = {
-        if (tree.pos != null && tree.pos.isDefined && !tree.pos.isTransparent && tree.pos.end == offset && depth >= deepestDepth) {
+        if (tree.pos != null && tree.pos.isDefined && !tree.pos.isTransparent && (tree.pos.source eq topTree.pos.source) && tree.pos.end == offset && depth >= deepestDepth) {
           deepest = tree
           deepestDepth = depth
         }
@@ -174,7 +174,7 @@ class ScalaCompleter[Compiler <: ScalaCompiler](val compiler: Compiler) {
         depth -= 1
       }
     }
-    traverser.traverse(tree)
+    traverser.traverse(topTree)
     deepest
   }
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/ScalaInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/ScalaInterpreter.scala
@@ -37,14 +37,14 @@ class ScalaInterpreter private[scal] (
   override def completionsAt(code: String, pos: Int, state: State): Task[List[Completion]] = for {
     collectedState   <- injectState(collectState(state)).provide(CurrentRuntime.NoCurrentRuntime)
     valDefs           = collectedState.values.mapValues(_._1).values.toList
-    cellCode         <- scalaCompiler.cellCode(s"Cell${state.id.toString}", s"\n$code", collectedState.prevCells, valDefs, collectedState.imports, strictParse = false)
+    cellCode         <- scalaCompiler.cellCode(s"Cell${state.id.toString}", s"\n${code.substring(0, pos)}", collectedState.prevCells, valDefs, collectedState.imports, strictParse = false)
   } yield completer.completions(cellCode, pos + 1)
 
   override def parametersAt(code: String, pos: Int, state: State): Task[Option[Signatures]] = for {
     collectedState <- injectState(collectState(state)).provide(CurrentRuntime.NoCurrentRuntime)
     valDefs         = collectedState.values.mapValues(_._1).values.toList
-    cellCode         <- scalaCompiler.cellCode(s"Cell${state.id.toString}", code, collectedState.prevCells, valDefs, collectedState.imports, strictParse = false)
-  } yield completer.paramHints(cellCode, pos)
+    cellCode         <- scalaCompiler.cellCode(s"Cell${state.id.toString}", s"\n$code", collectedState.prevCells, valDefs, collectedState.imports, strictParse = false)
+  } yield completer.paramHints(cellCode, pos + 1)
 
   override def init(state: State): TaskR[InterpreterEnv, State] = ZIO.succeed(state)
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/RemoteKernel.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/RemoteKernel.scala
@@ -197,7 +197,9 @@ class RemoteKernelClient(
 
   def run(): TaskR[KernelEnvironment, Int] =
     requests
-      .evalMap(handleRequest)
+      .map(handleRequest)
+      .map(Stream.eval)
+      .parJoinUnbounded
       .terminateAfter(_.isInstanceOf[ShutdownResponse])
       .evalMap(publishResponse.publish1)
       .compile.drain.const(0)

--- a/polynote-kernel/src/main/scala/polynote/kernel/util/LimitedSharingClassLoader.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/LimitedSharingClassLoader.scala
@@ -28,17 +28,12 @@ class LimitedSharingClassLoader(
     val c = if (share.test(name)) {
       //System.err.println(s"Delegating class $name")
       try {
-        super.loadClass(name, resolve)
+        super.loadClass(name, false)
       } catch {
         case err: ClassNotFoundException => findClass(name)
       }
     } else try {
-      findLoadedClass(name) match {
-        case null =>
-          //System.err.println(s"Privately loading class $name")
-          findClass(name)
-        case lc => lc
-      }
+      findClass(name)
     } catch {
       case _: ClassNotFoundException | _: LinkageError =>
         super.loadClass(name, resolve)

--- a/polynote-server/src/main/scala/polynote/server/KernelSubscriber.scala
+++ b/polynote-server/src/main/scala/polynote/server/KernelSubscriber.scala
@@ -53,7 +53,7 @@ object KernelSubscriber {
       updater          <- Stream.emits(Seq(
           foreignUpdates(lastLocalVersion, lastGlobalVersion),
           publisher.status.subscribe(128).map(KernelStatus(notebook.path, _)),
-          publisher.cellResults.subscribe(128)
+          publisher.cellResults.subscribe(128).unNone
         )).parJoinUnbounded.interruptWhen(closed.await.either).through(publishMessage.publish).compile.drain.fork
     } yield new KernelSubscriber(
       id,


### PR DESCRIPTION
- Don't output any braces or parens when completing a method. Let the user add the parens so they get parameter hints.
- Use the correct range for replacing the thing being completed (otherwise in some cases you end up with like `spspark` after completing `spark` based on `sp`)
- Some other dumb fixes for things that were breaking completions
- Let remote kernel client do stuff in parallel instead of blocking until each message is handled
- Kill the remote kernel process if it doesn't shutdown (that `jep.close()` thing is breaking it again)
- Don't let the parent classloader resolve classes when we delegate to them (I think this causes weird errors sometimes; i.e. if a spark class loads some AWS class, the AWS class gets loaded by the parent classloader)
- Don't use parent's version of an already-loaded class unless it's one of the explicitly shared ones