### PR TITLE
Better default output display for streams

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val versions = new {
   val coursier   = "2.0.0-RC2-6"
   val circe      = "0.11.1"
   val circeYaml  = "0.10.0"
-  val spark      = "2.1.1"
+  val spark      = "2.1.3"
 }
 
 def nativeLibraryPath = s"${sys.env.get("JAVA_LIBRARY_PATH") orElse sys.env.get("LD_LIBRARY_PATH") orElse sys.env.get("DYLD_LIBRARY_PATH") getOrElse "."}:."

--- a/polynote-frontend/polynote/ui/component/cell.ts
+++ b/polynote-frontend/polynote/ui/component/cell.ts
@@ -695,7 +695,7 @@ export class CodeCell extends Cell {
         return (div(['output'], content) as MIMEElement).attr('rel', rel).attr('mime-type', mimeType);
     }
 
-    buildOutput(mimeType: string, args: Record<string, string>, content: string) {
+    buildOutput(mimeType: string, args: Record<string, string>, content: string | DocumentFragment) {
         return displayContent(mimeType, content, args).then(
             (result: TagElement<any>) => this.mimeEl(mimeType, args, result)
         ).catch(function(err: any) {
@@ -842,12 +842,14 @@ export class CodeCell extends Cell {
                 this.cellResultMargin.innerHTML = '';
                 this.cellResultMargin.appendChild(outLabel);
 
-                const [mime, content] = result.displayRepr;
-                const [mimeType, args] = parseContentType(mime);
-                this.buildOutput(mime, args, content).then((el: MIMEElement) => {
-                    this.resultTabs.appendChild(el);
-                    this.cellOutputTools.classList.add('output');
-                })
+                result.displayRepr.then(display => {
+                    const [mime, content] = display;
+                    const [mimeType, args] = parseContentType(mime);
+                    this.buildOutput(mime, args, content).then((el: MIMEElement) => {
+                        this.resultTabs.appendChild(el);
+                        this.cellOutputTools.classList.add('output');
+                    })
+                });
             }
         } else {
             this.cellOutputTools.classList.add('output');

--- a/polynote-frontend/polynote/ui/component/value_inspector.ts
+++ b/polynote-frontend/polynote/ui/component/value_inspector.ts
@@ -5,33 +5,13 @@ import {div, button, TagElement} from "../util/tags";
 import {ResultValue} from "../../data/result";
 import {MIMERepr, DataRepr, LazyDataRepr, StreamingDataRepr, StringRepr} from "../../data/value_repr";
 import match from "../../util/match";
-import {displayContent, displayData, contentTypeName} from "./display_content"
+import {displayContent, displayData, contentTypeName, displaySchema} from "./display_content"
 import {ArrayType, DataType, MapType, StructType} from "../../data/data_type";
 import {PlotEditor} from "./plot_editor";
 import {TableView} from "./table_view";
 import {TabNav} from "./tab_nav";
 import {DataReader} from "../../data/codec";
 
-function schemaToObject(structType: StructType) {
-    const obj: Record<string, any> = {};
-    for (let field of structType.fields) {
-        const [name, desc] = dataTypeToObjectField(field.name, field.dataType);
-        obj[name] = desc;
-    }
-    return obj;
-}
-
-function dataTypeToObjectField(name: string, dataType: DataType): [string, any] {
-    if (dataType instanceof StructType) {
-        return [name, schemaToObject(dataType)];
-    } else if (dataType instanceof ArrayType) {
-        return [`${name}[]`, dataTypeToObjectField('element', dataType.element)[1]];
-    } else if (dataType instanceof MapType) {
-        return [`${name}`, schemaToObject(dataType.element)]
-    } else {
-        return [name, (dataType.constructor as typeof DataType).typeName(dataType)];
-    }
-}
 
 class ValueInspector extends FullScreenModal {
 
@@ -59,7 +39,7 @@ class ValueInspector extends FullScreenModal {
                     .when(StreamingDataRepr, (handle, dataType, knownSize) => {
                         const repr = new StreamingDataRepr(handle, dataType, knownSize);
                         if (dataType instanceof StructType) {
-                            tabs['Schema'] = div(['schema-display'], [displayData(schemaToObject(dataType), undefined, true)]);
+                            tabs['Schema'] = displaySchema(dataType);
                             try {
                                 tabs['Plot data'] = new PlotEditor(repr, notebookPath, resultValue.name, resultValue.sourceCell).setEventParent(this).container;
                                 tabs['View data'] = new TableView(repr, notebookPath).el;

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -2753,29 +2753,22 @@ button {
       }
     }
   }
+}
 
-  .schema-display {
-    .object-summary {
-      .summary-content::before {
-        content: none;
-      }
+.result-name-and-type {
+  font-family: @code-fonts;
+  font-weight: 400;
+  margin: 0;
+}
 
-      .summary-content * {
-        display: none;
-      }
+.schema-display {
 
-      .summary-content::after {
-        content: 'struct';
-        font-family: @code-fonts;
-      }
+  .object-fields .object-field {
+    .field-name::after {
+      content: none;
     }
-
-    .string {
-      color: inherit;
-    }
-
-    .string::before, .string::after { content: none; }
   }
+
 }
 
 .tab-nav {

--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/ScalaInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/ScalaInterpreter.scala
@@ -37,13 +37,13 @@ class ScalaInterpreter private[scal] (
   override def completionsAt(code: String, pos: Int, state: State): Task[List[Completion]] = for {
     collectedState   <- injectState(collectState(state)).provide(CurrentRuntime.NoCurrentRuntime)
     valDefs           = collectedState.values.mapValues(_._1).values.toList
-    cellCode         <- scalaCompiler.cellCode(s"Cell${state.id.toString}", s"\n${code.substring(0, pos)}", collectedState.prevCells, valDefs, collectedState.imports, strictParse = false)
+    cellCode         <- scalaCompiler.cellCode(s"Cell${state.id.toString}", s"\n${code.substring(0, math.min(pos, code.length))}", collectedState.prevCells, valDefs, collectedState.imports, strictParse = false)
   } yield completer.completions(cellCode, pos + 1)
 
   override def parametersAt(code: String, pos: Int, state: State): Task[Option[Signatures]] = for {
     collectedState <- injectState(collectState(state)).provide(CurrentRuntime.NoCurrentRuntime)
     valDefs         = collectedState.values.mapValues(_._1).values.toList
-    cellCode         <- scalaCompiler.cellCode(s"Cell${state.id.toString}", s"\n$code", collectedState.prevCells, valDefs, collectedState.imports, strictParse = false)
+    cellCode       <- scalaCompiler.cellCode(s"Cell${state.id.toString}", s"\n$code", collectedState.prevCells, valDefs, collectedState.imports, strictParse = false)
   } yield completer.paramHints(cellCode, pos + 1)
 
   override def init(state: State): TaskR[InterpreterEnv, State] = ZIO.succeed(state)

--- a/polynote-runtime/src/main/scala/polynote/runtime/ReprsOf.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/ReprsOf.scala
@@ -21,7 +21,11 @@ object ReprsOf extends ExpandedScopeReprs {
   }
 
   class DataReprsOf[T](val dataType: DataType, val encode: T => ByteBuffer) extends ReprsOf[T] {
-    def apply(t: T): Array[ValueRepr] = Array(DataRepr(dataType, encode(t)))
+    def apply(t: T): Array[ValueRepr] = try {
+      Array(DataRepr(dataType, encode(t)))
+    } catch {
+      case err: Throwable => Array()
+    }
   }
 
   object DataReprsOf {


### PR DESCRIPTION
Instead of the string repr, by default show the schema expando thingy. Also, improve the schema expando thingy rather than just turning the schema into an object and displaying that.

Note that this won't affect what is actually saved to the notebook - it only works while the notebook is still running. Which I think is probably good.

Also, updates Spark to 2.1.3. I think we'll keep building against 2.1 (since it's the lowest common denominator, and higher versions should still work because the binary compat seems fine for the APIs we're actually using in Polynote) but might as well have the latest version of that for local use. I did this because of a bug preventing me from making map schemas to test this change against.

Also fix a couple bugs I found in various places.