### PR TITLE
Fix synchronization in RefMap

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/util/RefMap.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/RefMap.scala
@@ -23,11 +23,9 @@ class RefMap[K, V] private (
       ZIO.succeed(underlying.get(key)).flatMap(_.get)
     } else {
       semaphore.withPermit {
-        if (underlying.containsKey(key)) {
-          ZIO.succeed(underlying.get(key)).flatMap(_.get)
-        } else {
-          create.tap(v => Ref[Task].of(v).flatMap(ref =>
-            ZIO(underlying.put(key, ref))))
+        ZIO(underlying.containsKey(key)).flatMap {
+          case true => ZIO.succeed(underlying.get(key)).flatMap(_.get)
+          case false => create.tap(v => Ref[Task].of(v).flatMap(ref => ZIO(underlying.put(key, ref))))
         }
       }
     }
@@ -38,10 +36,9 @@ class RefMap[K, V] private (
       ZIO.succeed(underlying.get(key)).flatMap(_.get)
     } else {
       semaphore.withPermit {
-        if (underlying.containsKey(key)) {
-          ZIO.succeed(underlying.get(key)).flatMap(_.get)
-        } else {
-          create.tap(ref => ZIO(underlying.put(key, ref))).flatMap(_.get)
+        ZIO(underlying.containsKey(key)).flatMap {
+          case true => ZIO.succeed(underlying.get(key)).flatMap(_.get)
+          case false => create.tap(ref => ZIO(underlying.put(key, ref))).flatMap(_.get)
         }
       }
     }


### PR DESCRIPTION
I think I found what could be a race condition leading to multiple subscribers for one kernel in one session.

The body given to `withPermit` is not lazy, so that double-check is really a single-check. Suspending the check in a lazy ZIO effect ought to solve that.