### PR TITLE
Quick links for data inspection

### DIFF
--- a/polynote-frontend/polynote/data/result.ts
+++ b/polynote-frontend/polynote/data/result.ts
@@ -9,8 +9,9 @@ import {ValueRepr, StringRepr, MIMERepr, StreamingDataRepr, DataRepr, LazyDataRe
 import {int16, int64} from "./codec";
 import {Cell} from "../ui/component/cell";
 import {displayData, displaySchema} from "../ui/component/display_content";
-import {div, h4, span} from "../ui/util/tags";
+import {div, h4, iconButton, span} from "../ui/util/tags";
 import * as monaco from "monaco-editor";
+import {ValueInspector} from "../ui/component/value_inspector";
 
 export class Result extends CodecContainer {
     static codec: Codec<Result>;
@@ -226,7 +227,7 @@ export class ResultValue extends Result {
     /**
      * Get a default MIME type and string, for display purposes
      */
-    get displayRepr(): Promise<[string, string | DocumentFragment]> {
+    displayRepr(path: string, valueInspector: ValueInspector): Promise<[string, string | DocumentFragment]> {
         // TODO: make this smarter
         let index = this.reprs.findIndex(repr => repr instanceof MIMERepr && repr.mimeType.startsWith("text/html"));
         if (index > 0) return Promise.resolve(MIMERepr.unapply(this.reprs[index] as MIMERepr));
@@ -245,10 +246,19 @@ export class ResultValue extends Result {
                 const frag = document.createDocumentFragment();
                 const resultType = span(['result-type'], []).attr("data-lang" as any, "scala");
                 resultType.innerHTML = typeHTML;
-                frag.appendChild(div([], [
-                    h4(['result-name-and-type'], [span(['result-name'], [this.name]), ': ', resultType]),
+                // Why do they put a <br> in there?
+                [...resultType.getElementsByTagName("br")].forEach(br => {if (br && br.parentNode) br.parentNode.removeChild(br)});
+                const el = div([], [
+                    h4(['result-name-and-type'], [
+                        span(['result-name'], [this.name]), ': ', resultType,
+                        iconButton(['view-data'], 'View data', '', '[View]')
+                            .click(_ => valueInspector.inspect(this, path, 'View data')),
+                        iconButton(['plot-data'], 'Plot data', '', '[Plot]')
+                            .click(_ => valueInspector.inspect(this, path, 'Plot data'))
+                    ]),
                     displaySchema(streamingRepr.dataType)
-                ]));
+                ]);
+                frag.appendChild(el);
                 return ["text/html", frag];
             })
         }

--- a/polynote-frontend/polynote/data/result.ts
+++ b/polynote-frontend/polynote/data/result.ts
@@ -7,7 +7,7 @@ import {
 
 import {ValueRepr, StringRepr, MIMERepr, StreamingDataRepr, DataRepr, LazyDataRepr} from './value_repr'
 import {int16, int64} from "./codec";
-import {Cell} from "../ui/component/cell";
+import {Cell, CodeCell} from "../ui/component/cell";
 import {displayData, displaySchema} from "../ui/component/display_content";
 import {div, h4, iconButton, span} from "../ui/util/tags";
 import * as monaco from "monaco-editor";
@@ -227,7 +227,7 @@ export class ResultValue extends Result {
     /**
      * Get a default MIME type and string, for display purposes
      */
-    displayRepr(path: string, valueInspector: ValueInspector): Promise<[string, string | DocumentFragment]> {
+    displayRepr(cell: CodeCell, valueInspector: ValueInspector): Promise<[string, string | DocumentFragment]> {
         // TODO: make this smarter
         let index = this.reprs.findIndex(repr => repr instanceof MIMERepr && repr.mimeType.startsWith("text/html"));
         if (index > 0) return Promise.resolve(MIMERepr.unapply(this.reprs[index] as MIMERepr));
@@ -252,9 +252,12 @@ export class ResultValue extends Result {
                     h4(['result-name-and-type'], [
                         span(['result-name'], [this.name]), ': ', resultType,
                         iconButton(['view-data'], 'View data', '', '[View]')
-                            .click(_ => valueInspector.inspect(this, path, 'View data')),
+                            .click(_ => valueInspector.inspect(this, cell.path, 'View data')),
                         iconButton(['plot-data'], 'Plot data', '', '[Plot]')
-                            .click(_ => valueInspector.inspect(this, path, 'Plot data'))
+                            .click(_ => {
+                                valueInspector.setEventParent(cell);
+                                valueInspector.inspect(this, cell.path, 'Plot data');
+                            })
                     ]),
                     displaySchema(streamingRepr.dataType)
                 ]);

--- a/polynote-frontend/polynote/ui/component/cell.ts
+++ b/polynote-frontend/polynote/ui/component/cell.ts
@@ -842,7 +842,7 @@ export class CodeCell extends Cell {
                 this.cellResultMargin.innerHTML = '';
                 this.cellResultMargin.appendChild(outLabel);
 
-                result.displayRepr(this.path, ValueInspector.get()).then(display => {
+                result.displayRepr(this, ValueInspector.get()).then(display => {
                     const [mime, content] = display;
                     const [mimeType, args] = parseContentType(mime);
                     this.buildOutput(mime, args, content).then((el: MIMEElement) => {

--- a/polynote-frontend/polynote/ui/component/cell.ts
+++ b/polynote-frontend/polynote/ui/component/cell.ts
@@ -15,7 +15,7 @@ import {createVim} from "../util/vim";
 import {DeleteCell} from "../../data/messages";
 import {Hotkeys, KeyAction} from "../util/hotkeys";
 import {clientInterpreters} from "../../interpreter/client_interpreter";
-import {valueInspector} from "./value_inspector";
+import {ValueInspector} from "./value_inspector";
 import {Interpreters} from "./ui";
 import {displayContent, parseContentType, prettyDuration} from "./display_content";
 import {CellMetadata} from "../../data/data";
@@ -831,8 +831,8 @@ export class CodeCell extends Cell {
                     inspectIcon = [
                         iconButton(['inspect'], 'Inspect', '', 'Inspect').click(
                             evt => {
-                                valueInspector.setEventParent(this);
-                                valueInspector.inspect(result, this.path)
+                                ValueInspector.get().setEventParent(this);
+                                ValueInspector.get().inspect(result, this.path)
                             }
                         )
                     ]
@@ -842,7 +842,7 @@ export class CodeCell extends Cell {
                 this.cellResultMargin.innerHTML = '';
                 this.cellResultMargin.appendChild(outLabel);
 
-                result.displayRepr.then(display => {
+                result.displayRepr(this.path, ValueInspector.get()).then(display => {
                     const [mime, content] = display;
                     const [mimeType, args] = parseContentType(mime);
                     this.buildOutput(mime, args, content).then((el: MIMEElement) => {

--- a/polynote-frontend/polynote/ui/component/notebook.ts
+++ b/polynote-frontend/polynote/ui/component/notebook.ts
@@ -128,7 +128,8 @@ export class NotebookUI extends UIEventTarget {
             if (evt.detail.mkCell) {
                 newCell = evt.detail.mkCell(nextId);
             } else {
-                newCell = current.language === 'text' ? new TextCell(nextId, '', this.path) : new CodeCell(nextId, '', current.language, this.path);
+                const lang = current.language == 'text' ? 'scala' : current.language;
+                newCell = new CodeCell(nextId, '', lang, this.path);
             }
             const notebookCell = new NotebookCell(newCell.id, newCell.language, newCell.content, evt.detail.results || [], newCell.metadata);
             const update = new messages.InsertCell(path, this.globalVersion, ++this.localVersion, notebookCell, current.id);

--- a/polynote-frontend/polynote/ui/component/plot_editor.ts
+++ b/polynote-frontend/polynote/ui/component/plot_editor.ts
@@ -501,7 +501,9 @@ export class PlotEditor extends UIEventTarget {
                 mkCell,
                 cellId: this.sourceCell,
                 results: [output],
-                afterInsert: (cell: { addResult: (arg0: PlotEditorResult) => void; }) => cell.addResult(new PlotEditorResult(this.plotOutput.querySelector('.plot-embed') as TagElement<"div">, output))
+                afterInsert: (cell: CodeCell) => {
+                    cell.addResult(new PlotEditorResult(this.plotOutput.querySelector('.plot-embed') as TagElement<"div">, output));
+                }
             });
             this.dispatchEvent(event);
         });
@@ -533,8 +535,7 @@ function normalSpec(this: PlotEditor, plotType: string, xField: StructField, yMe
             fold: yMeas.map(measure => measure.agg ? `${measure.agg}(${measure.field.name})` : measure.field.name)
         }];
         spec.encoding.y = {
-            field: 'value',
-            scale: {zero: false } // TODO: configurable
+            field: 'value'
         };
         spec.encoding.color = {
             field: 'key',
@@ -543,8 +544,7 @@ function normalSpec(this: PlotEditor, plotType: string, xField: StructField, yMe
     } else {
         spec.encoding.y = {
             field: yMeas.agg ? `${yMeas.agg}(${yMeas.field.name})` : yMeas.field.name,
-            type: 'quantitative',
-            scale: {zero: false } // TODO: configurable
+            type: 'quantitative'
         };
     }
 

--- a/polynote-frontend/polynote/ui/component/symbol_table.ts
+++ b/polynote-frontend/polynote/ui/component/symbol_table.ts
@@ -1,6 +1,6 @@
 import {UIEventTarget} from "../util/ui_event";
 import {div, h3, span, table, TableElement, TableRowElement, TagElement} from "../util/tags";
-import {valueInspector} from "./value_inspector";
+import {ValueInspector} from "./value_inspector";
 import {ResultValue} from "../../data/result";
 
 interface ResultRow extends TableRowElement {
@@ -51,8 +51,8 @@ export class KernelSymbolsUI extends UIEventTarget {
             type: span([], [resultValue.typeName]).attr('title', resultValue.typeName)
         }, whichBody) as ResultRow;
         tr.onclick = (evt) => {
-            valueInspector.setEventParent(this);
-            valueInspector.inspect(tr.resultValue, this.path);
+            ValueInspector.get().setEventParent(this);
+            ValueInspector.get().inspect(tr.resultValue, this.path);
         };
         tr.data = {name: resultValue.name, type: resultValue.typeName};
         tr.resultValue = resultValue;

--- a/polynote-frontend/polynote/ui/component/value_inspector.ts
+++ b/polynote-frontend/polynote/ui/component/value_inspector.ts
@@ -13,8 +13,14 @@ import {TabNav} from "./tab_nav";
 import {DataReader} from "../../data/codec";
 
 
-class ValueInspector extends FullScreenModal {
-
+export class ValueInspector extends FullScreenModal {
+    private static inst: ValueInspector;
+    static get() {
+        if (!ValueInspector.inst) {
+            ValueInspector.inst = new ValueInspector();
+        }
+        return ValueInspector.inst;
+    }
     constructor() {
         super(
             div([], []),
@@ -24,7 +30,7 @@ class ValueInspector extends FullScreenModal {
         this.addEventListener('InsertCellAfter', evt => this.hide());
     }
 
-    inspect(resultValue: ResultValue, notebookPath: string) {
+    inspect(resultValue: ResultValue, notebookPath: string, jumpTo?: string) {
         this.content.innerHTML = "";
         let tabsPromise = Promise.resolve({} as Record<string, TagElement<any>>);
 
@@ -63,7 +69,11 @@ class ValueInspector extends FullScreenModal {
 
         return tabsPromise.then(tabs => {
             if (Object.keys(tabs).length) {
-                this.content.appendChild(new TabNav(tabs).el);
+                const nav = new TabNav(tabs);
+                if (jumpTo && tabs[jumpTo]) {
+                    nav.showItem(jumpTo);
+                }
+                this.content.appendChild(nav.el);
                 this.setTitle(`Inspect: ${resultValue.name}`);
                 this.show();
             }
@@ -71,5 +81,3 @@ class ValueInspector extends FullScreenModal {
     }
 
 }
-
-export const valueInspector = new ValueInspector();

--- a/polynote-frontend/polynote/ui/util/tags.ts
+++ b/polynote-frontend/polynote/ui/util/tags.ts
@@ -103,14 +103,14 @@ export function div(classes: string[], content: Content) {
     return tag('div', classes, undefined, content);
 }
 
-export function button(classes: string[], attributes: Record<string, string>, content: Content) {
+export function button(classes: string[], attributes: Record<string, string>, content: Content): TagElement<"button"> {
     if (!("type" in attributes)) {
         attributes["type"] = "button"
     }
     return tag('button', classes, attributes, content);
 }
 
-export function iconButton(classes: string[], title: string, icon: string, alt: string) {
+export function iconButton(classes: string[], title: string, icon: string, alt: string): TagElement<"button"> {
     classes.push('icon-button');
     return button(classes, {title: title}, [
         span(['icon', 'fas'], [icon]),

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -2780,6 +2780,13 @@ button {
   font-family: @code-fonts;
   font-weight: 400;
   margin: 0;
+  button {
+    padding: 2px;
+    font-size: 10pt;
+  }
+  button:first-of-type {
+    margin-left: 10pt;
+  }
 }
 
 .schema-display {


### PR DESCRIPTION
Adds two little buttons to a streaming `Out` display, for plot and view data.
![Screen Shot 2019-10-07 at 2 17 30 PM](https://user-images.githubusercontent.com/864869/66349250-4bf98080-e90d-11e9-9507-c78b38619398.png)
