### PR TITLE
Fix remote kernel syncing

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/protocol.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/protocol.scala
@@ -21,7 +21,7 @@ abstract class RemoteRequestCompanion[T](msgTypeId: Byte) {
   implicit val discriminator: Discriminator[RemoteRequest, T, Byte] = Discriminator(msgTypeId)
 }
 
-final case class StartupRequest(reqId: Int, notebook: Notebook, config: PolynoteConfig) extends RemoteRequest
+final case class StartupRequest(reqId: Int, notebook: Notebook, globalVersion: Int, config: PolynoteConfig) extends RemoteRequest
 
 object StartupRequest extends RemoteRequestCompanion[StartupRequest](1) {
   private implicit val notebookCodec: Codec[Notebook] = Message.codec.exmap(

--- a/polynote-kernel/src/test/scala/polynote/kernel/remote/RemoteKernelSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/remote/RemoteKernelSpec.scala
@@ -114,7 +114,7 @@ class RemoteKernelSpec extends FreeSpec with Matchers with ZIOSpec with BeforeAn
       }
 
       "handles notebook updates" in {
-        forAll((Generators.genNotebookUpdates _).tupled(unsafeRun(env.currentNotebook.get))) {
+        forAll((Generators.genNotebookUpdates _).tupled(unsafeRun(env.currentNotebook.get)), MinSize(4)) {
           case (finalNotebook, updates) =>
             whenever(updates.nonEmpty) {
               val finalVersion = updates.last.globalVersion

--- a/polynote-kernel/src/test/scala/polynote/testing/Generators.scala
+++ b/polynote-kernel/src/test/scala/polynote/testing/Generators.scala
@@ -90,8 +90,8 @@ object Generators {
 
   def genNotebookUpdates(globalVersion: Int, initial: Notebook): Gen[(Notebook, List[NotebookUpdate])] = for {
     size  <- Gen.size
-    count <- Gen.choose(1, size)
-    (finalNotebook, edits) <- ((globalVersion + 1) until (globalVersion + count + 1)).foldLeft(Gen.const((initial, Queue.empty[NotebookUpdate]))) {
+    count <- Gen.choose(1, math.max(1,size))
+    (finalNotebook, edits) <- ((globalVersion + 1) to (globalVersion + count + 1)).foldLeft(Gen.const((initial, Queue.empty[NotebookUpdate]))) {
       (accum, nextVersion) => accum.flatMap {
         case (currentNotebook, updates) => genNotebookUpdate(currentNotebook, nextVersion).map {
           update => (update.applyTo(currentNotebook) -> updates.enqueue(update))

--- a/polynote-kernel/src/test/scala/polynote/testing/Generators.scala
+++ b/polynote-kernel/src/test/scala/polynote/testing/Generators.scala
@@ -2,7 +2,7 @@ package polynote.testing
 
 import org.scalacheck.{Arbitrary, Gen}
 import polynote.data.Rope
-import polynote.messages.{CellID, ContentEdit, ContentEdits, Delete, Insert, NotebookCell, ShortList, TinyString}
+import polynote.messages.{CellID, ContentEdit, ContentEdits, Delete, DeleteCell, Insert, InsertCell, Notebook, NotebookCell, NotebookUpdate, ShortList, TinyString, UpdateCell}
 
 import scala.collection.immutable.Queue
 
@@ -52,5 +52,52 @@ object Generators {
     content <- genRope
     // TODO: also generate results & metadata
   } yield NotebookCell(id, lang, content)
+
+  def genDeleteCell(notebook: Notebook, globalVersion: Int): Gen[DeleteCell] = notebook.cells.map(_.id) match {
+    case Nil => Gen.fail
+    case one :: Nil => Gen.const(DeleteCell(notebook.path, globalVersion, 0, one))
+    case one :: two :: rest => Gen.oneOf(one, two, rest: _*).map {
+      cellId => DeleteCell(notebook.path, globalVersion, 0, cellId)
+    }
+  }
+
+  def genInsertCell(notebook: Notebook, globalVersion: Int): Gen[InsertCell] = notebook.cells.map(_.id) match {
+    case Nil => genCell(CellID(0)).flatMap(cell => Gen.const(InsertCell(notebook.path, globalVersion, 0, cell, CellID(-1))))
+    case ids@(first :: rest) =>
+      val nextId = CellID(ids.max + 1)
+      genCell(nextId).flatMap {
+        cell => Gen.oneOf(
+          Gen.oneOf(ids).map(after => InsertCell(notebook.path, globalVersion, 0, cell, after)),
+          Gen.const(InsertCell(notebook.path, globalVersion, 0, cell, CellID(-1)))
+        )
+      }
+  }
+
+  def genUpdateCell(notebook: Notebook, globalVersion: Int): Gen[UpdateCell] = notebook.cells.toList match {
+    case Nil   => Gen.fail
+    case cells => Gen.oneOf(cells).flatMap {
+      cell => genEditsFor(cell.content).map {
+        case (edits, _) => UpdateCell(notebook.path, globalVersion, 0, cell.id, edits, None)
+      }
+    }
+  }
+
+  def genNotebookUpdate(notebook: Notebook, globalVersion: Int): Gen[NotebookUpdate] = Gen.oneOf(
+    Gen.delay(if (notebook.cells.nonEmpty) genDeleteCell(notebook, globalVersion) else genInsertCell(notebook, globalVersion)),
+    Gen.delay(genInsertCell(notebook, globalVersion)),
+    Gen.delay(genUpdateCell(notebook, globalVersion))
+  )
+
+  def genNotebookUpdates(globalVersion: Int, initial: Notebook): Gen[(Notebook, List[NotebookUpdate])] = for {
+    size  <- Gen.size
+    count <- Gen.choose(0, size)
+    (finalNotebook, edits) <- ((globalVersion + 1) until (globalVersion + count + 1)).foldLeft(Gen.const((initial, Queue.empty[NotebookUpdate]))) {
+      (accum, nextVersion) => accum.flatMap {
+        case (currentNotebook, updates) => genNotebookUpdate(currentNotebook, nextVersion).map {
+          update => (update.applyTo(currentNotebook) -> updates.enqueue(update))
+        }
+      }
+    }
+  } yield finalNotebook -> edits.toList
 
 }

--- a/polynote-kernel/src/test/scala/polynote/testing/Generators.scala
+++ b/polynote-kernel/src/test/scala/polynote/testing/Generators.scala
@@ -90,7 +90,7 @@ object Generators {
 
   def genNotebookUpdates(globalVersion: Int, initial: Notebook): Gen[(Notebook, List[NotebookUpdate])] = for {
     size  <- Gen.size
-    count <- Gen.choose(0, size)
+    count <- Gen.choose(1, size)
     (finalNotebook, edits) <- ((globalVersion + 1) until (globalVersion + count + 1)).foldLeft(Gen.const((initial, Queue.empty[NotebookUpdate]))) {
       (accum, nextVersion) => accum.flatMap {
         case (currentNotebook, updates) => genNotebookUpdate(currentNotebook, nextVersion).map {

--- a/polynote-kernel/src/test/scala/polynote/testing/kernel/MockEnv.scala
+++ b/polynote-kernel/src/test/scala/polynote/testing/kernel/MockEnv.scala
@@ -49,7 +49,7 @@ case class MockKernelEnv(
   interpreterFactories: Map[String, List[Interpreter.Factory]],
   taskManager: TaskManager.Service,
   updateTopic: Topic[Task, Option[NotebookUpdate]],
-  currentNotebook: SignallingRef[Task, Notebook],
+  currentNotebook: SignallingRef[Task, (Int, Notebook)],
   streamingHandles: StreamingHandles.Service,
   sessionID: Int = 0
 ) extends BaseEnvT with GlobalEnvT with CellEnvT with StreamingHandles with NotebookUpdates {
@@ -64,7 +64,7 @@ case class MockKernelEnv(
 object MockKernelEnv {
   def apply(kernelFactory: Factory.Service): TaskR[BaseEnv, MockKernelEnv] = for {
     baseEnv         <- ZIO.access[BaseEnv](identity)
-    currentNotebook <- SignallingRef[Task, Notebook](Notebook("empty", ShortList(Nil), None))
+    currentNotebook <- SignallingRef[Task, (Int, Notebook)](0 -> Notebook("empty", ShortList(Nil), None))
     updateTopic     <- Topic[Task, Option[NotebookUpdate]](None)
     publishUpdates   = new MockPublish[KernelStatusUpdate]
     taskManager     <- TaskManager(publishUpdates)

--- a/polynote-server/src/main/scala/polynote/util/VersionBuffer.scala
+++ b/polynote-server/src/main/scala/polynote/util/VersionBuffer.scala
@@ -32,7 +32,9 @@ class VersionBuffer[T] {
     }
   }
 
-  def getRange(startVersion: Int, endVersion: Int): List[(Int, T)] = {
+  def getRange(startVersion: Int, endVersion: Int): List[T] = getRangeV(startVersion, endVersion).map(_._2)
+
+  def getRangeV(startVersion: Int, endVersion: Int): List[(Int, T)] = {
     val iter = buffer.iterator()
     val results = new ListBuffer[(Int, T)]
     var finished = false


### PR DESCRIPTION
- Make sure that only the right updates are sent to the remote kernel
- Add tests for above
- Make sure that the startup message exchange always happens first
- Only send predef values when notebook is loaded (the rest are already in the notebook message)
- Discard any current value in result and status topics when subscribing (only care about new updates)