### PR TITLE
Dedicated channel for notebook updates in remote kernel

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/Kernel.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/Kernel.scala
@@ -86,6 +86,10 @@ object Kernel {
       def apply(): TaskR[BaseEnv with GlobalEnv with CellEnv with NotebookUpdates, Kernel]
     }
 
+    trait LocalService extends Service {
+      override def apply(): TaskR[BaseEnv with GlobalEnv with CellEnv, Kernel]
+    }
+
     def of(factory: Service): Factory = new Factory {
       val kernelFactory: Service = factory
     }

--- a/polynote-kernel/src/main/scala/polynote/kernel/LocalKernel.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/LocalKernel.scala
@@ -236,7 +236,7 @@ class LocalKernel private[kernel] (
   }
 }
 
-class LocalKernelFactory extends Kernel.Factory.Service {
+class LocalKernelFactory extends Kernel.Factory.LocalService {
 
   def apply(): TaskR[BaseEnv with GlobalEnv with CellEnv, Kernel] = for {
     scalaDeps    <- CoursierFetcher.fetch("scala")

--- a/polynote-kernel/src/main/scala/polynote/kernel/package.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/package.scala
@@ -105,6 +105,10 @@ package object kernel {
     def widen[A1 >: A]: ZIO[R, E, A1] = self
   }
 
+  final implicit class TaskRSyntax[R, A](val self: ZIO[R, Throwable, A]) extends AnyVal {
+    def withFilter(predicate: A => Boolean): ZIO[R, Throwable, A] = self.filterOrFail(predicate)(new MatchError("Predicate is not satisfied"))
+  }
+
   def withContextClassLoaderIO[A](cl: ClassLoader)(thunk: => A): TaskR[Blocking, A] =
     zio.blocking.effectBlocking(withContextClassLoader(cl)(thunk))
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/protocol.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/protocol.scala
@@ -1,5 +1,6 @@
 package polynote.kernel.remote
 
+import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
 import polynote.config.PolynoteConfig
@@ -12,6 +13,32 @@ import scodec.{Attempt, Codec, Err, codecs}
 import shapeless.{Coproduct, cachedImplicit}
 import polynote.kernel.ValueReprCodec.streamingDataReprCodec
 import polynote.kernel.TableOpCodec.tableOpCodec
+import scodec.bits.BitVector
+import zio.{Task, ZIO}
+
+sealed trait IdentifyChannel
+case object MainChannel extends IdentifyChannel
+case object NotebookUpdatesChannel extends IdentifyChannel
+object IdentifyChannel {
+  implicit val codec: Codec[IdentifyChannel] = byte.exmap(
+    {
+      case 0 => Attempt.successful(MainChannel)
+      case 1 => Attempt.successful(NotebookUpdatesChannel)
+      case n => Attempt.failure(Err(s"Invalid channel type identifier $n"))
+    },
+    {
+      case MainChannel => Attempt.successful(0)
+      case NotebookUpdatesChannel => Attempt.successful(1)
+    }
+  )
+
+  def decodeBuffer(buf: ByteBuffer): Task[IdentifyChannel] = ZIO.fromEither(codec.decode(BitVector(buf)).toEither).mapError(err => new RuntimeException(err.message)).map(_.value)
+  def encode(value: IdentifyChannel): Task[BitVector] = ZIO.fromEither(codec.encode(value).toEither).mapError(err => new RuntimeException(err.message))
+}
+
+object Update {
+  implicit val notebookUpdateCodec: Codec[NotebookUpdate] = NotebookUpdate.codec
+}
 
 sealed trait RemoteRequest {
   val reqId: Int
@@ -67,11 +94,6 @@ object ModifyStreamRequest extends RemoteRequestCompanion[ModifyStreamRequest](9
 
 final case class ReleaseHandleRequest(reqId: Int, sessionId: Int, handleType: HandleType, handleId: Int) extends RemoteRequest
 object ReleaseHandleRequest extends RemoteRequestCompanion[ReleaseHandleRequest](10)
-
-final case class UpdateNotebookRequest(reqId: Int, update: NotebookUpdate) extends RemoteRequest
-object UpdateNotebookRequest extends RemoteRequestCompanion[UpdateNotebookRequest](11) {
-  implicit val codec: Codec[UpdateNotebookRequest] = cachedImplicit
-}
 
 final case class CancelAllRequest(reqId: Int) extends RemoteRequest
 object CancelAllRequest extends RemoteRequestCompanion[CancelAllRequest](12)

--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/transport.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/transport.scala
@@ -14,20 +14,24 @@ import polynote.config.PolynoteConfig
 import polynote.kernel.environment.{Config, CurrentNotebook, CurrentTask}
 import polynote.kernel.logging.Logging
 import polynote.kernel.remote.SocketTransport.FramedSocket
-import polynote.messages.{Notebook, NotebookConfig}
+import polynote.messages._
+import scodec.Codec
+import scodec.codecs.implicits._
 import scodec.bits.BitVector
 import scodec.stream.decode
 import zio.Cause._
 import zio.blocking.{Blocking, effectBlocking}
 import zio.clock.Clock
 import zio.internal.Executor
-import zio.{Promise, Task, TaskR, ZIO}
+import zio.{Promise, Task, TaskR, ZIO, ZSchedule}
 import zio.duration.{durationInt, Duration => ZDuration}
 import zio.interop.catz._
 
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration.{Duration, MINUTES, SECONDS}
 import scala.reflect.{ClassTag, classTag}
+
+import Update.notebookUpdateCodec
 
 trait Transport[ServerAddress] {
   def serve(): TaskR[BaseEnv with GlobalEnv with CurrentNotebook with TaskManager, TransportServer[ServerAddress]]
@@ -45,6 +49,8 @@ trait TransportServer[ServerAddress] {
     * Send a request to the client
     */
   def sendRequest(req: RemoteRequest): TaskB[Unit]
+
+  def sendNotebookUpdate(update: NotebookUpdate): TaskB[Unit]
 
   /**
     * Shut down the server and any processes it's deployed
@@ -70,6 +76,8 @@ trait TransportClient {
     */
   def requests: Stream[TaskB, RemoteRequest]
 
+  def updates: Stream[TaskB, NotebookUpdate]
+
   /**
     * Shut down the client
     */
@@ -79,28 +87,35 @@ trait TransportClient {
 // TODO: need some fault tolerance mechanism here, like reconnecting on socket errors
 class SocketTransportServer private (
   server: ServerSocketChannel,
-  channel: FramedSocket,
+  channels: SocketTransport.Channels,
   process: SocketTransport.DeployedProcess,
   closed: Deferred[Task, Unit]
 ) extends TransportServer[InetSocketAddress] {
 
   override def sendRequest(req: RemoteRequest): TaskB[Unit] = for {
     msg     <- ZIO.fromEither(RemoteRequest.codec.encode(req).toEither).mapError(err => new RuntimeException(err.message))
-    _       <- channel.write(msg)
+    _       <- channels.mainChannel.write(msg)
+  } yield ()
+
+  private val updateCodec = Codec[NotebookUpdate]
+
+  override def sendNotebookUpdate(update: NotebookUpdate): TaskB[Unit] = for {
+    msg <- ZIO.fromEither(updateCodec.encode(update).toEither).mapError(err => new RuntimeException(err.message))
+    _   <- channels.notebookUpdatesChannel.write(msg)
   } yield ()
 
   override val responses: Stream[TaskB, RemoteResponse] =
       Stream.eval(Logging.info("Connected. Decoding incoming messages")).drain ++
-        channel.bitVectors
+        channels.mainChannel.bitVectors
           .interruptWhen(closed.get.either)
           .through(scodec.stream.decode.pipe[TaskB, RemoteResponse])
           .handleErrorWith {
             err => Stream.eval(Logging.error("Response stream terminated due to error", err)).drain
           } ++ Stream.eval(Logging.info("Response stream terminated")).drain
 
-  override def close(): TaskB[Unit] = Logging.info("Closing remote kernel transport") *> closed.complete(()) *> channel.close() *> process.awaitOrKill(30)
+  override def close(): TaskB[Unit] = Logging.info("Closing remote kernel transport") *> closed.complete(()) *> channels.close() *> process.awaitOrKill(30)
 
-  override def isConnected: TaskB[Boolean] = ZIO(channel.isConnected)
+  override def isConnected: TaskB[Boolean] = ZIO(channels.isConnected)
 
   override def address: TaskB[InetSocketAddress] = effectBlocking(Option(server.getLocalAddress)).flatMap {
     case Some(addr: InetSocketAddress) => ZIO.succeed(addr)
@@ -109,33 +124,56 @@ class SocketTransportServer private (
 }
 
 object SocketTransportServer {
+  private def selectChannels(channel1: FramedSocket, channel2: FramedSocket, address: InetSocketAddress): TaskB[SocketTransport.Channels] = {
+    def identify(channel: FramedSocket) = channel.read().repeat {
+      ZSchedule.doUntil[Option[Option[ByteBuffer]]] {
+        case Some(Some(_)) => true
+        case None => false
+      }
+    }.flatMap {
+      case Some(Some(buf)) => IdentifyChannel.decodeBuffer(buf)
+      case _               => ZIO.fail(new IllegalStateException("No buffer was received"))
+    }
+
+    (identify(channel1) zipPar identify(channel2)).flatMap {
+      case (MainChannel, NotebookUpdatesChannel) => ZIO.succeed(SocketTransport.Channels(channel1, channel2, address))
+      case (NotebookUpdatesChannel, MainChannel) => ZIO.succeed(SocketTransport.Channels(channel2, channel1, address))
+      case other => ZIO.fail(new IllegalStateException(s"Illegal channel set: $other"))
+    }
+  }
+
   def apply(
     server: ServerSocketChannel,
-    channel: FramedSocket,
+    channel1: FramedSocket,
+    channel2: FramedSocket,
     process: SocketTransport.DeployedProcess
-  ): TaskR[Logging, SocketTransportServer] = for {
-    closed  <- Deferred[Task, Unit]
-  } yield new SocketTransportServer(server, channel, process, closed)
+  ): TaskB[SocketTransportServer] = for {
+    closed   <- Deferred[Task, Unit]
+    channels <- selectChannels(channel1, channel2, server.getLocalAddress.asInstanceOf[InetSocketAddress])
+  } yield new SocketTransportServer(server, channels, process, closed)
 }
 
-class SocketTransportClient private (channel: FramedSocket, closed: Deferred[Task, Unit]) extends TransportClient {
+class SocketTransportClient private (channels: SocketTransport.Channels, closed: Deferred[Task, Unit]) extends TransportClient {
 
-  private val requestStream = channel.bitVectors.through(decode.pipe[TaskB, RemoteRequest])
+  private val requestStream = channels.mainChannel.bitVectors.through(decode.pipe[TaskB, RemoteRequest])
+  private val updateStream = channels.notebookUpdatesChannel.bitVectors.through(decode.pipe[TaskB, NotebookUpdate])
 
   def sendResponse(rep: RemoteResponse): TaskB[Unit] = for {
     bytes <- ZIO.fromEither(RemoteResponse.codec.encode(rep).toEither).mapError(err => new RuntimeException(err.message))
-    _     <- channel.write(bytes)
+    _     <- channels.mainChannel.write(bytes)
   } yield ()
 
-  override val requests: Stream[TaskB, RemoteRequest] = requestStream.terminateAfter(_.isInstanceOf[ShutdownRequest])
+  override val requests: Stream[TaskB, RemoteRequest] = requestStream.terminateAfter(_.isInstanceOf[ShutdownRequest]) ++ Stream.eval(close()).drain
 
-  def close(): TaskB[Unit] = channel.close()
+  override val updates: Stream[TaskB, NotebookUpdate] = updateStream.interruptWhen(closed.get.either)
+
+  def close(): TaskB[Unit] = closed.complete(()) *> channels.close()
 }
 
 object SocketTransportClient {
-  def apply(channel: FramedSocket): Task[SocketTransportClient] = for {
+  def apply(channels: SocketTransport.Channels): Task[SocketTransportClient] = for {
     closed <- Deferred[Task, Unit]
-  } yield new SocketTransportClient(channel, closed)
+  } yield new SocketTransportClient(channels, closed)
 }
 
 /**
@@ -174,7 +212,8 @@ class SocketTransport(
         process       <- deploy.deployKernel(this, serverAddress)
         _             <- CurrentTask.update(_.progress(0.5, Some("Waiting for remote kernel")))
         connection    <- startConnection(socketServer)
-        server        <- SocketTransportServer(socketServer, connection, process)
+        connection2   <- startConnection(socketServer)
+        server        <- SocketTransportServer(socketServer, connection, connection2, process)
       } yield server
     }
 
@@ -183,10 +222,22 @@ class SocketTransport(
 
 object SocketTransport {
 
+  case class Channels(
+    mainChannel: FramedSocket,
+    notebookUpdatesChannel: FramedSocket,
+    address: InetSocketAddress
+  ) {
+    def isConnected: Boolean = mainChannel.isConnected && notebookUpdatesChannel.isConnected
+    def close(): TaskB[Unit] = ZIO.sequencePar(Seq(mainChannel.close(), notebookUpdatesChannel.close())).unit
+  }
+
   def connectClient(serverAddress: InetSocketAddress): TaskB[TransportClient] = for {
-    channel <- effectBlocking(SocketChannel.open(serverAddress))
-    framed  <- FramedSocket(channel, keepalive = true)
-    client  <- SocketTransportClient(framed)
+    mainChannel    <- effectBlocking(SocketChannel.open(serverAddress)) >>= (FramedSocket(_, keepalive = true))
+    updatesChannel <- effectBlocking(SocketChannel.open(serverAddress)) >>= (FramedSocket(_, keepalive = true))
+    _              <- IdentifyChannel.encode(MainChannel) >>= mainChannel.write
+    _              <- IdentifyChannel.encode(NotebookUpdatesChannel) >>= updatesChannel.write
+    channels        = SocketTransport.Channels(mainChannel, updatesChannel, serverAddress)
+    client         <- SocketTransportClient(channels)
   } yield client
 
   /**

--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/transport.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/transport.scala
@@ -163,7 +163,7 @@ class SocketTransportClient private (channels: SocketTransport.Channels, closed:
     _     <- channels.mainChannel.write(bytes)
   } yield ()
 
-  override val requests: Stream[TaskB, RemoteRequest] = requestStream.terminateAfter(_.isInstanceOf[ShutdownRequest]) ++ Stream.eval(close()).drain
+  override val requests: Stream[TaskB, RemoteRequest] = requestStream.terminateAfter(_.isInstanceOf[ShutdownRequest])
 
   override val updates: Stream[TaskB, NotebookUpdate] = updateStream.interruptWhen(closed.get.either)
 

--- a/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
+++ b/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
@@ -217,6 +217,7 @@ sealed trait NotebookUpdate extends Message {
 
 }
 
+
 object NotebookUpdate {
   def unapply(message: Message): Option[NotebookUpdate] = message match {
     case msg: NotebookUpdate => Some(msg)
@@ -224,6 +225,7 @@ object NotebookUpdate {
   }
 
   implicit val discriminated: Discriminated[NotebookUpdate, Byte] = Discriminated(byte)
+  val codec: Codec[NotebookUpdate] = Codec[NotebookUpdate]
 }
 
 abstract class NotebookUpdateCompanion[T <: NotebookUpdate](msgTypeId: Byte) extends MessageCompanion[T](msgTypeId) {

--- a/polynote-kernel/src/test/scala/polynote/kernel/remote/RemoteKernelSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/remote/RemoteKernelSpec.scala
@@ -24,8 +24,8 @@ import scala.concurrent.TimeoutException
 
 class RemoteKernelSpec extends FreeSpec with Matchers with ZIOSpec with BeforeAndAfterAll with BeforeAndAfterEach with MockFactory with GeneratorDrivenPropertyChecks {
   private val kernel        = mock[Kernel]
-  private val kernelFactory = new Factory.Service {
-    def apply(): TaskR[BaseEnv with GlobalEnv with CellEnv with NotebookUpdates, Kernel] = ZIO.succeed(kernel)
+  private val kernelFactory = new Factory.LocalService {
+    def apply(): TaskR[BaseEnv with GlobalEnv with CellEnv, Kernel] = ZIO.succeed(kernel)
   }
 
   private val env           = unsafeRun(MockKernelEnv(kernelFactory))

--- a/polynote-kernel/src/test/scala/polynote/testing/kernel/remote/InProcessDeploy.scala
+++ b/polynote-kernel/src/test/scala/polynote/testing/kernel/remote/InProcessDeploy.scala
@@ -9,7 +9,7 @@ import polynote.kernel.remote.{RemoteKernelClient, SocketTransport}
 import zio.{Fiber, Ref, TaskR, ZIO}
 import zio.duration.Duration
 
-class InProcessDeploy(kernelFactory: Kernel.Factory.Service, clientRef: Ref[RemoteKernelClient]) extends SocketTransport.Deploy {
+class InProcessDeploy(kernelFactory: Kernel.Factory.LocalService, clientRef: Ref[RemoteKernelClient]) extends SocketTransport.Deploy {
   def deployKernel(transport: SocketTransport, serverAddress: InetSocketAddress): TaskR[BaseEnv with GlobalEnv with CurrentNotebook, SocketTransport.DeployedProcess] = {
     val connectClient = RemoteKernelClient.tapRunThrowable(
       RemoteKernelClient.Args(

--- a/polynote-spark/src/main/scala/polynote/kernel/LocalSparkKernel.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/LocalSparkKernel.scala
@@ -55,7 +55,7 @@ class LocalSparkKernel private[kernel] (
 
 }
 
-class LocalSparkKernelFactory extends Kernel.Factory.Service {
+class LocalSparkKernelFactory extends Kernel.Factory.LocalService {
   import LocalSparkKernel.kernelCounter
 
   // all the JARs in Spark's classpath. I don't think this is actually needed.


### PR DESCRIPTION
- Adds a secondary channel to the remote kernel client/server dedicated to notebook updates.
- Makes a subtrait `Kernel.Factory.LocalService` which doesn't require `NotebookUpdates`. Remote kernel client must use a local kernel, which simplifies some logic and removes the need for a `Topic` and a `Queue` (this makes remote kernel a lot more performant; should also help alleviate some issues with notebook synchronization)
- Sets up some future changes wrt allowing the remote client to have a whole pool of channels for sending responses – so that large responses won't block other interaction with the remote kernel