### PR TITLE
Disable spellcheck on code cells

### DIFF
--- a/polynote-frontend/polynote/ui/component/cell.ts
+++ b/polynote-frontend/polynote/ui/component/cell.ts
@@ -400,6 +400,7 @@ export class CodeCell extends Cell {
 
         this.editorEl.style.height = (this.editor.getScrollHeight()) + "px";
         this.editorEl.contentEditable = 'true'; // so right-click copy/paste can work.
+        this.editorEl.setAttribute('spellcheck', 'false');  // so code won't be spellchecked
         this.editor.layout();
 
         this.editor.onDidFocusEditorWidget(() => {


### PR DESCRIPTION
We turn on `contenteditable` for code cells so that OS-level context menu will have copy/paste on mac. This has the side effect of enabling spell checking which is a disaster for code.