### PR TITLE
Various bug fixes:

### DIFF
--- a/polynote-frontend/polynote/ui/component/display_content.ts
+++ b/polynote-frontend/polynote/ui/component/display_content.ts
@@ -2,7 +2,7 @@
 
 import * as monaco from "monaco-editor";
 import {Content, details, div, span, tag, TagElement} from "../util/tags";
-import {ArrayType, DataType, MapType, StructField, StructType} from "../../data/data_type";
+import {ArrayType, DataType, MapType, OptionalType, StructField, StructType} from "../../data/data_type";
 
 export function displayContent(contentType: string, content: string | DocumentFragment, contentTypeArgs?: Record<string, string>): Promise<TagElement<any>> {
     const [mimeType, args] = contentTypeArgs ? [contentType, contentTypeArgs] : parseContentType(contentType);
@@ -232,6 +232,11 @@ export function displaySchema(structType: StructType): HTMLElement {
                 ])
             ]);
         }
+
+        if (field.dataType instanceof OptionalType) {
+            return displayField(new StructField(field.name + "?", field.dataType.element));
+        }
+        
         const typeName = field.dataType.typeName();
         const attrs = {"data-fieldType": typeName} as any;
         return tag("li", ['object-field'], attrs, [

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -1585,6 +1585,7 @@ button.inspect.icon-button {
   grid-template-areas: "head" "body";
   grid-template-rows: 2em 1fr;
   display: grid;
+  width: 100%;
 
   .ui-panel-content {
     display: inline-block;
@@ -1597,8 +1598,6 @@ button.inspect.icon-button {
   background-color: @ui-background;
   border-left: 1px solid @ui-border;
 
-  // so the ui-panel-content can scroll properly
-  position: absolute;
   max-height: 100%;
   width: 100%;
 
@@ -1969,9 +1968,8 @@ button {
 }
 
 .grid-shell {
-  display: grid;
-  grid-template-rows: 1fr;
-  grid-template-columns: 1fr;
+  display: flex;
+  flex-direction: row;
   position: relative;
   background-color: @ui-background;
 }

--- a/polynote-kernel/src/main/scala/polynote/kernel/ScalaCompiler.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/ScalaCompiler.scala
@@ -331,8 +331,8 @@ class ScalaCompiler private (
     }
 
     // the type representing this cell's class. It may be null or NoType if invoked before compile is done!
-    def cellClassType: Type = exitingTyper(wrappedClass.symbol.info)
-    def cellClassSymbol: ClassSymbol = exitingTyper(wrappedClass.symbol.asClass)
+    lazy val cellClassType: Type = exitingTyper(wrappedClass.symbol.info)
+    lazy val cellClassSymbol: ClassSymbol = exitingTyper(wrappedClass.symbol.asClass)
     lazy val cellCompanionSymbol: ModuleSymbol = exitingTyper(companion.symbol.asModule)
     lazy val cellInstSymbol: Symbol = exitingTyper(cellCompanionSymbol.info.member(TermName("instance")).accessedOrSelf)
     lazy val cellInstType: Type = exitingTyper(cellCompanionSymbol.info.member(TypeName("Inst")).info.dealias)
@@ -358,6 +358,13 @@ class ScalaCompiler private (
         reporter.attempt {
           run.compileUnits(List(compilationUnit), run.namerPhase)
           exitingTyper(compilationUnit.body)
+          // materialize these lazy vals now while the run is still active
+          val _1 = cellClassSymbol
+          val _2 = cellClassType
+          val _3 = cellCompanionSymbol
+          val _4 = cellInstSymbol
+          val _5 = cellInstType
+          val _6 = typedOutputs
         }
       }.lock(compilerThread).absolve
     }.flatten

--- a/polynote-server/src/main/scala/polynote/server/KernelPublisher.scala
+++ b/polynote-server/src/main/scala/polynote/server/KernelPublisher.scala
@@ -158,7 +158,7 @@ class KernelPublisher private (
     subscriber         <- KernelSubscriber(subscriberId, this)
   } yield subscriber
 
-  def close(): Task[Unit] = closed.succeed(()).const(())
+  def close(): Task[Unit] = closed.succeed(()).const(()) *> taskManager.shutdown()
 
   private def createKernel(): TaskR[BaseEnv with GlobalEnv, Kernel] = kernelFactory()
     .provideSomeM(Env.enrichM[BaseEnv with GlobalEnv](kernelFactoryEnv))

--- a/polynote-spark/src/main/scala/polynote/kernel/KernelListener.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/KernelListener.scala
@@ -96,9 +96,10 @@ class KernelListener(taskManager: TaskManager.Service, session: SparkSession, ru
 
     jobStages.put(jobId, stageMap)
     jobTasksCompleted.put(jobId, new AtomicInteger(0))
+    val jobName = jobStart.stageInfos.headOption.map(_.name).getOrElse("")
 
     runtime.unsafeRun {
-      taskManager.register(sparkJobTaskId(jobId), label, "", None, Complete) {
+      taskManager.register(sparkJobTaskId(jobId), label, jobName, None, Complete) {
         updater =>
           jobUpdaters.put(jobId, updater)
           cancelJob(jobId)


### PR DESCRIPTION
- Queueing order is still not deterministic sometimes. Change from relying on semaphore permit ordering to an explicit queue.
- Always send the completed execution info when a cell stops for any reason.
- Eagerly materialize some lazy vals in the Scala compiler, while the run is still active (otherwise `exitingTyper` can throw NPE if they get materialized at the wrong time).
- Add the job name to the task for Spark jobs (i.e. "collect at foo:32")
- Tweak CSS to get rid of omnipresent scrollbar in kernel UI
- Fix display of schemas with optional complex types