### PR TITLE
Change name of CI workflow to "Build"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Doing this because that name is what shows up in the build status badge. I'd rather it say "Build passing" than "CI passing".