### PR TITLE
Close subscribers and publishers

### DIFF
--- a/polynote-server/src/main/scala/polynote/server/KernelSubscriber.scala
+++ b/polynote-server/src/main/scala/polynote/server/KernelSubscriber.scala
@@ -14,7 +14,7 @@ import zio.interop.catz._
 
 class KernelSubscriber private[server] (
   id: SubscriberId,
-  closed: Promise[Throwable, Unit],
+  val closed: Promise[Throwable, Unit],
   process: Fiber[Throwable, Unit],
   val publisher: KernelPublisher,
   val lastLocalVersion: AtomicInteger,

--- a/polynote-server/src/main/scala/polynote/server/NotebookManager.scala
+++ b/polynote-server/src/main/scala/polynote/server/NotebookManager.scala
@@ -52,6 +52,7 @@ object NotebookManager {
           writer    <- publisher.notebooksTimed(Duration(1, TimeUnit.SECONDS))
               .evalMap(notebook => repository.saveNotebook(notebook.path, notebook))
               .compile.drain.fork
+          onClose   <- publisher.closed.await.flatMap(_ => openNotebooks.remove(path)).fork
         } yield publisher
       }
 


### PR DESCRIPTION
- Allow subscribers and publishers to be closed
- Remove from notebook manager when publisher is closed
- Remove from socket session when publisher or subscriber are closed
- Close publisher if there's an error launching the kernel

Fixes an issue where failed dependency downloads can cause that notebook to be dead until restart.