### PR TITLE
Revert scodec-stream upgrade

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -115,7 +115,7 @@ val `polynote-kernel` = project.settings(
     "dev.zio" %% "zio-interop-cats" % versions.zioInterop,
     "co.fs2" %% "fs2-io" % versions.fs2,
     "org.scodec" %% "scodec-core" % "1.11.4",
-    "org.scodec" %% "scodec-stream" % "2.0.0",
+    "org.scodec" %% "scodec-stream" % "1.2.0",
     "io.get-coursier" %% "coursier" % versions.coursier,
     "io.get-coursier" %% "coursier-cache" % versions.coursier,
     "io.github.classgraph" % "classgraph" % "4.8.47",

--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/transport.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/transport.scala
@@ -18,7 +18,7 @@ import polynote.messages._
 import scodec.{Codec, Decoder}
 import scodec.codecs.implicits._
 import scodec.bits.BitVector
-import scodec.stream.StreamDecoder
+import scodec.stream.decode
 import zio.Cause._
 import zio.blocking.{Blocking, effectBlocking}
 import zio.clock.Clock
@@ -107,7 +107,7 @@ class SocketTransportServer private (
       Stream.eval(Logging.info("Connected. Decoding incoming messages")).drain ++
         channels.mainChannel.bitVectors
           .interruptWhen(closed.get.either)
-          .through(StreamDecoder.many(Decoder[RemoteResponse]).toPipe[TaskB])
+          .through(scodec.stream.decode.pipe[TaskB, RemoteResponse])
           .handleErrorWith {
             err => Stream.eval(Logging.error("Response stream terminated due to error", err)).drain
           } ++ Stream.eval(Logging.info("Response stream terminated")).drain
@@ -154,8 +154,8 @@ object SocketTransportServer {
 
 class SocketTransportClient private (channels: SocketTransport.Channels, closed: Deferred[Task, Unit]) extends TransportClient {
 
-  private val requestStream = channels.mainChannel.bitVectors.through(StreamDecoder.many(Decoder[RemoteRequest]).toPipe[TaskB])
-  private val updateStream = channels.notebookUpdatesChannel.bitVectors.through(StreamDecoder.many(Decoder[NotebookUpdate]).toPipe[TaskB])
+  private val requestStream = channels.mainChannel.bitVectors.through(decode.pipe[TaskB, RemoteRequest])
+  private val updateStream = channels.notebookUpdatesChannel.bitVectors.through(decode.pipe[TaskB, NotebookUpdate])
 
   def sendResponse(rep: RemoteResponse): TaskB[Unit] = for {
     bytes <- ZIO.fromEither(RemoteResponse.codec.encode(rep).toEither).mapError(err => new RuntimeException(err.message))


### PR DESCRIPTION
Initially upgraded this in an effort to support Scala 2.13 cross-building. But that didn't work out, and the new scodec-stream is incompatible with the fs2 version that http4s uses, and we can't upgrade http4s because they stopped publishing for Scala 2.11 and we have to publish for Scala 2.11 because Spark.

\o/