### PR TITLE
Add python runner script

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -230,7 +230,8 @@ lazy val polynote = project.in(file(".")).aggregate(`polynote-runtime`, `polynot
     val files = jars ++ List(
       (file(".") / "config-template.yml") -> "polynote/config-template.yml",
       (file(".") / "scripts" / "polynote") -> "polynote/polynote",
-      (file(".") / "scripts" / "plugin") -> "polynote/plugin")
+      (file(".") / "scripts" / "plugin") -> "polynote/plugin",
+      (file(".") / "scripts" / "polynote.py") -> "polynote/polynote.py")
 
     // build a .tar.gz by invoking command-line tools. Sorry, Windows.
     val targetDir = crossTarget.value / "polynote"

--- a/scripts/polynote.py
+++ b/scripts/polynote.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+import sys
+from pathlib import Path
+import os
+
+polynote_dir = os.path.dirname(os.path.realpath(__file__))
+os.chdir(polynote_dir)
+
+paths = [ Path(p) for p in sys.path if Path(p).exists() ]
+jep_paths = [ p.joinpath("jep") for p in paths if p.joinpath("jep").exists() ]
+
+if len(jep_paths) >= 1:
+    jep_path = jep_paths[0]
+else:
+    raise Exception("Couldn't find jep library. Try running `pip3 install jep` first.")
+
+plugins_path = Path(polynote_dir).joinpath("plugins.d")
+plugins = []
+
+if plugins_path.exists():
+    plugins = list(plugins_path.glob("*.jar"))
+
+deps_path = Path(polynote_dir).joinpath("deps")
+
+if not(deps_path.exists()):
+    raise Exception("Couldn't find the deps directory. Are we in the polynote installation directory?")
+
+deps = Path(polynote_dir).joinpath("deps").glob("*.jar")
+classpath = "polynote.jar:" + ":".join([ str(d) for d in deps ])
+cmd = f"java -cp polynote.jar:{classpath} -Djava.library.path={jep_path} polynote.Main"
+print(cmd)
+os.system(cmd)


### PR DESCRIPTION
This adds a `polynote.py` runner script as an alternative to the bash script. It's easier to reliably find jep from within python, and the theory is that this will also obviate the need for the `LD_PRELOAD` stuff (since python must already be running!) and will be better about paying attention to virtual environments and such.