### PR TITLE
fix bug in state rewind

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/State.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/State.scala
@@ -127,8 +127,8 @@ trait State {
     if (predicate(this)) {
       return this
     }
-    var s = this
-    while (s != Root && !predicate(s.prev)) {
+    var s = this.prev
+    while (s != Root && !predicate(s)) {
       s = s.prev
     }
     s

--- a/polynote-kernel/src/test/scala/polynote/kernel/interpreter/StateSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/interpreter/StateSpec.scala
@@ -47,4 +47,17 @@ class StateSpec extends FreeSpec with Matchers {
 
   }
 
+  "rewindUntil" - {
+    "find the first state in the chain where the predicate holds" in {
+      val one = State.id(1)
+      val state = State.id(
+        3,
+        State.id(
+          2,
+          one))
+
+      state.rewindUntil(_.id < 3).id shouldEqual 2
+      state.rewindUntil(_.id < 2) shouldEqual one
+    }
+  }
 }


### PR DESCRIPTION
This was causing strange behavior if the Python interpreter was started part of the way through a notebook execution. 