### PR TITLE
Improved compatibility for IDEs and Embedded environments

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -201,6 +201,27 @@ lazy val `polynote-spark` = project.settings(
   `polynote-runtime` % "provided",
   `polynote-runtime` % "test")
 
+val `polynote-embedded` = project.settings(
+  commonSettings,
+  sparkSettings,
+  libraryDependencies ++= Seq(
+    "dev.zio" %% "zio-interop-cats" % versions.zioInterop % "compile",
+    "org.apache.spark" %% "spark-sql" % sparkVersion.value % "compile",
+    "org.apache.spark" %% "spark-repl" % sparkVersion.value % "compile",
+    "org.scala-lang" % "scala-compiler" % scalaVersion.value % "compile",
+    "org.scala-lang" % "scala-reflect" % scalaVersion.value % "compile"
+  ),
+  excludeDependencies ++= Seq(
+    ExclusionRule("org.slf4j", "slf4j-simple")
+  )
+) dependsOn (
+  `polynote-spark`,
+  `polynote-spark-runtime`,
+  `polynote-server`,
+  `polynote-kernel`,
+  `polynote-runtime`
+)
+
 lazy val polynote = project.in(file(".")).aggregate(`polynote-runtime`, `polynote-spark-runtime`, `polynote-kernel`, `polynote-server`, `polynote-spark`)
     .settings(
       commonSettings,

--- a/polynote-embedded/src/test/resources/log4j.properties
+++ b/polynote-embedded/src/test/resources/log4j.properties
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set everything to be logged to the console
+log4j.rootCategory=INFO, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+# Set the default spark-shell log level to WARN. When running the spark-shell, the
+# log level for this class is used to overwrite the root logger's log level, so that
+# the user can have different defaults for the shell and regular Spark apps.
+log4j.logger.org.apache.spark.repl.Main=WARN
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.spark_project.jetty=WARN
+log4j.logger.org.spark_project.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
+
+# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
+log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL
+log4j.logger.org.apache.hadoop.hive.ql.exec.FunctionRegistry=ERROR
+
+# Parquet related logging
+log4j.logger.org.apache.parquet.CorruptStatistics=ERROR
+log4j.logger.parquet.CorruptStatistics=ERROR

--- a/polynote-embedded/src/test/scala/Polynote.scala
+++ b/polynote-embedded/src/test/scala/Polynote.scala
@@ -1,0 +1,3 @@
+object Polynote extends polynote.Main {
+  def main(args: Array[String]): Unit = polynote.Main.main(args)
+}

--- a/polynote-kernel/src/main/scala/polynote/buildinfo/SafeBuildInfo.scala
+++ b/polynote-kernel/src/main/scala/polynote/buildinfo/SafeBuildInfo.scala
@@ -1,0 +1,30 @@
+package polynote.buildinfo
+
+import scala.util.Try
+
+object SafeBuildInfo {
+  private val buildInfoClass: Option[Class[_]] = Try(Class.forName("polynote.buildinfo.BuildInfo$")).toOption
+  private val buildInfoModule = for (buildInfoClass <- buildInfoClass) yield buildInfoClass.getField("MODULE$").get(null)
+
+  val name: String = (for (buildInfoClass <- buildInfoClass; buildInfoModule <- buildInfoModule) yield
+    buildInfoClass.getMethod("name").invoke(buildInfoModule).asInstanceOf[String]
+    ).getOrElse("polynote")
+
+  val version: String = (for (buildInfoClass <- buildInfoClass; buildInfoModule <- buildInfoModule) yield
+    buildInfoClass.getMethod("version").invoke(buildInfoModule).asInstanceOf[String]
+    ).getOrElse("DEV")
+
+  val commit: String = (for (buildInfoClass <- buildInfoClass; buildInfoModule <- buildInfoModule) yield
+    buildInfoClass.getMethod("commit").invoke(buildInfoModule).asInstanceOf[String]
+    ).getOrElse("---")
+
+  val buildTime: scala.Long = (for (buildInfoClass <- buildInfoClass; buildInfoModule <- buildInfoModule) yield
+    buildInfoClass.getMethod("buildTime").invoke(buildInfoModule).asInstanceOf[java.lang.Long].toLong
+    ).getOrElse(System.currentTimeMillis())
+
+  override val toString: String = {
+    "name: %s, version: %s, commit: %s, buildTime: %s" format(
+      name, version, commit, buildTime
+    )
+  }
+}

--- a/polynote-server/src/main/scala/polynote/server/SocketSession.scala
+++ b/polynote-server/src/main/scala/polynote/server/SocketSession.scala
@@ -12,7 +12,7 @@ import org.http4s.Response
 import org.http4s.server.websocket.WebSocketBuilder
 import org.http4s.websocket.WebSocketFrame
 import org.http4s.websocket.WebSocketFrame.Binary
-import polynote.buildinfo.BuildInfo
+import polynote.buildinfo.SafeBuildInfo
 import polynote.kernel
 import polynote.kernel.util.{Publish, RefMap}
 import polynote.kernel.{BaseEnv, ClearResults, GlobalEnv, Kernel, StreamOps, StreamingHandles, TaskG, UpdatedTasks}
@@ -68,8 +68,8 @@ class SocketSession(
     ZIO.access[Interpreter.Factories](_.interpreterFactories).map {
       factories => ServerHandshake(
         (SortedMap.empty[String, String] ++ factories.mapValues(_.head.languageName)).asInstanceOf[TinyMap[TinyString, TinyString]],
-        serverVersion = BuildInfo.version,
-        serverCommit = BuildInfo.commit)
+        serverVersion = SafeBuildInfo.version,
+        serverCommit = SafeBuildInfo.commit)
     }
 }
 

--- a/polynote-spark/src/main/scala/polynote/kernel/LocalSparkKernel.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/LocalSparkKernel.scala
@@ -10,7 +10,7 @@ import cats.syntax.traverse._
 import fs2.concurrent.SignallingRef
 import org.apache.spark.SparkEnv
 import org.apache.spark.sql.SparkSession
-import polynote.buildinfo.BuildInfo
+import polynote.buildinfo.SafeBuildInfo
 import polynote.config.PolynoteConfig
 import polynote.kernel.dependency.CoursierFetcher
 import polynote.kernel.environment.{Config, CurrentNotebook, CurrentTask, Env, InterpreterEnvironment}
@@ -157,7 +157,7 @@ class LocalSparkKernelFactory extends Kernel.Factory.LocalService {
       conf
         .setJars(jars)
         .set("spark.repl.class.outputDir", outputPath.toString)
-        .setAppName(s"Polynote ${BuildInfo.version} session")
+        .setAppName(s"Polynote ${SafeBuildInfo.version} session")
 
       org.apache.spark.repl.Main.createSparkSession()
     }


### PR DESCRIPTION
- Added a separate tip module with needed dependencies for a self-contained classpath.
- Added `SafeBuildInfo` to prevent linking problems with generated `BuildInfo` class in IDE environments.
- Using more common slf4j-log4j with default spark logging setup.

With these changes made, Polynote can be run easily and directly from IDEA and other IDEs without relying on build, packaging, and installation details. This also makes it directly importable into other Java/Scala applications to deploy and launch this as an embedded library.