### PR TITLE
Avoid String.lines for JVM forward-compatibility.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -191,7 +191,7 @@ lazy val `polynote-spark` = project.settings(
     (assemblyOption in assembly).value.copy(
       includeScala = false,
       prependShellScript = Some(
-        IO.read(file(".") / "scripts/polynote").lines.toSeq
+        IO.read(file(".") / "scripts/polynote").linesIterator.toSeq
       ))
   }
 ) dependsOn (


### PR DESCRIPTION
The `lines` method that the base Scala library introduces 
is not compatible with newer versions of Java Virtual Machine.
Detailed explanation in https://github.com/scala/bug/issues/11125