### PR TITLE
Fix numeric aggregations casting

### DIFF
--- a/polynote-runtime/src/main/scala/polynote/runtime/ReprsOf.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/ReprsOf.scala
@@ -210,7 +210,7 @@ private[runtime] trait CollectionReprs extends FromDataReprs { self: ReprsOf.typ
     private def aggregate(col: String, aggName: String): Aggregator[_] = {
       def numericEncoder = enc.field(col) match {
         case Some((getter, colEnc)) if colEnc.numeric.nonEmpty =>
-          val numeric = colEnc.numeric.get.asInstanceOf[Any => Double]
+          val numeric = (colEnc.numeric.get.toDouble(_)).asInstanceOf[Any => Double]
           getter andThen numeric
         case Some(_) => throw new IllegalArgumentException(s"Field $col is not numeric; cannot compute $aggName")
         case None => throw new IllegalArgumentException(s"No field $col in struct")


### PR DESCRIPTION
Numeric aggregations are not working (a `Numeric[T]` is being wrongly cast to `Any => Double`). This PR fixes that.

The problem can be easilly reproduced with the following example:
```scala
case class Person(name: String, age: Int, height: Double)

List(
    Person("Alice", 18, 1.5),
    Person("Bob", 20, 1.60),
    Person("Charlie", 16, 1.45),
    Person("Dennis", 20, 1.80)
)
```

Trying to plot a "mean height" by "age" bar chart fails on master, while it works just fine with this fix.