### PR TITLE
Fix numeric aggregations

### DIFF
--- a/polynote-runtime/src/main/scala/polynote/runtime/ReprsOf.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/ReprsOf.scala
@@ -210,7 +210,7 @@ private[runtime] trait CollectionReprs extends FromDataReprs { self: ReprsOf.typ
     private def aggregate(col: String, aggName: String): Aggregator[_] = {
       def numericEncoder = enc.field(col) match {
         case Some((getter, colEnc)) if colEnc.numeric.nonEmpty =>
-          val numeric = colEnc.numeric.get.asInstanceOf[Any => Double]
+          val numeric = (colEnc.numeric.get.toDouble(_)).asInstanceOf[Any => Double]
           getter andThen numeric
         case Some(_) => throw new IllegalArgumentException(s"Field $col is not numeric; cannot compute $aggName")
         case None => throw new IllegalArgumentException(s"No field $col in struct")

--- a/polynote-runtime/src/main/scala/polynote/runtime/ReprsOf.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/ReprsOf.scala
@@ -189,12 +189,13 @@ private[runtime] trait CollectionReprs extends FromDataReprs { self: ReprsOf.typ
       val resultName: String = s"sum($name)"
     }
 
-    private class CountAggregator(name: String) extends Aggregator[Long] {
+    // FIXME: This should be an Aggregator[Long], but for some reason that's not working
+    private class CountAggregator(name: String) extends Aggregator[Double] { 
       private var count = 0L
       override def reset(): Unit = count = 0L 
       override def accumulate(value: B): Unit = count += 1
-      override def summarize(): Long = count
-      val encoder: DataEncoder[Long] = DataEncoder.long
+      override def summarize(): Double = count.toDouble
+      val encoder: DataEncoder[Double] = DataEncoder.double
       val resultName: String = s"count($name)"
     }
 


### PR DESCRIPTION
Fixes numeric aggregations (counts and quartiles).

I'm not exactly sure what's going on, other than:
- The `groupTransform` function is being called more than once, but it's not RT, so aggregations are being computed more than once.
  - I added a `reset()` method to the aggregations, so that at least the computed values are correct
- Results from `Aggregator[Long]` are not showing up in the frontend. Might be related to the `DataEncoder.double`
  - I changed the `CountAggregator` to an `Aggregator[Double]` for the time being.

Depends on #566 (I decided to open another PR, since the changes presented here are just hacks, so it might make sense to merge the other PR and reject this one).