### PR TITLE
Package cells spark

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/ScalaCompiler.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/ScalaCompiler.scala
@@ -336,7 +336,7 @@ class ScalaCompiler private (
     // Wrap the code in a class within the given package. Constructing the class runs the code.
     // The constructor parameters are
     private lazy val wrapped: PackageDef = compiledCode match {
-      case (pkg @ PackageDef(_, stats)) :: Nil => atPos(wrappedPos)(pkg.copy(stats = copyAndReset(inheritedImports.externalImports) ::: stats))
+      case (pkg @ PackageDef(_, stats)) :: Nil => atPos(wrappedPos)(pkg)
       case code => atPos(wrappedPos) {
         q"""
           package $packageName {

--- a/polynote-runtime/src/main/scala/polynote/runtime/DataEncoder.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/DataEncoder.scala
@@ -45,7 +45,7 @@ object DataEncoder extends DataEncoder0 {
   implicit val double: DataEncoder[Double] = numericInstance(DoubleType)(_ writeDouble _)
   implicit val string: DataEncoder[String] = sizedInstance[String](StringType, str => if (str == null) 4 else str.getBytes(StandardCharsets.UTF_8).length + 4) {
     (out, str) =>
-      if (out == null) {
+      if (str == null) {
         out.writeInt(-1)
       } else {
         val bytes = str.getBytes(StandardCharsets.UTF_8)


### PR DESCRIPTION
Package cells break when Spark is enabled, because it tries to import stuff from `spark`. Don't inherit any imports in a package cell, because they're not safe.