### PR TITLE
Fit initial plot to the modal

### DIFF
--- a/polynote-frontend/polynote/ui/component/plot_editor.ts
+++ b/polynote-frontend/polynote/ui/component/plot_editor.ts
@@ -193,6 +193,17 @@ export class PlotEditor extends EventTarget {
 
         this.container = div(['plot-editor-container'], [this.el]);
 
+        this.container.addEventListener("TabDisplayed" as any, evt => {
+           const maxWidth = this.plotArea.offsetWidth * 0.8;
+           const maxHeight = this.plotArea.offsetHeight * 0.8;
+           const width = Math.min((+this.plotWidthInput.value), maxWidth).toFixed(0);
+           const height = Math.min((+this.plotHeightInput.value), maxHeight).toFixed(0);
+           this.plotHeightInput.value = height;
+           this.plotWidthInput.value = width;
+           this.plotOutput.style.width = `${width}px`;
+           this.plotOutput.style.height = `${height}px`;
+        });
+
         this.saveButton.style.display = 'none';
 
         this.plotOutput.style.width = '960px';

--- a/polynote-frontend/polynote/ui/component/tab_nav.ts
+++ b/polynote-frontend/polynote/ui/component/tab_nav.ts
@@ -54,6 +54,9 @@ export class TabNav extends UIMessageTarget {
         }
 
         this.content.appendChild(tabContent);
+        if (this.content.offsetWidth) {
+            tabContent.dispatchEvent(new CustomEvent("TabDisplayed"));
+        }
 
         this.selectedItem = name;
     }

--- a/polynote-frontend/polynote/ui/component/value_inspector.ts
+++ b/polynote-frontend/polynote/ui/component/value_inspector.ts
@@ -68,12 +68,15 @@ export class ValueInspector extends FullScreenModal {
         return tabsPromise.then(tabs => {
             if (Object.keys(tabs).length) {
                 const nav = new TabNav(tabs);
-                if (jumpTo && tabs[jumpTo]) {
-                    nav.showItem(jumpTo);
-                }
                 this.content.appendChild(nav.el);
                 this.setTitle(`Inspect: ${resultValue.name}`);
                 this.show();
+
+                if (jumpTo && tabs[jumpTo]) {
+                    nav.showItem(jumpTo);
+                } else {
+                    Object.values(tabs).shift().dispatchEvent(new CustomEvent('TabDisplayed'))
+                }
             }
         })
     }


### PR DESCRIPTION
If the window is too small to fit a 960x480 plot, then the axes are clipped and you have to shrink the plot before you can do anything. It's also easy to miss the fact that the axes are even there, so you might not even realize that you have to shrink the plot.

Attempts to automatically adjust the initial plot size to fit the available size.