### PR TITLE
make sure to set sys.argv

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/python/PythonInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/python/PythonInterpreter.scala
@@ -194,6 +194,9 @@ class PythonInterpreter private[python] (
       |from polynote.kernel import Pos
       |from polynote.kernel import KernelReport
       |
+      |if not hasattr(sys, 'argv') or len(sys.argv) == 0:
+      |    sys.argv  = ['']
+      |
       |class LastExprAssigner(ast.NodeTransformer):
       |
       |    # keep track of last line of initial tree passed in


### PR DESCRIPTION
Solves issues with libraries that expect sys.argv to be set and have some value. 