### PR TITLE
Switch to SharedInterpreters

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,0 +1,28 @@
+FROM openjdk:8-slim-buster
+
+WORKDIR /opt
+
+RUN apt update -y && \
+    apt install -y wget python3 python3-dev python3-pip build-essential && \
+    pip3 install jep jedi virtualenv
+
+# First, create the distribution with `sbt dist`
+# Then this from the dist target directory (e.g., `target/scala-2.11`) using `-f ../../docker/dev/Dockerfile` to select this file.
+# for example (don't forget the dot at the end!):
+#   docker build -t polynote:dev -f ../../docker/dev/Dockerfile .
+COPY polynote-dist.tar.gz .
+RUN tar xfzp polynote-dist.tar.gz && \
+    rm polynote-dist.tar.gz
+
+RUN wget -q https://www-us.apache.org/dist/spark/spark-2.4.4/spark-2.4.4-bin-hadoop2.7.tgz && \
+    tar xfz spark-2.4.4-bin-hadoop2.7.tgz && \
+    rm spark-2.4.4-bin-hadoop2.7.tgz
+
+ENV SPARK_HOME="/opt/spark-2.4.4-bin-hadoop2.7"
+ENV PATH="$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin"
+
+RUN pip3 install pyspark==2.4.4
+
+EXPOSE 8192
+
+ENTRYPOINT ["./polynote/polynote.py"]

--- a/docs/examples/Accessing a Python object in Scala.ipynb
+++ b/docs/examples/Accessing a Python object in Scala.ipynb
@@ -7,14 +7,9 @@
       "exclusions" : [
       ],
       "repositories" : [
-        {
-          "ivy" : {
-            "base" : "https://artifacts.netflix.com/libs-releases-local"
-          }
-        }
       ],
       "sparkConfig" : {
-        "" : ""
+
       }
     }
   },

--- a/docs/examples/Accessing a Scala object in Python.ipynb
+++ b/docs/examples/Accessing a Scala object in Python.ipynb
@@ -7,14 +7,9 @@
       "exclusions" : [
       ],
       "repositories" : [
-        {
-          "ivy" : {
-            "base" : "https://artifacts.netflix.com/libs-releases-local"
-          }
-        }
       ],
       "sparkConfig" : {
-        "" : ""
+
       }
     }
   },

--- a/docs/examples/Case class access in Python.ipynb
+++ b/docs/examples/Case class access in Python.ipynb
@@ -7,14 +7,9 @@
       "exclusions" : [
       ],
       "repositories" : [
-        {
-          "ivy" : {
-            "base" : "https://artifacts.netflix.com/libs-releases-local"
-          }
-        }
       ],
       "sparkConfig" : {
-        "" : ""
+
       }
     }
   },

--- a/docs/examples/Hello World.ipynb
+++ b/docs/examples/Hello World.ipynb
@@ -7,14 +7,9 @@
       "exclusions" : [
       ],
       "repositories" : [
-        {
-          "ivy" : {
-            "base" : "https://artifacts.netflix.com/libs-releases-local"
-          }
-        }
       ],
       "sparkConfig" : {
-        "" : ""
+
       }
     }
   },

--- a/docs/examples/Plotting Scala data with Matplotlib.ipynb
+++ b/docs/examples/Plotting Scala data with Matplotlib.ipynb
@@ -2,19 +2,16 @@
   "metadata" : {
     "config" : {
       "dependencies" : {
-        
+        "python" : [
+          "matplotlib"
+        ]
       },
       "exclusions" : [
       ],
       "repositories" : [
-        {
-          "ivy" : {
-            "base" : "https://artifacts.netflix.com/libs-releases-local"
-          }
-        }
       ],
       "sparkConfig" : {
-        "" : ""
+
       }
     }
   },

--- a/docs/examples/Scala Spark to Pandas.ipynb
+++ b/docs/examples/Scala Spark to Pandas.ipynb
@@ -9,11 +9,6 @@
       "exclusions" : [
       ],
       "repositories" : [
-        {
-          "ivy" : {
-            "base" : "https://artifacts.netflix.com/libs-releases-local"
-          }
-        }
       ],
       "sparkConfig" : {
         "spark.driver.memory" : "2g"

--- a/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
@@ -52,7 +52,7 @@ object KernelIsolation {
 
 final case class Behavior(
   dependencyIsolation: Boolean = true,
-  kernelIsolation: KernelIsolation = KernelIsolation.SparkOnly
+  kernelIsolation: KernelIsolation = KernelIsolation.Always
 )
 
 object Behavior {

--- a/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
@@ -17,7 +17,7 @@ object PySparkInterpreter {
     def apply(): RIO[Blocking with Config with ScalaCompiler.Provider with CurrentNotebook with CurrentTask with TaskManager, Interpreter] = for {
       venv        <- VirtualEnvFetcher.fetch()
       gatewayRef   = new AtomicReference[GatewayServer]()
-      interpreter <- PythonInterpreter(venv, "py4j" :: "pyspark" :: PythonInterpreter.sharedModules, getPy4JError(gatewayRef))
+      interpreter <- PythonInterpreter(venv, getPy4JError(gatewayRef))
       _           <- setupPySpark(interpreter, gatewayRef)
     } yield interpreter
 


### PR DESCRIPTION
* Improves Jep + virtualenv behavior when using remote kernels at the
  expense of degrading their performance on local kernels: Local kernels
  will now share dependencies across notebooks, unfortunately.
  Since local kernels are not really used except for development, this
  shouldn't be too much of a problem but it's still annoying. Open to
  suggestions on how to fix this.  Maybe Polynote can handle setting
  the `sys.path` for each notebook?
* Set kernelIsolation default to Always.