### PR TITLE
Add Storage Mounts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -217,7 +217,7 @@ lazy val polynote = project.in(file(".")).aggregate(`polynote-runtime`, `polynot
         val jars = ((assembly in (`polynote-spark`, Compile)).value -> "polynote/polynote.jar") +:
           ((polynoteJars in (`polynote-spark`, Compile)).value ++ (dependencyJars in (`polynote-spark`, Compile)).value)
 
-        val examples = IO.listFiles(file(".") / "docs" / "examples").map(f => (f, s"polynote/notebooks/examples/${f.getName}"))
+        val examples = IO.listFiles(file(".") / "docs" / "examples").map(f => (f, s"polynote/examples/${f.getName}"))
 
         val versionTag = scalaBinaryVersion.value match {
           case "2.11" => ""

--- a/config-template.yml
+++ b/config-template.yml
@@ -27,8 +27,12 @@
 ############################################################################################
 
 #storage:
-#  # The location Polynote looks for your notebooks in
-#  dir: notebooks
+#  # Where Polynote looks for notebooks. You can specify multiple mounts. The first mount is used as the
+#  # default mount point in case of ambiguity.
+#  mounts:
+#    - src: notebooks
+#    - src: examples
+#    - src: myteam/ournotebooks/
 #  # The location Polynote puts various caches, such as virtual environments created for your notebooks.
 #  cache: tmp
 

--- a/config-template.yml
+++ b/config-template.yml
@@ -27,12 +27,17 @@
 ############################################################################################
 
 #storage:
-#  # Where Polynote looks for notebooks. You can specify multiple mounts. The first mount is used as the
-#  # default mount point in case of ambiguity.
+#  # The base directory Polynote should use when looking for notebooks. This location can be absolute or
+#  # relative to Polynote's working directory.
+#  dir: notebooks
+#  # These are additional mount points. Folders specified here will be 'mounted' into the base directory
+#  # and visible by their keys - so `foo: dir: bar` will show a folder `foo` in the UI that shows the contents of the
+#  # file system under `bar/`
 #  mounts:
-#    - src: notebooks
-#    - src: examples
-#    - src: myteam/ournotebooks/
+#    examples:
+#      dir: examples
+#    team_notebooks:
+#      dir: /shared/notebooks
 #  # The location Polynote puts various caches, such as virtual environments created for your notebooks.
 #  cache: tmp
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -38,30 +38,43 @@ Next, make a `config.yml` file with the following contents:
 ```
 listen:
   host: 0.0.0.0
+
+storage:
+  mounts:
+    - src: /opt/notebooks
+    - src: examples
 ```
 
-> This tells Polynote to listen on all interfaces inside the Docker container. While this is probably fine for trying it out, it's not fit for production settings. 
+> The `listen` directive tells Polynote to listen on all interfaces inside the Docker container. 
+> While this is probably fine for trying it out, it's not fit for production settings. 
+>
+> The `storage` directive specifies `/opt/notebooks` as the primary notebook location. It also tells Polynote to 
+> mount the examples directory that is present in the Docker distribution as a secondary mount, allowing you to see the
+> examples and try them out! 
+> Note that changes to the examples might not be persisted onto the host if you follow the instructions below.
 
 Ok, now we are ready to run the Docker container! Use the following command: 
 
 ```
-docker run --rm -it -e PYSPARK_ALLOW_INSECURE_GATEWAY=1 -p 127.0.0.1:8192:8192 -p 127.0.0.1:4040-4050:4040-4050 -v `pwd`:/opt/config -v `pwd`/notebooks:/opt/polynote/notebooks/notebooks polynote/polynote:latest --config /opt/config/config.yml
+docker run --rm -it -e PYSPARK_ALLOW_INSECURE_GATEWAY=1 -p 127.0.0.1:8192:8192 -p 127.0.0.1:4040-4050:4040-4050 -v `pwd`:/opt/config -v `pwd`/notebooks:/opt/notebooks polynote/polynote:latest --config /opt/config/config.yml
 ```
 
 Let's go over what this command does. 
 
 - `-e PYSPARK_ALLOW_INSECURE_GATEWAY=1` Unfortunately this is needed due to [this bug](https://github.com/polynote/polynote/issues/602). 
 - `-p 127.0.0.1:8192:8192` This binds `127.0.0.1:8192` on the host machine to port `8192` inside the container.
+- `-p 127.0.0.1:4040-4050:4040-4050` This binds a range of ports on the host machine so you can see the Spark UI. 
 - ``-v `pwd`:/opt/config`` This mounts the current directory (the one you just created) into the container at `/opt/config`
-- ``-v `pwd`/notebooks:/opt/polynote/notebooks/notebooks`` This mounts the `./notebooks` directory into the container at `/opt/polynote/notebooks/notebooks`, so that any notebooks you create are saved back to the host. 
+- ``-v `pwd`/notebooks:/opt/notebooks`` This mounts the `./notebooks` directory on the host into the container at `/opt/notebooks`, so that any notebooks you create are saved back to the host. 
 - `polynote/polynote:latest` pulls the latest Polynote image
 - `--config /opt/config/config.yml` tells Polynote to use the `config.yml` file you created earlier. 
 
-Great! Now just open up Chrome and navigate over to http://localhost:8192/ and you'll see the Polynote UI! You'll see the example folder show up on the left. Open it up and run some of the examples! :smile: 
+Great! Now just open up Chrome and navigate over to http://localhost:8192/ and you'll see the Polynote UI! You'll see the example folder show up on the left. 
+Open it up and run some of the examples! :smile: 
 
-> Note: Changes you make to the example notebooks won't persist, since they aren't mounted to the host. This is due to the way Docker's mounts work as far as I can tell. 
+> Note: Changes you make to the example notebooks won't persist, since they aren't mounted to the host.
 
-To make a new notebook that will persist the the host, make sure to prefix the notebook name with `notebooks/`. For example, click the new notebook button and type "notebooks/my first notebook" into the dialog box. You should see the notebooks folder appear on the left with your new notebook in it. 
+Try making a new notebook by clicking the new notebook button and typing "my first notebook" into the dialog box. You should see it show up in the notebooks tree!
 
 Now, if you open up a new terminal window and run `ls -l ~/polynote-docker/notebooks`, you should see `my first notebook.ipynb` on your host machine!
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -40,9 +40,10 @@ listen:
   host: 0.0.0.0
 
 storage:
+  dir: /opt/notebooks
   mounts:
-    - src: /opt/notebooks
-    - src: examples
+    examples:
+      dir: examples
 ```
 
 > The `listen` directive tells Polynote to listen on all interfaces inside the Docker container. 

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -7,8 +7,9 @@ RUN apt update -y && \
     pip3 install jep jedi virtualenv
 
 # First, create the distribution with `sbt dist`
-# Then this from the dist target directory (e.g., `target/scala-2.11`) using `-f ../../docker/dev/Dockerfile` to select this file.
+# Then build this from the dist target directory (e.g., `target/scala-2.11`) using `-f ../../docker/dev/Dockerfile` to select this file.
 # for example (don't forget the dot at the end!):
+#   cd target/scala-2.11/
 #   docker build -t polynote:dev -f ../../docker/dev/Dockerfile .
 COPY polynote-dist.tar.gz .
 RUN tar xfzp polynote-dist.tar.gz && \

--- a/polynote-frontend/polynote/data/messages.ts
+++ b/polynote-frontend/polynote/data/messages.ts
@@ -457,13 +457,13 @@ export class ListNotebooks extends Message {
 }
 
 export class CreateNotebook extends Message {
-    static codec = combined(shortStr, optional(either(shortStr, str as Codec<string>))).to(CreateNotebook);
+    static codec = combined(shortStr, optional(str)).to(CreateNotebook);
     static get msgTypeId() { return 14; }
     static unapply(inst: CreateNotebook): ConstructorParameters<typeof CreateNotebook> {
-        return [inst.path, inst.uriOrContents];
+        return [inst.path, inst.content];
     }
 
-    constructor(readonly path: string, readonly uriOrContents?: Left<string> | Right<string>) {
+    constructor(readonly path: string, readonly content?: string) {
         super();
         Object.freeze(this);
     }

--- a/polynote-frontend/polynote/ui/component/notebook_list.ts
+++ b/polynote-frontend/polynote/ui/component/notebook_list.ts
@@ -1,15 +1,14 @@
 import {
-    ImportNotebook,
-    UIMessage,
-    UIMessageTarget,
     CreateNotebook,
-    RenameNotebook,
     DeleteNotebook,
+    ImportNotebook,
+    ModalClosed,
+    RenameNotebook,
     TriggerItem,
-    UIToggle,
-    ModalClosed
+    UIMessageTarget,
+    UIToggle
 } from "../util/ui_event";
-import {button, div, h2, iconButton, span, a, tag, TagElement, textbox} from "../util/tags";
+import {a, button, div, h2, iconButton, span, tag, TagElement, textbox} from "../util/tags";
 import {storage} from "../util/storage";
 import {Modal} from "./modal";
 
@@ -208,10 +207,6 @@ export class NotebookListUI extends UIMessageTarget {
                 h2([], [
                     'Notebooks',
                     span(['buttons'], [
-                        iconButton(['import-notebook'], 'Import a notebook', 'file-import', 'Import').click(evt => {
-                            evt.stopPropagation();
-                            this.publish(new ImportNotebook());
-                        }),
                         iconButton(['create-notebook'], 'Create new notebook', 'plus-circle', 'New').click(evt => {
                             evt.stopPropagation();
                             this.publish(new CreateNotebook());

--- a/polynote-frontend/polynote/ui/component/notebook_list.ts
+++ b/polynote-frontend/polynote/ui/component/notebook_list.ts
@@ -454,7 +454,6 @@ export class CreateNotebookDialog extends Modal {
     private dialogContent: TagElement<"div">;
     private onComplete: (path: string) => void;
     private onCancel: () => void;
-    private path?: string;
 
     private static INSTANCE: CreateNotebookDialog;
 
@@ -463,7 +462,6 @@ export class CreateNotebookDialog extends Modal {
             CreateNotebookDialog.INSTANCE = new CreateNotebookDialog();
         }
         const inst = CreateNotebookDialog.INSTANCE;
-        inst.path = path;
         return new Promise((complete, cancel) => {
             inst.onComplete = complete;
             inst.onCancel = cancel;
@@ -501,12 +499,11 @@ export class CreateNotebookDialog extends Modal {
     }
 
     complete() {
-        const path = this.path ? [this.path, this.pathInput.value].join('/') : this.pathInput.value;
         const onComplete = this.onComplete;
         this.onCancel = () => null;
         this.onComplete = _ => null;
         this.hide();
-        onComplete(path);
+        onComplete(this.pathInput.value);
     }
 }
 

--- a/polynote-frontend/polynote/ui/component/ui.ts
+++ b/polynote-frontend/polynote/ui/component/ui.ts
@@ -313,26 +313,12 @@ export class MainUI extends UIMessageTarget {
         }
     }
 
-    importNotebook(name?: string, content?: string) {
-        const handler = SocketSession.get.addMessageListener(messages.CreateNotebook, (actualPath) => {
-            SocketSession.get.removeMessageListener(handler);
+    importNotebook(name: string, content: string) {
+        SocketSession.get.listenOnceFor(messages.CreateNotebook, (actualPath) => {
             this.browseUI.addItem(actualPath);
             this.loadNotebook(actualPath);
         });
-
-        if (name && content) { // the evt has all we need
-            SocketSession.get.send(new messages.CreateNotebook(name, Either.right(content)));
-        } else {
-            const userInput = prompt("Enter the full URL of another Polynote instance.");
-            const notebookURL = userInput && new URL(userInput);
-
-            if (notebookURL && notebookURL.protocol.startsWith("http")) {
-                const nbFile = decodeURI(notebookURL.pathname.split("/").pop()!);
-                notebookURL.search = "download=true";
-                notebookURL.hash = "";
-                SocketSession.get.send(new messages.CreateNotebook(nbFile, Either.left(notebookURL.href)));
-            }
-        }
+        SocketSession.get.send(new messages.CreateNotebook(name, content));
     }
 
     handleHashChange() {

--- a/polynote-frontend/polynote/ui/util/ui_event.ts
+++ b/polynote-frontend/polynote/ui/util/ui_event.ts
@@ -147,7 +147,7 @@ export class CellsLoaded extends UIMessage {
 }
 
 export class ImportNotebook extends UIMessage {
-    constructor(readonly name?: string, readonly content?: string) { super(); }
+    constructor(readonly name: string, readonly content: string) { super(); }
     static unapply(inst: ImportNotebook): ConstructorParameters<typeof ImportNotebook> {
         return [inst.name, inst.content]
     }

--- a/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
+++ b/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
@@ -268,7 +268,7 @@ object StartKernel extends MessageCompanion[StartKernel](12) {
 final case class ListNotebooks(paths: List[ShortString]) extends Message
 object ListNotebooks extends MessageCompanion[ListNotebooks](13)
 
-final case class CreateNotebook(path: ShortString, externalURI: Option[Either[ShortString, String]] = None) extends Message
+final case class CreateNotebook(path: ShortString, maybeContent: Option[String] = None) extends Message
 object CreateNotebook extends MessageCompanion[CreateNotebook](14)
 
 final case class RenameNotebook(path: ShortString, newPath: ShortString) extends Message

--- a/polynote-kernel/src/test/scala/polynote/config/PolynoteConfigSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/config/PolynoteConfigSpec.scala
@@ -29,10 +29,10 @@ class PolynoteConfigSpec extends FlatSpec with Matchers with EitherValues {
         |
         |storage:
         |  cache: tmp
+        |  dir: notebooks
         |  mounts:
-        |    - src: notebooks
-        |    - src: examples
-        |      name: Polynote Examples
+        |    examples:
+        |      dir: examples
         |
         |# Default repositories can be specified. Uncommenting the following lines would add four default repositories which are inherited by new notebooks.
         |repositories:
@@ -72,7 +72,7 @@ class PolynoteConfigSpec extends FlatSpec with Matchers with EitherValues {
         host = "1.1.1.1",
         port = 8193
       ),
-      Storage("tmp", List(Mount("notebooks"), Mount("examples"))),
+      Storage("tmp", dir = "notebooks", Map("examples" -> Mount("examples"))),
       List(
         ivy("https://my-artifacts.org/artifacts/"),
         ivy(
@@ -105,18 +105,5 @@ class PolynoteConfigSpec extends FlatSpec with Matchers with EitherValues {
     parsed.right.value.behavior.sharedPackages shouldEqual List("com.esotericsoftware.kryo", "org.myclass")
     parsed.right.value.behavior.getSharedString shouldEqual
       "^(com.esotericsoftware.kryo|org.myclass|scala|javax?|jdk|sun|com.sun|com.oracle|polynote|org.w3c|org.xml|org.omg|org.ietf|org.jcp|org.apache.spark|org.spark_project|org.glassfish.jersey|org.jvnet.hk2|org.apache.hadoop|org.codehaus|org.slf4j|org.log4j|org.apache.log4j)\\."
-  }
-
-  it should "convert old Storage configs to the new format" in {
-    val oldStorageConfig =
-      """
-        |storage:
-        | cache: tmp
-        | dir: foo
-        |
-        |""".stripMargin
-
-    val config = yaml.parser.parse(oldStorageConfig).flatMap(_.as[PolynoteConfig]).right.value
-    config shouldEqual PolynoteConfig(storage=Storage("tmp", List(Mount("foo"))))
   }
 }

--- a/polynote-kernel/src/test/scala/polynote/config/PolynoteConfigSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/config/PolynoteConfigSpec.scala
@@ -28,7 +28,11 @@ class PolynoteConfigSpec extends FlatSpec with Matchers with EitherValues {
         |  port: 8193
         |
         |storage:
-        |  dir: foo
+        |  cache: tmp
+        |  mounts:
+        |    - src: notebooks
+        |    - src: examples
+        |      name: Polynote Examples
         |
         |# Default repositories can be specified. Uncommenting the following lines would add four default repositories which are inherited by new notebooks.
         |repositories:
@@ -68,7 +72,7 @@ class PolynoteConfigSpec extends FlatSpec with Matchers with EitherValues {
         host = "1.1.1.1",
         port = 8193
       ),
-      Storage("foo"),
+      Storage("tmp", List(Mount("notebooks"), Mount("examples"))),
       List(
         ivy("https://my-artifacts.org/artifacts/"),
         ivy(
@@ -101,5 +105,18 @@ class PolynoteConfigSpec extends FlatSpec with Matchers with EitherValues {
     parsed.right.value.behavior.sharedPackages shouldEqual List("com.esotericsoftware.kryo", "org.myclass")
     parsed.right.value.behavior.getSharedString shouldEqual
       "^(com.esotericsoftware.kryo|org.myclass|scala|javax?|jdk|sun|com.sun|com.oracle|polynote|org.w3c|org.xml|org.omg|org.ietf|org.jcp|org.apache.spark|org.spark_project|org.glassfish.jersey|org.jvnet.hk2|org.apache.hadoop|org.codehaus|org.slf4j|org.log4j|org.apache.log4j)\\."
+  }
+
+  it should "convert old Storage configs to the new format" in {
+    val oldStorageConfig =
+      """
+        |storage:
+        | cache: tmp
+        | dir: foo
+        |
+        |""".stripMargin
+
+    val config = yaml.parser.parse(oldStorageConfig).flatMap(_.as[PolynoteConfig]).right.value
+    config shouldEqual PolynoteConfig(storage=Storage("tmp", List(Mount("foo"))))
   }
 }

--- a/polynote-server/src/main/scala/polynote/server/NotebookManager.scala
+++ b/polynote-server/src/main/scala/polynote/server/NotebookManager.scala
@@ -1,6 +1,7 @@
 package polynote.server
 
 import java.io.File
+import java.net.URI
 import java.nio.file.{AccessDeniedException, FileAlreadyExistsException, Path}
 import java.util.concurrent.TimeUnit
 
@@ -29,7 +30,7 @@ object NotebookManager {
 
   trait Service {
     def open(path: String): RIO[BaseEnv with GlobalEnv, KernelPublisher]
-    def location(path: String): RIO[BaseEnv with GlobalEnv, String]
+    def location(path: String): RIO[BaseEnv with GlobalEnv, Option[URI]]
     def list(): RIO[BaseEnv with GlobalEnv, List[String]]
     def listRunning(): RIO[BaseEnv with GlobalEnv, List[String]]
     def status(path: String): RIO[BaseEnv with GlobalEnv, KernelBusyState]
@@ -79,7 +80,7 @@ object NotebookManager {
         }
       }
 
-      override def location(path: String): RIO[BaseEnv with GlobalEnv, String] = repository.notebookLoc(path)
+      override def location(path: String): RIO[BaseEnv with GlobalEnv, Option[URI]] = repository.notebookURI(path)
 
       override def list(): RIO[BaseEnv with GlobalEnv, List[String]] = repository.listNotebooks()
 

--- a/polynote-server/src/main/scala/polynote/server/Server.scala
+++ b/polynote-server/src/main/scala/polynote/server/Server.scala
@@ -15,7 +15,7 @@ import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.headers.{`Content-Length`, `Content-Type`}
 import polynote.buildinfo.BuildInfo
 import polynote.config.PolynoteConfig
-import polynote.kernel.environment.Env
+import polynote.kernel.environment.{Config, Env}
 import polynote.kernel.logging.Logging
 import polynote.kernel.{BaseEnv, GlobalEnv, Kernel, interpreter}
 import polynote.messages.Message
@@ -80,6 +80,7 @@ class Server(kernelFactory: Kernel.Factory.Service) extends polynote.app.App wit
     args         <- ZIO.fromEither(Server.parseArgs(args)).orDie
     _            <- Logging.info(s"Loading configuration from ${args.configFile}")
     config       <- PolynoteConfig.load(args.configFile).orDie
+    _            <- Logging.info(s"Loaded configuration: $config")
     port          = config.listen.port
     address       = config.listen.host
     wsKey         = config.security.websocketKey.getOrElse(UUID.randomUUID().toString)
@@ -131,10 +132,11 @@ class Server(kernelFactory: Kernel.Factory.Service) extends polynote.app.App wit
     }
   }
 
-  def downloadFile(path: String, req: Request[Task], config: PolynoteConfig): Task[Response[Task]] = {
-    val nbLoc = new File(System.getProperty("user.dir")).toPath.resolve(s"${config.storage.dir}/$path").toString
-    staticFile(nbLoc, req)
-  }
+  def downloadFile(path: String, req: Request[Task]): ZIO[BaseEnv with GlobalEnv with NotebookManager, Throwable, Response[Task]] = for {
+    notebookManager <- ZIO.access[NotebookManager](_.notebookManager)
+    nbLoc           <- notebookManager.location(path)
+    result          <- staticFile(nbLoc, req).onError(err => Logging.error("Error downloading file", err))
+  } yield result
 
   object DownloadMatcher extends OptionalQueryParamDecoderMatcher[String]("download")
   object KeyMatcher extends QueryParamDecoderMatcher[String]("key")
@@ -160,7 +162,7 @@ class Server(kernelFactory: Kernel.Factory.Service) extends polynote.app.App wit
       case req @ GET -> Root / "ws" :? KeyMatcher(`wsKey`)                  => SocketSession(broadcastAll).flatMap(_.toResponse).provide(env)
       case GET -> Root / "ws"                                               => Forbidden()
       case req @ GET -> Root                                                => indexResponse.provide(env)
-      case req @ GET -> "notebook" /: path :? DownloadMatcher(Some("true")) => downloadFile(path.toList.mkString("/"), req, env.polynoteConfig)
+      case req @ GET -> "notebook" /: path :? DownloadMatcher(Some("true")) => downloadFile(path.toList.mkString("/"), req).provide(env)
       case req @ GET -> "notebook" /: _                                     => indexResponse.provide(env)
       case req @ GET -> (Root / "polynote-assembly.jar")                    => StaticFile.fromFile[Task](new File(getClass.getProtectionDomain.getCodeSource.getLocation.getPath), blockingEC).getOrElseF(NotFound())
       case req @ GET -> path                                                => serveFile(path.toString, req, watchUI)

--- a/polynote-server/src/main/scala/polynote/server/SocketSession.scala
+++ b/polynote-server/src/main/scala/polynote/server/SocketSession.scala
@@ -16,7 +16,7 @@ import polynote.buildinfo.BuildInfo
 import polynote.kernel
 import polynote.kernel.util.{Publish, RefMap}
 import polynote.kernel.{BaseEnv, ClearResults, GlobalEnv, Kernel, StreamOps, StreamingHandles, TaskG, UpdatedTasks}
-import polynote.kernel.environment.{Env, PublishMessage}
+import polynote.kernel.environment.{Config, Env, PublishMessage}
 import polynote.kernel.interpreter.Interpreter
 import polynote.kernel.logging.Logging
 import polynote.messages._
@@ -133,8 +133,8 @@ class SessionHandler(
         case Some(subscriber) => subscriber.close()
       }
 
-    case CreateNotebook(path, maybeUriOrContent) =>
-      notebookManager.create(path, maybeUriOrContent).unit
+    case CreateNotebook(path, maybeContent) =>
+      notebookManager.create(path, maybeContent).unit
 
     case RenameNotebook(path, newPath) =>
       notebookManager.rename(path, newPath).unit

--- a/polynote-server/src/main/scala/polynote/server/repository/NotebookRepository.scala
+++ b/polynote-server/src/main/scala/polynote/server/repository/NotebookRepository.scala
@@ -1,62 +1,212 @@
 package polynote.server.repository
 
-import java.io.FileNotFoundException
+import java.io.{File, FileNotFoundException}
 import java.nio.charset.StandardCharsets
 import java.nio.file.{FileAlreadyExistsException, FileVisitOption, Files, Path}
 
-import cats.effect.{ConcurrentEffect, ContextShift, IO, Sync}
-import cats.syntax.flatMap._
-import cats.syntax.functor._
-import cats.syntax.apply._
+import cats.implicits._
 import io.circe.Printer
-import org.http4s.client.blaze._
-import polynote.config.PolynoteConfig
+import polynote.config.{Mount, PolynoteConfig}
+import polynote.kernel.environment.{Config, Env}
+import polynote.kernel.{BaseEnv, GlobalEnv}
+import polynote.kernel.util.RefMap
 import polynote.messages._
 import polynote.server.repository.ipynb.ZeppelinNotebook
+import zio.{RIO, Task, ZIO}
+import zio.blocking.Blocking
+import zio.interop.catz._
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
-trait NotebookRepository[F[_]] {
+trait NotebookRepository {
 
   /**
     * @return Whether a notebook exists at the specified path
     */
-  def notebookExists(path: String): F[Boolean]
+  def notebookExists(path: String): RIO[BaseEnv with GlobalEnv, Boolean]
+
+  /**
+    * @return The location of the notebook on disk (absolute path)
+    */
+  def notebookLoc(path: String): RIO[BaseEnv with GlobalEnv, String]
 
   /**
     * @return The notebook at the specified path
     */
-  def loadNotebook(path: String): F[Notebook]
+  def loadNotebook(path: String): RIO[BaseEnv with GlobalEnv, Notebook]
 
   /**
     * Save the given notebook to the specified path
     */
-  def saveNotebook(path: String, cells: Notebook): F[Unit]
+  def saveNotebook(path: String, cells: Notebook): RIO[BaseEnv with GlobalEnv, Unit]
 
   /**
     * @return A list of notebook paths that exist in this repository
     */
-  def listNotebooks(): F[List[String]]
+  def listNotebooks(): RIO[BaseEnv with GlobalEnv, List[String]]
 
-  // TODO: imports shouldn't happen on the server anymore... second arg should be Option[Notebook]
   /**
-    * Create a notebook at the given path, optionally importing from the given URI (on the left) or the given content
-    * string (on the right).
+    * Create a notebook at the given path, optionally creating it from the given content string.
+    *
+    * TODO: Server no longer imports. Need to implement this on the client side.
     */
-  def createNotebook(path: String, maybeUriOrContent: Option[Either[String, String]]): F[String]
+  def createNotebook(path: String, maybeContent: Option[String]): RIO[BaseEnv with GlobalEnv, String]
 
-  def renameNotebook(path: String, newPath: String): F[String]
+  def renameNotebook(path: String, newPath: String): RIO[BaseEnv with GlobalEnv, String]
 
-  def deleteNotebook(path: String): F[Unit]
+  def deleteNotebook(path: String): RIO[BaseEnv with GlobalEnv, Unit]
 
   /**
     * Initialize the storage for this repository (i.e. create directory if it doesn't exist)
     */
-  def initStorage(): F[Unit]
+  def initStorage(): RIO[BaseEnv with GlobalEnv, Unit]
 }
 
-abstract class FileBasedRepository[F[_]](implicit F: ConcurrentEffect[F], contextShift: ContextShift[F]) extends NotebookRepository[F] {
+/**
+  * Notebook Repository that understands Storage Mounts [[polynote.config.Mount]].
+  *
+  * Multiplexes multiple Repositories - one for each mount point - based on the notebooks path prefix.
+  *
+  * @param repos:  Map of mount point -> repository
+  * @param mkRepo: How to create a new repository that will handle a specific mount point.
+  */
+class MountAwareRepository (
+  repos: RefMap[String, NotebookRepository],
+  mkRepo: (Path, PolynoteConfig, ExecutionContext) => NotebookRepository
+) extends NotebookRepository {
+
+  val baseMount: RIO[Config, Mount] = for {
+    config <- Config.access
+  } yield config.storage.mounts.head
+
+  def mountFromPath(notebookPath: String): RIO[BaseEnv with GlobalEnv, Mount] = for {
+    config <- Config.access
+    mount  <- ZIO.fromOption(config.storage.mounts.find(mount => notebookPath.startsWith(mount.src)))
+//        .mapError(_ => new FileNotFoundException(s"Unable to find mount for $notebookPath, available mounts: ${config.storage.mounts}"))
+      .catchAll(_ => baseMount) // if it's unprefixed, we default to the base mount.
+  } yield mount
+
+  def getOrCreateRepo(notebookPath: String): RIO[BaseEnv with GlobalEnv, (NotebookRepository, Mount)] = {
+    for {
+      config <- Config.access
+      mount  <- mountFromPath(notebookPath)
+      repo   <- repos.getOrCreate(mount.src) {
+        for {
+          blocking <- ZIO.accessM[Blocking](_.blocking.blockingExecutor)
+          r        = mkRepo(new File(sys.props("user.dir")).toPath.resolve(mount.src), config, blocking.asEC)
+          _        <- r.initStorage()
+        } yield r
+      }
+    } yield (repo, mount)
+  }
+
+  private def relativize(mount: Mount, path: String) = {
+    val mountPath = new File(mount.src).toPath
+    val nbPath = new File(path).toPath
+    if (nbPath.startsWith(mountPath)) mountPath.relativize(nbPath).toString else path
+  }
+
+  private def delegate[T](originalPath: String)(f: (NotebookRepository, String, Mount) => RIO[BaseEnv with GlobalEnv, T]): RIO[BaseEnv with GlobalEnv, T] = {
+    getOrCreateRepo(originalPath).flatMap {
+      case (repo, mount) =>
+        val relativePath = relativize(mount, originalPath)
+        f(repo, relativePath, mount)
+    }
+  }
+
+  override def notebookExists(originalPath: String): RIO[BaseEnv with GlobalEnv, Boolean] = delegate(originalPath) {
+    (repo, relativePath, _) => repo.notebookExists(relativePath)
+  }
+
+  // Because notebookLoc is an absolute path we don't modify it here (in other cases)
+  override def notebookLoc(originalPath: String): RIO[BaseEnv with GlobalEnv, String] = delegate(originalPath) {
+    (repo, relativePath, _) =>
+      repo.notebookLoc(relativePath)
+  }
+
+  override def loadNotebook(originalPath: String): RIO[BaseEnv with GlobalEnv, Notebook] = delegate(originalPath) {
+    (repo, relativePath, mount) =>
+     for {
+       nb <- repo.loadNotebook(relativePath)
+       baseMount <- baseMount
+     } yield if (mount == baseMount) nb else nb.copy(path = s"${mount.src}/${nb.path}")
+  }
+
+  override def saveNotebook(originalPath: String, cells: Notebook): RIO[BaseEnv with GlobalEnv, Unit] = delegate(originalPath) {
+    (repo, relativePath, _) => repo.saveNotebook(relativePath, cells)
+  }
+
+  override def listNotebooks(): RIO[BaseEnv with GlobalEnv, List[String]] = {
+    for {
+      config    <- Config.access
+      mounts    <- config.storage.mounts.map(_.src).map(getOrCreateRepo).sequence
+      baseMount <- baseMount
+      notebooks <- mounts.map {
+        case (repo, mount) =>
+          if (mount == baseMount) {
+            repo.listNotebooks()
+          } else {
+            repo.listNotebooks().map(_.map(nbPath => s"${mount.src}/$nbPath"))
+          }
+      }.sequence
+    } yield notebooks.flatten
+  }
+
+  override def createNotebook(originalPath: String, maybeContent: Option[String]): RIO[BaseEnv with GlobalEnv, String] = delegate(originalPath) {
+    (repo, relativePath, mount) =>
+        for {
+          nbPath <- repo.createNotebook(relativePath, maybeContent)
+          baseMount <- baseMount
+        } yield if (mount == baseMount) nbPath else s"${mount.src}/${nbPath}"
+  //      repo.createNotebook(relativePath, maybeContent).map(nbPath => s"${mount.src}/$nbPath")
+  }
+
+  override def renameNotebook(path: String, newPath: String): RIO[BaseEnv with GlobalEnv, String] = {
+    def rename(oldMount: Mount, newMount: Mount): RIO[BaseEnv with GlobalEnv, String] = {
+      if (oldMount.src == newMount.src) { // same repo, just use the default rename
+        getOrCreateRepo(path).flatMap {
+          case (repo, mount) =>
+            val oldRelPath = relativize(mount, path)
+            val newRelPath = relativize(mount, newPath)
+            for {
+              renamed <- repo.renameNotebook(oldRelPath, newRelPath)
+              baseMount <- baseMount
+            } yield if (mount == baseMount) renamed else s"${mount.src}/$renamed"
+        }
+      } else { // different repos, so we need to do more stuff
+        for {
+          (oldRepo, _) <- getOrCreateRepo(path)
+          oldPath      = relativize(oldMount, path)
+          oldNB        <- oldRepo.loadNotebook(oldPath)
+          (newRepo, _) <- getOrCreateRepo(newPath)
+          newRelPath   = relativize(newMount, newPath)
+          _            <- newRepo.saveNotebook(newRelPath, oldNB)
+          _            <- oldRepo.deleteNotebook(oldPath) // only delete old after the new one was successfully saved
+          baseMount    <- baseMount
+        } yield if (newMount == baseMount) newRelPath else s"${newMount.src}/$newRelPath"
+      }
+    }
+
+
+    for {
+      oldMount  <- mountFromPath(path)
+      newMount  <- mountFromPath(newPath)
+      result    <- rename(oldMount, newMount)
+    } yield result
+  }
+
+  override def deleteNotebook(originalPath: String): RIO[BaseEnv with GlobalEnv, Unit] = delegate(originalPath) {
+    (repo, relativePath, _) => repo.deleteNotebook(relativePath)
+  }
+
+  override def initStorage(): RIO[BaseEnv with GlobalEnv, Unit] = for {
+    config <- Config.access
+    _      <- config.storage.mounts.map(_.src).map(getOrCreateRepo).sequence
+  } yield ()
+}
+
+abstract class FileBasedRepository extends NotebookRepository {
   def path: Path
   def chunkSize: Int
   def executionContext: ExecutionContext
@@ -64,11 +214,11 @@ abstract class FileBasedRepository[F[_]](implicit F: ConcurrentEffect[F], contex
 
   protected def pathOf(relativePath: String): Path = path.resolve(relativePath)
 
-  protected def loadString(path: String): F[String] = for {
+  protected def loadString(path: String): RIO[BaseEnv with GlobalEnv, String] = for {
     content <- readBytes(Files.newInputStream(pathOf(path)), chunkSize, executionContext)
   } yield new String(content.toArray, StandardCharsets.UTF_8)
 
-  def writeString(relativePath: String, content: String): F[Unit] = F.delay {
+  def writeString(relativePath: String, content: String): RIO[BaseEnv with GlobalEnv, Unit] = ZIO {
     val nbPath = pathOf(relativePath)
 
     if (nbPath.getParent != this.path) {
@@ -83,21 +233,26 @@ abstract class FileBasedRepository[F[_]](implicit F: ConcurrentEffect[F], contex
   protected def validNotebook(path: Path): Boolean = path.toString.endsWith(s".$defaultExtension")
   protected def maxDepth: Int = 4
 
-  def listNotebooks(): F[List[String]] =
-    F.delay(Files.walk(path, maxDepth, FileVisitOption.FOLLOW_LINKS).iterator().asScala.drop(1).filter(validNotebook).toList).map {
+  def listNotebooks(): RIO[BaseEnv with GlobalEnv, List[String]] =
+    ZIO(Files.walk(path, maxDepth, FileVisitOption.FOLLOW_LINKS).iterator().asScala.drop(1).filter(validNotebook).toList).map {
       paths => paths.map {
         path => this.path.relativize(path).toString
       }
     }
 
-  def notebookExists(path: String): F[Boolean] = {
+  def notebookExists(path: String): RIO[BaseEnv with GlobalEnv, Boolean] = {
     val repoPath = this.path.resolve(path)
-    F.delay(repoPath.toFile.exists())
+    ZIO(repoPath.toFile.exists())
+  }
+
+  def notebookLoc(path: String): RIO[BaseEnv with GlobalEnv, String] = {
+    val repoPath = this.path.resolve(path)
+    ZIO(repoPath.toAbsolutePath.toString)
   }
 
   val EndsWithNum = """^(.*)(\d+)$""".r
 
-  def findUniqueName(path: String, ext: String): F[String] = {
+  def findUniqueName(path: String, ext: String): RIO[BaseEnv with GlobalEnv, String] = {
     notebookExists(path + ext).flatMap {
       case true =>
         path match {
@@ -107,7 +262,7 @@ abstract class FileBasedRepository[F[_]](implicit F: ConcurrentEffect[F], contex
             findUniqueName(s"${path}2", ext) // start at two because the first one is implicitly #1? Or is that weird?
         }
       case false =>
-        F.pure(path)
+        ZIO.succeed(path)
     }
   }
 
@@ -127,32 +282,26 @@ abstract class FileBasedRepository[F[_]](implicit F: ConcurrentEffect[F], contex
     Some(NotebookConfig.fromPolynoteConfig(config))
   )
 
-  def createNotebook(relativePath: String, maybeUriOrContent: Option[Either[String, String]] = None): F[String] = {
+  def createNotebook(relativePath: String, maybeContent: Option[String] = None): RIO[BaseEnv with GlobalEnv, String] = {
     val ext = s".$defaultExtension"
     val noExtPath = relativePath.replaceFirst("""^/+""", "").stripSuffix(ext)
 
     if (relativeDepth(relativePath) > maxDepth) {
-      F.raiseError(new IllegalArgumentException(s"Input path ($relativePath) too deep, maxDepth is $maxDepth"))
+      ZIO.fail(new IllegalArgumentException(s"Input path ($relativePath) too deep, maxDepth is $maxDepth"))
     } else {
       findUniqueName(noExtPath, ext).flatMap { name =>
         val extPath = name + ext
-        val createOrImport = maybeUriOrContent match {
+        val createOrImport = maybeContent match {
           case None =>
             val defaultTitle = name.split('/').last.replaceAll("[\\s\\-_]+", " ").trim()
             saveNotebook(extPath, emptyNotebook(extPath, defaultTitle))
-          case Some(Left(uri)) =>
-            BlazeClientBuilder[F](executionContext).resource.use { client =>
-              client.expect[String](uri)
-            }.flatMap { content =>
-              writeString(extPath, content)
-            }
-          case Some(Right(content)) =>
+          case Some(content) =>
             if (relativePath.endsWith(".json")) { // assume zeppelin
               import io.circe.parser.parse
               import io.circe.syntax._
               for {
-                parsed <- F.fromEither(parse(content))
-                  zep <- F.fromEither(parsed.as[ZeppelinNotebook])
+                parsed <- ZIO.fromEither(parse(content))
+                  zep <- ZIO.fromEither(parsed.as[ZeppelinNotebook])
                   jup = zep.toJupyterNotebook
                   jupStr = Printer.spaces2.copy(dropNullValues = true).pretty(jup.asJson)
                   io <- writeString(extPath, jupStr)
@@ -166,20 +315,20 @@ abstract class FileBasedRepository[F[_]](implicit F: ConcurrentEffect[F], contex
     }
   }
 
-  def renameNotebook(oldPath: String, newPath: String): F[String] = {
+  def renameNotebook(oldPath: String, newPath: String): RIO[BaseEnv with GlobalEnv, String] = {
     val ext = s".$defaultExtension"
     val withExt = newPath.replaceFirst("""^/+""", "").stripSuffix(ext) + ext
 
     if (relativeDepth(withExt) > maxDepth) {
-      F.raiseError(new IllegalArgumentException(s"Input path ($newPath) too deep, maxDepth is $maxDepth"))
+      ZIO.fail(new IllegalArgumentException(s"Input path ($newPath) too deep, maxDepth is $maxDepth"))
     } else {
       (notebookExists(oldPath), notebookExists(withExt)).mapN(_ -> _).flatMap {
-        case (false, _)    => F.raiseError(new FileNotFoundException(s"File $oldPath doesn't exist"))
-        case (_, true)     => F.raiseError(new FileAlreadyExistsException(s"File $withExt already exists"))
+        case (false, _)    => ZIO.fail(new FileNotFoundException(s"File $oldPath doesn't exist"))
+        case (_, true)     => ZIO.fail(new FileAlreadyExistsException(s"File $withExt already exists"))
         case (true, false) =>
           val absOldPath = pathOf(oldPath)
           val absNewPath = pathOf(withExt)
-          F.delay {
+          ZIO {
             Files.move(absOldPath, absNewPath)
           }.as(withExt)
       }
@@ -187,14 +336,14 @@ abstract class FileBasedRepository[F[_]](implicit F: ConcurrentEffect[F], contex
   }
 
   // TODO: should probably have a "trash" or something instead – a way of recovering a file from accidental deletion?
-  def deleteNotebook(path: String): F[Unit] = {
+  def deleteNotebook(path: String): RIO[BaseEnv with GlobalEnv, Unit] = {
     notebookExists(path).flatMap {
-      case false => F.raiseError(new FileNotFoundException(s"File $path does't exist"))
-      case true  => F.delay(Files.delete(pathOf(path)))
+      case false => ZIO.fail(new FileNotFoundException(s"File $path does't exist"))
+      case true  => ZIO(Files.delete(pathOf(path)))
     }
   }
 
-  def initStorage(): F[Unit] = F.delay {
+  def initStorage(): RIO[BaseEnv with GlobalEnv, Unit] = ZIO {
     if (!Files.exists(path)) {
       Files.createDirectories(path)
     }

--- a/polynote-server/src/main/scala/polynote/server/repository/package.scala
+++ b/polynote-server/src/main/scala/polynote/server/repository/package.scala
@@ -2,15 +2,22 @@ package polynote.server
 
 import java.io.InputStream
 
-import cats.effect.{ContextShift, IO, Sync}
-import cats.syntax.functor._
 import fs2.Chunk
+import polynote.kernel.BaseEnv
+import zio.{RIO, Task, ZIO}
+import zio.blocking.effectBlocking
+import zio.interop.catz._
 
 import scala.concurrent.ExecutionContext
 
 package object repository {
 
-  def readBytes[F[_]](is: => InputStream, chunkSize: Int, executionContext: ExecutionContext)(implicit F: Sync[F], shift: ContextShift[F]): F[Chunk.Bytes] =
-    fs2.io.readInputStream(F.delay(is), chunkSize, executionContext, closeAfterUse = true).compile.toChunk.map(_.toBytes)
+  def readBytes(is: => InputStream, chunkSize: Int, executionContext: ExecutionContext): RIO[BaseEnv, Chunk.Bytes] = {
+    for {
+      env    <- ZIO.environment[BaseEnv]
+      ec     <- env.blocking.blockingExecutor.map(_.asEC)
+      chunks <- fs2.io.readInputStream[Task](effectBlocking(is).provide(env), chunkSize, ec, closeAfterUse = true).compile.toChunk.map(_.toBytes)
+    } yield chunks
+  }
 
 }

--- a/polynote-server/src/test/scala/polynote/server/ServerIntegrationSpec.scala
+++ b/polynote-server/src/test/scala/polynote/server/ServerIntegrationSpec.scala
@@ -5,8 +5,9 @@ import java.util.concurrent.atomic.AtomicInteger
 import fs2.concurrent.Topic
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FeatureSpec, GivenWhenThen}
+import polynote.config.PolynoteConfig
 import polynote.kernel.Kernel.Factory
-import polynote.kernel.environment.NotebookUpdates
+import polynote.kernel.environment.{Env, NotebookUpdates}
 import polynote.kernel.{BaseEnv, CellEnv, GlobalEnv, Kernel}
 import polynote.kernel.util.RefMap
 import polynote.messages.Message
@@ -25,11 +26,11 @@ class ServerIntegrationSpec extends FeatureSpec with ZIOSpec with GivenWhenThen 
   // set up fixture
   private val broadcastAll    = unsafeRun(Topic[Task, Option[Message]](None))
   private val repository      = new MemoryRepository
-  private val notebookManager = unsafeRun(NotebookManager.Service(repository, broadcastAll))
   private val kernel          = mock[Kernel]
   private val kernelFactory   = new Factory.Service {
     def apply(): RIO[BaseEnv with GlobalEnv with CellEnv with NotebookUpdates, Kernel] = ZIO.succeed(kernel)
   }
+  private val notebookManager = unsafeRun(NotebookManager.Service(repository, broadcastAll).provide(Env.enrichWith[BaseEnv, GlobalEnv](Environment, GlobalEnv(PolynoteConfig(), Map.empty, kernelFactory))))
 
   private val nextSessionId = new AtomicInteger(0)
 

--- a/polynote-server/src/test/scala/polynote/testing/repository/MemoryRepository.scala
+++ b/polynote-server/src/test/scala/polynote/testing/repository/MemoryRepository.scala
@@ -9,10 +9,12 @@ import zio.{Task, UIO, ZIO}
 
 import scala.collection.mutable
 
-class MemoryRepository extends NotebookRepository[TaskB] {
+class MemoryRepository extends NotebookRepository {
   private val notebooks = new mutable.HashMap[String, Notebook]()
 
   def notebookExists(path: String): UIO[Boolean] = ZIO.effectTotal(notebooks contains path)
+
+  def notebookLoc(path: String): UIO[String] = ZIO.effectTotal(if (notebooks contains path) path else "")
 
   def loadNotebook(path: String): Task[Notebook] = ZIO.effectTotal(notebooks.get(path)).get.mapError(err => new FileNotFoundException(path))
 
@@ -20,7 +22,7 @@ class MemoryRepository extends NotebookRepository[TaskB] {
 
   def listNotebooks(): UIO[List[String]] = ZIO.effectTotal(notebooks.keys.toList)
 
-  def createNotebook(path: String, maybeUriOrContent: Option[Either[String, String]]): UIO[String] =
+  def createNotebook(path: String, maybeUriOrContent: Option[String]): UIO[String] =
     ZIO.effectTotal(notebooks.put(path, Notebook(path, ShortList.of(), None))).as(path)
 
   def initStorage(): TaskB[Unit] = ZIO.unit

--- a/polynote-server/src/test/scala/polynote/testing/repository/MemoryRepository.scala
+++ b/polynote-server/src/test/scala/polynote/testing/repository/MemoryRepository.scala
@@ -1,6 +1,7 @@
 package polynote.testing.repository
 
 import java.io.FileNotFoundException
+import java.net.URI
 
 import polynote.kernel.TaskB
 import polynote.messages._
@@ -14,7 +15,7 @@ class MemoryRepository extends NotebookRepository {
 
   def notebookExists(path: String): UIO[Boolean] = ZIO.effectTotal(notebooks contains path)
 
-  def notebookLoc(path: String): UIO[String] = ZIO.effectTotal(if (notebooks contains path) path else "")
+  def notebookURI(path: String): UIO[Option[URI]] = ZIO.effectTotal(if (notebooks contains path) Option(new URI(s"memory://$path")) else None)
 
   def loadNotebook(path: String): Task[Notebook] = ZIO.effectTotal(notebooks.get(path)).get.mapError(err => new FileNotFoundException(path))
 


### PR DESCRIPTION
Polynote can now read notebooks from multiple locations, called 'mounts'.

Directories you mount are shown in a unified view, a little bit like symlinked directories in a filesystem. They are 'mounted' onto the root directory configured under `storage.dir`.

For example, consider the following directory structure:

    notebooks/
      nb1.ipynb
    other_notebooks/
      nb2.ipynb

With the following storage configuration:

    storage:
      dir: notebooks
      mounts:
        others:
          dir: other_notebooks

You will see the following directory structure in the Polynote UI:

    nb1.ipynb         <--- this file is in notebooks/
    others/           <--- this is the key for the mount
      nb2.ipynb       <--- this file is in other_notebooks/

You can interact with the notebooks in the UI as if they were all in a single directory, even though they are backed by completely different ones in the filesystem.