### PR TITLE
py4j gateway not secure using PySpark 2.4.4 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -128,6 +128,7 @@ val `polynote-kernel` = project.settings(
     "io.circe" %% "circe-generic" % "0.11.1",
     "io.circe" %% "circe-generic-extras" % "0.11.1",
     "io.circe" %% "circe-parser" % "0.11.1",
+    "net.sf.py4j" % "py4j" % "0.10.7",
     "org.scalamock" %% "scalamock" % "4.4.0" % "test"
   ),
   coverageExcludedPackages := "polynote\\.kernel\\.interpreter\\.python\\..*;polynote\\.runtime\\.python\\..*" // see https://github.com/scoverage/scalac-scoverage-plugin/issues/176

--- a/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
@@ -1,16 +1,29 @@
 package polynote.kernel.interpreter.python
 
+import java.net.InetAddress
 import java.util.concurrent.atomic.AtomicReference
 
+import org.apache.commons.lang3.RandomStringUtils
 import org.apache.spark.sql.SparkSession
 import polynote.kernel.{BaseEnv, GlobalEnv, ScalaCompiler, TaskManager}
 import polynote.kernel.environment.{Config, CurrentNotebook, CurrentTask}
 import polynote.kernel.interpreter.Interpreter
 import py4j.GatewayServer
-import zio.{Task, RIO, ZIO}
+import py4j.GatewayServer.GatewayServerBuilder
+import zio.{RIO, Task, ZIO}
 import zio.blocking.{Blocking, effectBlocking}
 
 object PySparkInterpreter {
+
+  private lazy val py4jToken: String = RandomStringUtils.randomAlphanumeric(256)
+
+  private lazy val gwBuilder: GatewayServerBuilder = new GatewayServerBuilder()
+    .authToken(py4jToken)
+    .javaPort(0)
+    .callbackClient(0, InetAddress.getByName(GatewayServer.DEFAULT_ADDRESS))
+    .connectTimeout(GatewayServer.DEFAULT_CONNECT_TIMEOUT)
+    .readTimeout(GatewayServer.DEFAULT_READ_TIMEOUT)
+    .customCommands(null)
 
   object Factory extends Interpreter.Factory {
     def languageName: String = "Python"
@@ -73,13 +86,7 @@ object PySparkInterpreter {
   }
 
   private def startPySparkGateway(spark: SparkSession) = effectBlocking {
-    val gateway = new GatewayServer(
-      spark,
-      0,
-      0,
-      GatewayServer.DEFAULT_CONNECT_TIMEOUT,
-      GatewayServer.DEFAULT_READ_TIMEOUT,
-      null)
+    val gateway = gwBuilder.entryPoint(spark).build()
 
     gateway.start(true)
 
@@ -98,8 +105,8 @@ object PySparkInterpreter {
         s"""gateway = JavaGateway(
            |  auto_field = True,
            |  auto_convert = True,
-           |  gateway_parameters = GatewayParameters(port = $javaPort, auto_convert = True),
-           |  callback_server_parameters = CallbackServerParameters(port = 0))""".stripMargin)
+           |  gateway_parameters = GatewayParameters(port = $javaPort, auto_convert = True, auth_token = "$py4jToken"),
+           |  callback_server_parameters = CallbackServerParameters(port = 0, auth_token = "$py4jToken"))""".stripMargin)
 
       // Register shutdown handlers so pyspark exits cleanly. We need to make sure that all threads are closed before stopping jep.
       jep.eval("import atexit")


### PR DESCRIPTION
I tested this with Spark 2.4.4 and there is no need to set `PYSPARK_ALLOW_INSECURE_GATEWAY=1`.

GatewayServer is created with a GatewayServerBuilder which allows setting an auth_token, this token is a random alphanumeric string length 256, it's initialized the first time the gateway is created.

Note that the version of py4j in polynote-kernel was too old.

This is the issue https://github.com/polynote/polynote/issues/602