### PR TITLE
Remove pysparksession

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         architecture: 'x64'
     - name: Build
       run: |
-        pip install virtualenv ipython nbconvert jedi numpy scipy pyspark==2.1.2 jep==3.9.0
+        pip install virtualenv ipython nbconvert jedi numpy scipy jep==3.9.0
         jep_site_packages_path=`pip show jep | grep "^Location:" | cut -d ':' -f 2 | cut -d ' ' -f 2`
         jep_path=${jep_site_packages_path}/jep
         jep_lib_path=`realpath ${jep_site_packages_path}/../../`

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -13,8 +13,6 @@ RUN wget -q https://www-us.apache.org/dist/spark/spark-2.4.4/spark-2.4.4-bin-had
 ENV SPARK_HOME="/opt/spark-2.4.4-bin-hadoop2.7"
 ENV PATH="$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin"
 
-RUN pip3 install pyspark==2.4.4
-
 # First, create the distribution with `sbt dist`
 # Then build this from the dist target directory (e.g., `target/scala-2.11`) using `-f ../../docker/dev/Dockerfile` to select this file.
 # for example (don't forget the dot at the end!):

--- a/docker/spark-2.4/Dockerfile
+++ b/docker/spark-2.4/Dockerfile
@@ -13,7 +13,5 @@ RUN wget -q https://www-us.apache.org/dist/spark/spark-2.4.4/spark-2.4.4-bin-had
 ENV SPARK_HOME="/opt/spark-2.4.4-bin-hadoop2.7"
 ENV PATH="$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin"
 
-RUN pip3 install pyspark==2.4.4
-
 # switch to non-root user
 USER ${NB_USER}

--- a/docs/01-installation.md
+++ b/docs/01-installation.md
@@ -62,10 +62,8 @@ cd polynote
   You'll also need to install some Python dependencies `jep`, `jedi`, `virtualenv`:
   
   ```
-  pip3 install jep jedi pyspark virtualenv
+  pip3 install jep jedi virtualenv
   ``` 
-  
-  For PySpark support you'll want to install `pyspark` as well. 
   
   Additionally, you will probably want to install `numpy` and `pandas`. 
   

--- a/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
@@ -26,16 +26,7 @@ class PySparkInterpreter(
   runtime: Runtime[Any],
   pyApi: PythonInterpreter.PythonAPI,
   venvPath: Option[Path]
-) extends PythonInterpreter(
-  compiler,
-  jepInstance,
-  jepExecutor,
-  jepThread,
-  jepBlockingService,
-  runtime,
-  pyApi,
-  venvPath
-) {
+) extends PythonInterpreter(compiler, jepInstance, jepExecutor, jepThread, jepBlockingService, runtime, pyApi, venvPath) {
 
   val gatewayRef = new AtomicReference[GatewayServer]()
 

--- a/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
@@ -59,8 +59,17 @@ class PySparkInterpreter(
 
     s"""
        |import os
+       |import sys
        |if "PYSPARK_PYTHON" not in os.environ:
        |    $setPySpark
+       |
+       |# grab the pyspark included in the spark distribution, if available.
+       |spark_home = os.environ.get("SPARK_HOME")
+       |if spark_home:
+       |    sys.path.insert(1, os.path.join(spark_home, "python"))
+       |    import glob
+       |    py4j_path = glob.glob(os.path.join(spark_home, 'python', 'lib', 'py4j-*.zip'))[0]  # we want to use the py4j distributed with pyspark
+       |    sys.path.insert(1, py4j_path)
        |
        |from py4j.java_gateway import java_import, JavaGateway, JavaObject, GatewayParameters, CallbackServerParameters
        |from pyspark.conf import SparkConf

--- a/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
@@ -1,118 +1,115 @@
 package polynote.kernel.interpreter.python
 
 import java.net.InetAddress
+import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicReference
 
+import jep.Jep
+import jep.python.{PyCallable, PyObject}
 import org.apache.commons.lang3.RandomStringUtils
 import org.apache.spark.sql.SparkSession
-import polynote.kernel.{BaseEnv, GlobalEnv, ScalaCompiler, TaskManager}
-import polynote.kernel.environment.{Config, CurrentNotebook, CurrentTask}
-import polynote.kernel.interpreter.Interpreter
+import polynote.kernel.{BaseEnv, GlobalEnv, InterpreterEnv, ScalaCompiler, TaskManager}
+import polynote.kernel.environment.{Config, CurrentNotebook, CurrentRuntime, CurrentTask}
+import polynote.kernel.interpreter.{Interpreter, State}
 import py4j.GatewayServer
 import py4j.GatewayServer.GatewayServerBuilder
-import zio.{RIO, Task, ZIO}
+import zio.{RIO, Runtime, Task, ZIO}
 import zio.blocking.{Blocking, effectBlocking}
+import zio.internal.Executor
 
-object PySparkInterpreter {
+class PySparkInterpreter(
+  compiler: ScalaCompiler,
+  jepInstance: Jep,
+  jepExecutor: Executor,
+  jepThread: AtomicReference[Thread],
+  jepBlockingService: Blocking,
+  runtime: Runtime[Any],
+  pyApi: PythonInterpreter.PythonAPI,
+  venvPath: Option[Path]
+) extends PythonInterpreter(
+  compiler,
+  jepInstance,
+  jepExecutor,
+  jepThread,
+  jepBlockingService,
+  runtime,
+  pyApi,
+  venvPath
+) {
 
-  private lazy val py4jToken: String = RandomStringUtils.randomAlphanumeric(256)
+  val gatewayRef = new AtomicReference[GatewayServer]()
 
-  private lazy val gwBuilder: GatewayServerBuilder = {
-    new GatewayServerBuilder()
-      .javaPort(0)
-      .callbackClient(0, InetAddress.getByName(GatewayServer.DEFAULT_ADDRESS))
-      .connectTimeout(GatewayServer.DEFAULT_CONNECT_TIMEOUT)
-      .readTimeout(GatewayServer.DEFAULT_READ_TIMEOUT)
-      .customCommands(null)
+  override protected def injectGlobals(globals: PyObject): RIO[CurrentRuntime, Unit] = jep {
+    jep =>
+      val setItem = globals.getAttr("__setitem__", classOf[PyCallable])
+
+      val pySparkSession = jep.getValue("spark", classOf[PyObject])
+      setItem.call("spark", pySparkSession)
+
+      super.injectGlobals(globals)
   }
 
-  object Factory extends Interpreter.Factory {
-    def languageName: String = "Python"
-    def apply(): RIO[Blocking with Config with ScalaCompiler.Provider with CurrentNotebook with CurrentTask with TaskManager, Interpreter] = for {
-      venv        <- VirtualEnvFetcher.fetch()
-      gatewayRef   = new AtomicReference[GatewayServer]()
-      interpreter <- PythonInterpreter(venv, getPy4JError(gatewayRef))
-      _           <- setupPySpark(interpreter, gatewayRef)
-    } yield interpreter
+  override def init(state: State): RIO[InterpreterEnv, State] =  for {
+    spark   <- ZIO(SparkSession.builder().getOrCreate())
+    _       <- exec(pysparkImports(spark.sparkContext.isLocal))
+    doAuth  <- shouldAuthenticate
+    gateway <- startPySparkGateway(spark, doAuth)
+    _       <- ZIO(gatewayRef.set(gateway))
+    _       <- registerGateway(gateway, doAuth)
+    res <- super.init(state)
+  } yield res
 
-    override val requireSpark: Boolean = true
-    override val priority: Int = 1
-  }
-
-  private def getPy4JError(gatewayRef: AtomicReference[GatewayServer]): String => Option[Throwable] = {
-    id =>
-      val obj = for {
-        gatewayServer <- Option(gatewayRef.get())
-        gateway       <- Option(gatewayServer.getGateway)
-        obj           <- Option(gateway.getObject(id))
-      } yield obj
-
-      obj.collect {
-        case err: Throwable => err
-      }
-  }
-
-  private def setupPySpark(interp: PythonInterpreter, gatewayRef: AtomicReference[GatewayServer]): RIO[Blocking with TaskManager, Unit] =
-    TaskManager.run("PySpark", "Initializing PySpark") {
-      for {
-        spark   <- ZIO(SparkSession.builder().getOrCreate())
-        _       <- CurrentTask.update(_.progress(0.2))
-        _       <- pySparkImports(interp, spark)
-        _       <- CurrentTask.update(_.progress(0.3))
-        doAuth  <- shouldAuthenticate(interp)
-        _       <- CurrentTask.update(_.progress(0.4))
-        gateway <- startPySparkGateway(spark, doAuth)
-        _       <- CurrentTask.update(_.progress(0.7))
-        _       <- ZIO(gatewayRef.set(gateway))
-        _       <- registerGateway(interp, gateway, doAuth)
-        _       <- CurrentTask.update(_.progress(0.9))
-      } yield ()
+  protected def pysparkImports(sparkLocal: Boolean): String = {
+    val setPySpark = if (sparkLocal) {
+      """os.environ["PYSPARK_PYTHON"] = os.environ.get("PYSPARK_DRIVER_PYTHON", "python3")"""
+    } else {
+      """os.environ["PYSPARK_PYTHON"] = "python3" """
     }
 
-  private def pySparkImports(interp: PythonInterpreter, spark: SparkSession): Task[Unit] = {
-    // if we are running in local mode we need to set this so the executors can find the venv's python
-    interp.jep {
-      jep =>
-        jep.eval("import os")
-        if (spark.sparkContext.master.contains("local")) {
-          jep.eval("""os.environ["PYSPARK_PYTHON"] = os.environ.get("PYSPARK_DRIVER_PYTHON", "python3")""")
-        } else {
-          jep.eval("""os.environ["PYSPARK_PYTHON"] = "python3" """)
-        }
-        jep.exec(
-          """from py4j.java_gateway import java_import, JavaGateway, JavaObject, GatewayParameters, CallbackServerParameters
-            |from pyspark.conf import SparkConf
-            |from pyspark.context import SparkContext
-            |from pyspark.sql import SparkSession, SQLContext
-            |""".stripMargin)
-    }
+    s"""
+       |import os
+       |if "PYSPARK_PYTHON" not in os.environ:
+       |    $setPySpark
+       |
+       |from py4j.java_gateway import java_import, JavaGateway, JavaObject, GatewayParameters, CallbackServerParameters
+       |from pyspark.conf import SparkConf
+       |from pyspark.context import SparkContext
+       |from pyspark.sql import SparkSession, SQLContext
+       |""".stripMargin
   }
 
   /**
     * Whether or not to authenticate, based on the py4j version available.
     * We can get rid of this when we drop support for Spark 2.1
     */
-  private def shouldAuthenticate(interp: PythonInterpreter) = for {
-    py4jVersion <- interp.jep {
-      jep =>
-        jep.eval("import py4j")
-        jep.getValue("py4j.__version__", classOf[String])
-    }
-  } yield {
-    val Version = "(\\d+).(\\d+).(\\d+)".r
+  private def shouldAuthenticate = jep {
+    jep =>
+      jep.eval("import py4j")
+      val py4jVersion = jep.getValue("py4j.__version__", classOf[String])
 
-    py4jVersion match {
-      case Version(_, _, patch) if patch.toInt >= 7 => true
-      case _ => false
-    }
+      val Version = "(\\d+).(\\d+).(\\d+)".r
+
+      py4jVersion match {
+        case Version(_, _, patch) if patch.toInt >= 7 => true
+        case _ => false
+      }
   }
+
+  private lazy val py4jToken: String = RandomStringUtils.randomAlphanumeric(256)
+
+  private lazy val gwBuilder: GatewayServerBuilder = new GatewayServerBuilder()
+    .javaPort(0)
+    .callbackClient(0, InetAddress.getByName(GatewayServer.DEFAULT_ADDRESS))
+    .connectTimeout(GatewayServer.DEFAULT_CONNECT_TIMEOUT)
+    .readTimeout(GatewayServer.DEFAULT_READ_TIMEOUT)
+    .customCommands(null)
 
   private def startPySparkGateway(spark: SparkSession, doAuth: Boolean) = effectBlocking {
     val builder = if (doAuth) {
-        // use try here just to be extra careful
-        try gwBuilder.authToken(py4jToken) catch {
-          case err: Throwable => gwBuilder
-        }
+      // use try here just to be extra careful
+      try gwBuilder.authToken(py4jToken) catch {
+        case err: Throwable => gwBuilder
+      }
     } else gwBuilder
 
     val gateway = builder.entryPoint(spark).build()
@@ -126,7 +123,7 @@ object PySparkInterpreter {
     gateway
   }
 
-  private def registerGateway(interpreter: PythonInterpreter, gateway: GatewayServer, doAuth: Boolean) = interpreter.jep {
+  private def registerGateway(gateway: GatewayServer, doAuth: Boolean) = jep {
     jep =>
       val javaPort = gateway.getListeningPort
 
@@ -169,7 +166,6 @@ object PySparkInterpreter {
 
       gateway.resetCallbackClient(py4j.GatewayServer.defaultAddress(), pythonPort)
 
-      // TODO: `pysparksession` is gross. We need a better solution allowing Predefs to define the same values.
       jep.exec(
         """java_import(gateway.jvm, "org.apache.spark.SparkEnv")
           |java_import(gateway.jvm, "org.apache.spark.SparkConf")
@@ -181,10 +177,45 @@ object PySparkInterpreter {
           |
           |__sparkConf = SparkConf(_jvm = gateway.jvm, _jconf = gateway.entry_point.sparkContext().getConf())
           |sc = SparkContext(jsc = gateway.jvm.org.apache.spark.api.java.JavaSparkContext(gateway.entry_point.sparkContext()), gateway = gateway, conf = __sparkConf)
-          |pysparksession = SparkSession(sc, gateway.entry_point)
-          |sqlContext = pysparksession._wrapped
+          |spark = SparkSession(sc, gateway.entry_point)
+          |sqlContext = spark._wrapped
           |from pyspark.sql import DataFrame
           |""".stripMargin)
+  }
+
+  override protected def errorCause(get: PyCallable): Option[Throwable] = {
+    Option(get.callAs(classOf[String], "py4j_error")).flatMap {
+      py4jObjectId =>
+        val obj = for {
+          gatewayServer <- Option(gatewayRef.get())
+          gateway       <- Option(gatewayServer.getGateway)
+          obj           <- Option(gateway.getObject(py4jObjectId))
+        } yield obj
+
+        obj.collect {
+          case err: Throwable => err
+        }
+    }
+  }
+}
+
+object PySparkInterpreter {
+
+  def apply(venv: Option[Path]): RIO[ScalaCompiler.Provider, PySparkInterpreter] = {
+    for {
+      (compiler, jep, executor, jepThread, blocking, runtime, api) <- PythonInterpreter.interpreterDependencies(venv)
+    } yield new PySparkInterpreter(compiler, jep, executor, jepThread, blocking, runtime, api, venv)
+  }
+
+  object Factory extends Interpreter.Factory {
+    def languageName: String = "Python"
+    def apply(): RIO[Blocking with Config with ScalaCompiler.Provider with CurrentNotebook with CurrentTask with TaskManager, Interpreter] = for {
+      venv        <- VirtualEnvFetcher.fetch()
+      interpreter <- PySparkInterpreter(venv)
+    } yield interpreter
+
+    override val requireSpark: Boolean = true
+    override val priority: Int = 1
   }
 
 }


### PR DESCRIPTION
With these changes pyspark users can refer to the spark session as `spark` again! No more `pysparksession` :) 

This entailed making PySparkInterpreter a subclass of PythonInterpreter. 

Addresses #643 

Additionally, uses `pyspark` from the spark distribution itself rather than using pip. 