### PR TITLE
Add support for Safari

### DIFF
--- a/polynote-frontend/package-lock.json
+++ b/polynote-frontend/package-lock.json
@@ -1901,6 +1901,11 @@
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
     "events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",

--- a/polynote-frontend/package.json
+++ b/polynote-frontend/package.json
@@ -4,6 +4,7 @@
     "@types/katex": "0.10.1",
     "@types/tinycon": "0.6.1",
     "acorn": "6.2.0",
+    "event-target-shim": "5.0.1",
     "katex": "0.10.2",
     "markdown-it": "9.0.1",
     "markdown-it-katex": "2.0.3",

--- a/polynote-frontend/polynote/comms.ts
+++ b/polynote-frontend/polynote/comms.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import { Message } from './data/messages'
+import {EventTarget} from 'event-target-shim'
 
 export class PolynoteMessageEvent<T extends Message> extends CustomEvent<any> {
     constructor(readonly message: T) {

--- a/polynote-frontend/polynote/data/value_repr.ts
+++ b/polynote-frontend/polynote/data/value_repr.ts
@@ -11,6 +11,7 @@ import {CancelTasks, GroupAgg, HandleData, Message, ModifyStream, QuantileBin, S
 import {MessageListener, SocketSession} from "../comms";
 import {DataType, DoubleType, LongType, NumericTypes, StructField, StructType} from "./data_type";
 import {Either, Left, Right} from "./types";
+import {EventTarget} from "event-target-shim"
 
 export abstract class ValueRepr extends CodecContainer {
     static codec: Codec<ValueRepr>;

--- a/polynote-frontend/polynote/ui/component/plot_editor.ts
+++ b/polynote-frontend/polynote/ui/component/plot_editor.ts
@@ -17,16 +17,16 @@ import {
 import {FakeSelect} from "./fake_select";
 import {fakeSelectElem, span, textbox} from "../util/tags";
 import {SocketSession} from "../../comms";
-import {GroupAgg, ModifyStream, ReleaseHandle, TableOp} from "../../data/messages";
+import {GroupAgg, TableOp} from "../../data/messages";
 import {Pair} from "../../data/codec";
 import {DataStream, StreamingDataRepr} from "../../data/value_repr";
 import embed, {Result as VegaResult} from "vega-embed";
-import {UIMessageTarget} from "../util/ui_event";
 import {Cell, CodeCell} from "./cell";
 import {VegaClientResult} from "../../interpreter/vega_interpreter";
 import {ClientResult, Output} from "../../data/result";
 import {CellMetadata} from "../../data/data";
 import {CurrentNotebook} from "./current_notebook";
+import {EventTarget} from "event-target-shim"
 
 
 function isDimension(dataType: DataType): boolean {


### PR DESCRIPTION
As Safari currently doesn't support constructor for EventTarget,
use event-target-shim lbrary instead.