### PR TITLE
[WIP] Track cells which depend on a value that's changed

### DIFF
--- a/polynote-frontend/polynote/data/result.ts
+++ b/polynote-frontend/polynote/data/result.ts
@@ -2,7 +2,7 @@
 
 import {
     Codec, DataReader, DataWriter, discriminated, combined, arrayCodec, optional,
-    str, shortStr, tinyStr, uint8, uint16, int32, ior, CodecContainer
+    str, shortStr, tinyStr, uint8, uint16, int32, ior, CodecContainer, Pair
 } from './codec'
 
 import {ValueRepr, StringRepr, MIMERepr, StreamingDataRepr, DataRepr, LazyDataRepr} from './value_repr'
@@ -326,6 +326,18 @@ export class ExecutionInfo extends Result {
     }
 }
 
+export class CellDependencies extends Result {
+    static codec = combined(arrayCodec(int16, Pair.codec(int16, tinyStr))).to(CellDependencies)
+    static get msgTypeId() { return 6 }
+    static unapply(inst: CellDependencies): ConstructorParameters<typeof CellDependencies> {
+        return [inst.dependencies];
+    }
+    constructor(readonly dependencies: Pair<number, string>[]) {
+        super(dependencies);
+        Object.freeze(this);
+    }
+}
+
 Result.codecs = [
   Output,           // 0
   CompileErrors,    // 1
@@ -333,6 +345,7 @@ Result.codecs = [
   ClearResults,     // 3
   ResultValue,      // 4
   ExecutionInfo,    // 5
+  CellDependencies, // 6
 ];
 
 Result.codec = discriminated(

--- a/polynote-frontend/polynote/ui/component/cell.ts
+++ b/polynote-frontend/polynote/ui/component/cell.ts
@@ -476,6 +476,14 @@ export class CodeCell extends Cell {
         }
     }
 
+    setOutdated(outdated: boolean): void {
+        if (outdated) {
+            this.container.classList.add('outdated');
+        } else {
+            this.container.classList.remove('outdated');
+        }
+    }
+
     toggleCode() {
         const prevMetadata = this.metadata || new CellMetadata();
         this.setMetadata(prevMetadata.copy({hideSource: !prevMetadata.hideSource}));
@@ -820,6 +828,12 @@ export class CodeCell extends Cell {
         window.clearInterval(this.execDurationUpdater);
         delete this.execDurationUpdater;
 
+        if (!this.metadata) {
+            this.setMetadata(new CellMetadata(false, false, false, result));
+        } else {
+            this.setMetadata(this.metadata.copy({executionInfo: result}));
+        }
+
         // populate display
         this.execInfoEl.appendChild(span(['exec-start'], [start.toLocaleString("en-US", {timeZoneName: "short"})]));
         this.execInfoEl.appendChild(span(['exec-duration'], [prettyDuration(duration)]));
@@ -836,20 +850,17 @@ export class CodeCell extends Cell {
     }
 
     setStatus(status: "running" | "queued" | "error" | "complete") {
+        this.container.classList.remove('running', 'queued', 'error', 'outdated');
         switch(status) {
             case "complete":
-                this.container.classList.remove('running', 'queued', 'error');
                 break;
             case "error":
-                this.container.classList.remove('queued', 'running');
                 this.container.classList.add('error');
                 break;
             case "queued":
-                this.container.classList.remove('running', 'error');
                 this.container.classList.add('queued');
                 break;
             case "running":
-                this.container.classList.remove('queued', 'error');
                 this.container.classList.add('running');
                 break;
         }

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -296,6 +296,10 @@ body {
   border-left-width: @cell-left-border-width;
   position: relative;
 
+  &.outdated {
+    border-color: gold;
+  }
+
   &.selected, &.active {
     border-radius: 6px;
     border: 1px solid @ui-selected;

--- a/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
@@ -98,7 +98,7 @@ final case class PolynoteConfig(
 
 object PolynoteConfig {
   implicit val encoder: ObjectEncoder[PolynoteConfig] = deriveEncoder
-  implicit val decoder: Decoder[PolynoteConfig] = deriveDecoder[PolynoteConfig]
+  implicit val decoder: Decoder[PolynoteConfig] = deriveDecoder[PolynoteConfig] or Decoder.decodeBoolean.map(_ => PolynoteConfig())
 
   private val defaultConfig = "default.yml" // we expect this to be in the directory Polynote was launched from.
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/Result.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/Result.scala
@@ -10,7 +10,7 @@ import scodec.codecs.implicits._
 import shapeless.cachedImplicit
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
-import polynote.messages.{CellID, TinyList, TinyString, iorCodec, tinyListCodec, tinyStringCodec, truncateTinyString}
+import polynote.messages.{CellID, ShortList, TinyList, TinyString, iorCodec, tinyListCodec, tinyStringCodec, truncateTinyString}
 import polynote.runtime.ValueRepr
 import scodec.bits.BitVector
 
@@ -143,7 +143,6 @@ object ErrorResult {
 
 
 final case class ClearResults() extends Result
-
 object ClearResults extends ResultCompanion[ClearResults](3)
 
 
@@ -180,6 +179,8 @@ object ExecutionInfo extends ResultCompanion[ExecutionInfo](5) {
   implicit val decoder: Decoder[ExecutionInfo] = deriveDecoder[ExecutionInfo]
 }
 
+final case class CellDependencies(dependencies: ShortList[(CellID, TinyString)]) extends Result
+object CellDependencies extends ResultCompanion[CellDependencies](6)
 
 sealed trait Result
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/State.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/State.scala
@@ -28,6 +28,11 @@ trait State {
     */
   def values: List[ResultValue]
 
+  /**
+    * The names of the scope values consumed by the code that created this state, if known
+    */
+  def usedValues: Option[List[String]]
+
   // TODO: make this protected, public API should prevent you from removing Root from the chain
   def withPrev(prev: State): State
   def updateValues(fn: ResultValue => ResultValue): State
@@ -187,12 +192,13 @@ object State {
     override val id: CellID = Short.MinValue
     override val prev: State = this
     override val values: List[ResultValue] = Nil
+    override val usedValues: Option[List[String]] = None
     override def withPrev(prev: State): Root.type = this
     override def updateValues(fn: ResultValue => ResultValue): State = this
     override def updateValuesM[R](fn: ResultValue => RIO[R, ResultValue]): RIO[R, State] = ZIO.succeed(this)
   }
 
-  final case class Id(id: CellID, prev: State, values: List[ResultValue]) extends State {
+  final case class Id(id: CellID, prev: State, values: List[ResultValue], usedValues: Option[List[String]] = None) extends State {
     override def withPrev(prev: State): State = copy(prev = prev)
     override def updateValues(fn: ResultValue => ResultValue): State = copy(values = values.map(fn))
     override def updateValuesM[R](fn: ResultValue => RIO[R, ResultValue]): RIO[R, State] =

--- a/polynote-server/src/main/scala/polynote/server/KernelPublisher.scala
+++ b/polynote-server/src/main/scala/polynote/server/KernelPublisher.scala
@@ -14,7 +14,7 @@ import polynote.env.ops._
 import polynote.kernel.environment.{Config, CurrentNotebook, Env, NotebookUpdates, PublishMessage, PublishResult, PublishStatus}
 import polynote.kernel.interpreter.Interpreter
 import polynote.messages.{CellID, CellResult, KernelStatus, Message, Notebook, NotebookUpdate, RenameNotebook, ShortList, ShortString}
-import polynote.kernel.{BaseEnv, CellEnv, CellEnvT, ClearResults, Completion, Deque, ExecutionInfo, GlobalEnv, Kernel, KernelBusyState, KernelStatusUpdate, Result, ScalaCompiler, Signatures, TaskB, TaskManager}
+import polynote.kernel.{BaseEnv, CellDependencies, CellEnv, CellEnvT, ClearResults, Completion, Deque, ExecutionInfo, GlobalEnv, Kernel, KernelBusyState, KernelStatusUpdate, Result, ScalaCompiler, Signatures, TaskB, TaskManager}
 import polynote.util.VersionBuffer
 import zio.{Fiber, Promise, RIO, Semaphore, Task, UIO, ZIO}
 import zio.interop.catz._

--- a/polynote-server/src/main/scala/polynote/server/repository/MarkdownNotebookRepository.scala
+++ b/polynote-server/src/main/scala/polynote/server/repository/MarkdownNotebookRepository.scala
@@ -113,6 +113,7 @@ class MarkdownNotebookRepository(
     case ClearResults() => ""
     case ResultValue(_, _, _, _, _, _, _) => "" // TODO
     case ExecutionInfo(_, _) => "" // TODO
+    case CellDependencies(_) => ""
   }
 
   private def htmlToResult(html: scala.xml.Elem, id: String): Option[Result] = html.attribute("class").map(_.head.text).flatMap {

--- a/polynote-server/src/main/scala/polynote/server/repository/ipynb/ast.scala
+++ b/polynote-server/src/main/scala/polynote/server/repository/ipynb/ast.scala
@@ -155,6 +155,7 @@ object JupyterOutput {
 
     case ResultValue(_, _, _, _, _, _, _) => Nil
     case ExecutionInfo(_, _) => Nil
+    case CellDependencies(_) => Nil
   }
 }
 


### PR DESCRIPTION
Puts a yellow border around a cell when a cell that defined one of its inputs has been re-executed.

Caveats:
- It doesn't do this transitively; it wouldn't be hard but I think it might get annoying?
- This information isn't really persisted into the notebook, so it only works while the notebook remains open on the server (works across simple reloads though)
- It doesn't check whether the inputs actually changed... it would be difficult to do this reliably (maybe it would work for simple scalars and such, but we don't really want to be equality-checking on other things... maybe in the future we could use static analysis to determine if the definition of the things have changed)