### PR TITLE
Make JS obey the `<base>` tag

### DIFF
--- a/polynote-frontend/polynote/comms.ts
+++ b/polynote-frontend/polynote/comms.ts
@@ -46,8 +46,9 @@ export class SocketSession extends EventTarget {
     }
 
     mkSocket() {
-        const schema = location.protocol === 'https:' ? 'wss://' : 'ws://';
-        this.socket = new WebSocket(schema + document.location.host + '/ws?key=' + socketKey);
+        const wsUrl = new URL(`ws?key=${socketKey}`, document.baseURI);
+        wsUrl.protocol = wsUrl.protocol === "https:" ? 'wss:' : 'ws';
+        this.socket = new WebSocket(wsUrl.href);
         this.socket.binaryType = 'arraybuffer';
         this.listeners = {
             message: this.receive.bind(this),

--- a/polynote-frontend/polynote/main.ts
+++ b/polynote-frontend/polynote/main.ts
@@ -26,10 +26,10 @@ SocketSession.get;
 const mainUI = new MainUI();
 const mainEl = document.getElementById('Main');
 mainEl && mainEl.appendChild(mainUI.el);
-const path = unescape(window.location.pathname);
-
-if (path.startsWith('/notebook/')) {
-  mainUI.loadNotebook(path.replace(/^\/notebook\//, ''));
+const path = unescape(window.location.href.replace(document.baseURI, ''));
+const notebookBase = 'notebook/';
+if (path.startsWith(notebookBase)) {
+  mainUI.loadNotebook(path.substring(notebookBase.length));
 } else {
   mainUI.showWelcome();
 }

--- a/polynote-frontend/polynote/main.ts
+++ b/polynote-frontend/polynote/main.ts
@@ -26,7 +26,7 @@ SocketSession.get;
 const mainUI = new MainUI();
 const mainEl = document.getElementById('Main');
 mainEl && mainEl.appendChild(mainUI.el);
-const path = unescape(window.location.href.replace(document.baseURI, ''));
+const path = unescape(window.location.pathname.replace(new URL(document.baseURI).pathname, ''));
 const notebookBase = 'notebook/';
 if (path.startsWith(notebookBase)) {
   mainUI.loadNotebook(path.substring(notebookBase.length));

--- a/polynote-frontend/polynote/ui/component/about.ts
+++ b/polynote-frontend/polynote/ui/component/about.ts
@@ -23,7 +23,7 @@ export class About extends FullScreenModal {
     aboutMain() {
         const el = div(["about-display"], [
             div([], [
-                tag('img', [], {src: "/style/polynote.svg", alt:"Polynote"}, []),
+                tag('img', [], {src: "style/polynote.svg", alt:"Polynote"}, []),
                 h2([], ["About this Polynote Server"])
             ])
         ]);

--- a/polynote-frontend/polynote/ui/component/home.ts
+++ b/polynote-frontend/polynote/ui/component/home.ts
@@ -10,12 +10,12 @@ export class HomeUI extends UIMessageTarget {
         super();
         this.el = div(['welcome-page'], []);
         this.el.innerHTML = `
-          <img src="/style/polynote.svg" alt="Polynote" />
+          <img src="style/polynote.svg" alt="Polynote" />
           <h2>Home</h2>
           
           <p>
             To get started, open a notebook by clicking on it in the Notebooks panel, or create a new notebook by
-             clicking the Create Notebook (<span class="create-notebook icon fas"><img class="icon" src="/style/icons/fa/plus-circle.svg"/></span>) button.
+             clicking the Create Notebook (<span class="create-notebook icon fas"><img class="icon" src="style/icons/fa/plus-circle.svg"/></span>) button.
           </p>
           
           <h3>Recent notebooks</h3>

--- a/polynote-frontend/polynote/ui/component/ui.ts
+++ b/polynote-frontend/polynote/ui/component/ui.ts
@@ -149,7 +149,7 @@ export class MainUI extends UIMessageTarget {
 
         this.subscribe(TabActivated, (name, type) => {
             if (type === 'notebook') {
-                const tabPath = `/notebook/${name}`;
+                const tabUrl = new URL(`notebook/${name}`, document.baseURI);
 
                 const href = window.location.href;
                 const hash = window.location.hash;
@@ -157,11 +157,11 @@ export class MainUI extends UIMessageTarget {
                 document.title = title; // looks like chrome ignores history title so we need to be explicit here.
 
                  // handle hashes and ensure scrolling works
-                if (hash && window.location.pathname === tabPath) {
+                if (hash && window.location.href === tabUrl.href) {
                     window.history.pushState({notebook: name}, title, href);
                     this.handleHashChange()
                 } else {
-                    window.history.pushState({notebook: name}, title, tabPath);
+                    window.history.pushState({notebook: name}, title, tabUrl.href);
                 }
 
                 const currentNotebook = this.tabUI.getTab(name).content.notebook.cellsUI;
@@ -172,7 +172,7 @@ export class MainUI extends UIMessageTarget {
                 }
             } else if (type === 'home') {
                 const title = 'Polynote';
-                window.history.pushState({notebook: name}, title, '/');
+                window.history.pushState({notebook: name}, title, document.baseURI);
                 document.title = title;
                 this.toolbarUI.setDisabled(true);
             }
@@ -180,8 +180,8 @@ export class MainUI extends UIMessageTarget {
 
         this.subscribe(TabRenamed, (oldName, newName, type, isCurrent) => {
             if (isCurrent) {
-                const tabPath = `/notebook/${newName}`;
-                const href = window.location.hash ? `${tabPath}#${window.location.hash.replace(/^#/, '')}` : tabPath;
+                const tabUrl = new URL(`notebook/${name}`, document.baseURI);
+                const href = window.location.hash ? `${tabUrl.href}#${window.location.hash.replace(/^#/, '')}` : tabUrl.href;
                 window.history.replaceState({notebook: newName}, `${newName.split(/\//g).pop()} | Polynote`, href);
             }
         });

--- a/polynote-frontend/polynote/ui/util/tags.ts
+++ b/polynote-frontend/polynote/ui/util/tags.ts
@@ -104,7 +104,7 @@ export function img(classes: string[], src: string, alt: string) {
 }
 
 export function icon(classes: string[], iconName: string, alt?: string) {
-    return span(classes, img(['icon'], `/style/icons/fa/${iconName}.svg`, alt || iconName))
+    return span(classes, img(['icon'], `style/icons/fa/${iconName}.svg`, alt || iconName))
 }
 
 export function a(classes: string[], href: string, contentOrPreventNavigate: Content | boolean, contentWhenPreventNavigate?: Content) {


### PR DESCRIPTION
Even after adding the ability to configure `base_uri`, much of the JavaScript source still uses absolute paths. This changes it to use relative paths where possible, and take into account the base URI where absolute paths are required.