### PR TITLE
Add polynote-dist.tar.gz to the dev docker image only after downloading Spark

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -6,6 +6,15 @@ RUN apt update -y && \
     apt install -y wget python3 python3-dev python3-pip build-essential && \
     pip3 install jep jedi virtualenv
 
+RUN wget -q https://www-us.apache.org/dist/spark/spark-2.4.4/spark-2.4.4-bin-hadoop2.7.tgz && \
+    tar xfz spark-2.4.4-bin-hadoop2.7.tgz && \
+    rm spark-2.4.4-bin-hadoop2.7.tgz
+
+ENV SPARK_HOME="/opt/spark-2.4.4-bin-hadoop2.7"
+ENV PATH="$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin"
+
+RUN pip3 install pyspark==2.4.4
+
 # First, create the distribution with `sbt dist`
 # Then build this from the dist target directory (e.g., `target/scala-2.11`) using `-f ../../docker/dev/Dockerfile` to select this file.
 # for example (don't forget the dot at the end!):
@@ -15,15 +24,6 @@ RUN apt update -y && \
 COPY polynote-dist.tar.gz .
 RUN tar xfzp polynote-dist.tar.gz && \
     rm polynote-dist.tar.gz
-
-RUN wget -q https://www-us.apache.org/dist/spark/spark-2.4.4/spark-2.4.4-bin-hadoop2.7.tgz && \
-    tar xfz spark-2.4.4-bin-hadoop2.7.tgz && \
-    rm spark-2.4.4-bin-hadoop2.7.tgz
-
-ENV SPARK_HOME="/opt/spark-2.4.4-bin-hadoop2.7"
-ENV PATH="$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin"
-
-RUN pip3 install pyspark==2.4.4
 
 # to wrap up, we create (safe)user
 ENV UID 1000


### PR DESCRIPTION
This way spark is cached and doesn't need to be downloaded every time the polynote binary changes, which makes building the docker image much faster.