### PR TITLE
Change default artifact configuration to Configuration.empty

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/dependency/CoursierFetcher.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/dependency/CoursierFetcher.scala
@@ -89,9 +89,9 @@ object CoursierFetcher {
     lazy val coursierDeps = dependencies.map {
       moduleStr =>
         val (org, name, typ, config, classifier, ver) = moduleStr.split(':') match {
-          case Array(org, name, ver) => (Organization(org), ModuleName(name), Type.empty, Configuration.default, Classifier.empty, ver)
-          case Array(org, name, classifier, ver) => (Organization(org), ModuleName(name), Type.empty, Configuration.default, Classifier(classifier), ver)
-          case Array(org, name, typ, classifier, ver) => (Organization(org), ModuleName(name), Type(typ), Configuration.default, Classifier(classifier), ver)
+          case Array(org, name, ver) => (Organization(org), ModuleName(name), Type.empty, Configuration.empty, Classifier.empty, ver)
+          case Array(org, name, classifier, ver) => (Organization(org), ModuleName(name), Type.empty, Configuration.empty, Classifier(classifier), ver)
+          case Array(org, name, typ, classifier, ver) => (Organization(org), ModuleName(name), Type(typ), Configuration.empty, Classifier(classifier), ver)
           case Array(org, name, typ, config, classifier, ver) => (Organization(org), ModuleName(name), Type(typ), Configuration(config), Classifier(classifier), ver)
           case _ => throw new Exception(s"Unable to parse dependency '$moduleStr'")
         }
@@ -145,8 +145,6 @@ object CoursierFetcher {
           md => resolveModules(md.size).as(md)
         }
     }
-
-
 
     Resolve(cache)
       .addDependencies(coursierDeps: _*)


### PR DESCRIPTION
Changes the default artifact configuration from `Configuration.default` to `Configuration.empty`, which is the actual default: (https://github.com/coursier/coursier/blob/5e81bd11c6493b37ac04812501247b988670909c/modules/core/shared/src/main/scala/coursier/core/Dependency.scala#L62)

`Configuration.default` seems to be a configuration literally named "default": (https://github.com/coursier/coursier/blob/5e81bd11c6493b37ac04812501247b988670909c/modules/core/shared/src/main/scala/coursier/core/Definitions.scala#L171). Running `sbt ivyConfigurations` on some scala projects doesn't return this configuration, so it doesn't seem to be an actual default.

I tried with both local and remote repositories and everything seems to be working fine.

Fix #668