### PR TITLE
Fix drag and drop events on Firefox

### DIFF
--- a/polynote-frontend/polynote/ui/component/plot_editor.ts
+++ b/polynote-frontend/polynote/ui/component/plot_editor.ts
@@ -212,6 +212,8 @@ export class PlotEditor extends EventTarget {
         this.plotTypeSelector.addListener(() => this.onPlotTypeChange());
 
         this.el.addEventListener('dragstart', evt => {
+           // Firefox only allows dragging elements with a set DataTransfer
+           evt && evt.dataTransfer && evt.dataTransfer.setData('dummy', 'dummy');
            this.draggingEl = evt.target as MeasureEl;
         });
 


### PR DESCRIPTION
Firefox requires that the event DataTransfer contains something for a `<div>` element to be draggable (https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations#dragdata)

This PR simply adds a `dummy` variable with `dummy` type to the DataTransfer.