### PR TITLE
Added Hotkey to run all cells.

### DIFF
--- a/polynote-frontend/polynote/ui/component/cell.ts
+++ b/polynote-frontend/polynote/ui/component/cell.ts
@@ -323,6 +323,10 @@ export class CodeCell extends Cell {
                     .endColumn -= 1
             }
         })],
+        // run all cells
+        [monaco.KeyMod.Shift | monaco.KeyCode.F10,
+            new KeyAction((pos, range, selection, cell) => CurrentNotebook.get.runAllCells())
+                .withDesc("Run all cells.")],
         // run cell on enter
         [monaco.KeyMod.Shift | monaco.KeyCode.Enter,
             new KeyAction((pos, range, selection, cell) => CurrentNotebook.get.runCells(cell.id))


### PR DESCRIPTION
**Related issues** : https://github.com/polynote/polynote/issues/266

**Binding Keys** : `Shift + F10`

### Screenshots
![2019-11-24 20-04-23 2019-11-24 20_05_02](https://user-images.githubusercontent.com/20429567/69493752-e9c50100-0ef5-11ea-8421-b366ad570f10.gif)