### PR TITLE
Add identity provider interfaces

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
@@ -71,8 +71,16 @@ object Behavior {
   implicit val decoder: Decoder[Behavior] = deriveDecoder
 }
 
+final case class AuthProvider(provider: String, config: JsonObject)
+
+object AuthProvider {
+  implicit val encoder: ObjectEncoder[AuthProvider] = deriveEncoder
+  implicit val decoder: Decoder[AuthProvider] = deriveDecoder
+}
+
 final case class Security(
-  websocketKey: Option[String] = None
+  websocketKey: Option[String] = None,
+  auth: Option[AuthProvider] = None
 )
 
 object Security {

--- a/polynote-kernel/src/main/scala/polynote/kernel/environment/environment.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/environment/environment.scala
@@ -237,7 +237,33 @@ object InterpreterEnvironment {
   */
 object Env {
 
-
+  /**
+    * Add a new type to the environment inside a for-comprehension. This variant is for an environment that's constructed
+    * effectfully.
+    *
+    * This method takes the "current" environment type, and enriches it with the given value. The remainder of the
+    * for-comprehension can then access that environment. For example, instead of this:
+    *
+    * for {
+    *   someValue <- computeThing
+    *   myEnv1    <- Env.enrichM[Env1 with Env2](CreateMyEnv(someValue))
+    *   thing1    <- doThing1.provide(myEnv1)
+    *   thing2    <- doThing2.provide(myEnv1)
+    *   // etc
+    * } yield thing2
+    *
+    * You can do this:
+    *
+    * for {
+    *   someValue <- computeThing
+    *   _         <- Env.addM[Env1 with Env2](CreateMyEnv(someValue))
+    *   thing1    <- doThing1
+    *   thing2    <- doThing2
+    * } yield thing2
+    *
+    * The MyEnv environment is automatically provided to the continuation after Env.addM, so it doesn't have to be
+    * named and explicitly provided everywhere.
+    */
   def addM[RO]: AddMPartial[RO] = addMPartialInst.asInstanceOf[AddMPartial[RO]]
 
   class AddMPartial[RO] {
@@ -253,7 +279,35 @@ object Env {
       rbTask.flatMap(rb => Env.enrich[RO][RB](rb)).flatMap(r => zio(r).provide(r))
   }
 
+  /**
+    * Add a new type to the environment inside a for-comprehension. This variant is for an environment that's constructed
+    * directly.
+    *
+    * This method takes the "current" environment type, and enriches it with the given value. The remainder of the
+    * for-comprehension can then access that environment. For example, instead of this:
+    *
+    * for {
+    *   someValue <- computeThing
+    *   myEnv1    <- Env.enrich[Env1 with Env2](CreateMyEnv(someValue))
+    *   thing1    <- doThing1.provide(myEnv1)
+    *   thing2    <- doThing2.provide(myEnv1)
+    *   // etc
+    * } yield thing2
+    *
+    * You can do this:
+    *
+    * for {
+    *   someValue <- computeThing
+    *   _         <- Env.add[Env1 with Env2](CreateMyEnv(someValue))
+    *   thing1    <- doThing1
+    *   thing2    <- doThing2
+    * } yield thing2
+    *
+    * The MyEnv environment is automatically provided to the continuation after Env.add, so it doesn't have to be
+    * named and explicitly provided everywhere.
+    */
   def add[RO]: AddPartial[RO] = addPartialInstance.asInstanceOf[AddPartial[RO]]
+
   class AddPartial[RO] {
     def apply[R](r: R): Add[RO, R] = new Add[RO, R](r)
   }
@@ -267,14 +321,43 @@ object Env {
   }
 
 
+  /**
+    * Enrich A with B, resulting in a value that is both A and B. This is intended for ZIO environments, and as such,
+    * A and B must be traits. It's a good practice for each of these traits to have exactly one abstract method which
+    * provides that environment's aspect.
+    *
+    * The returned value will implement A and B, delegating all of A's methods to the given A and all of B's methods to
+    * the given B. If A already extends B, the methods of B will be replaced to delegate to the given instance of B.
+    *
+    * @see [[Enrich]] for the macro implementation.
+    */
   def enrichWith[A, B](a: A, b: B)(implicit enrich: Enrich[A, B]): A with B = enrich(a, b)
 
+  /**
+    * A partially applied enrichment. Provide as a type parameter the type that will be pulled from the ZIO environment
+    * and enriched, and as a value parameter the value that will be added (its type can typically be inferred).
+    *
+    * Example:
+    *     val zio: ZIO[Thing1 with Thing2 with Thing3, Nothing, Int] = ???
+    *     val thing3: Thing3 = ???
+    *     zio.provideSomeM(Env.enrich[Thing1 with Thing2](thing3)) // result: ZIO[Thing1 with Thing2, Nothing, Int]
+    */
   def enrich[A]: Enricher[A] = new Enricher()
 
   class Enricher[A] {
     def apply[B](b: B)(implicit enrich: Enrich[A, B]): ZIO[A, Nothing, A with B] = ZIO.access[A](identity).map(enrichWith[A, B](_, b))
   }
 
+  /**
+    * A partially applied enrichment. Provide as a type parameter the type that will be pulled from the ZIO environment
+    * and enriched, and as a value parameter an effect that will produce the value that will be added (its type can
+    * typically be inferred).
+    *
+    * Example:
+    *     val zio: ZIO[Thing1 with Thing2 with Thing3, Nothing, Int] = ???
+    *     val thing3: ZIO[Thing1, Nothing, Thing3] = ???
+    *     zio.provideSomeM(Env.enrichM[Thing1 with Thing2](thing3)) // result: ZIO[Thing1 with Thing2, Nothing, Int]
+    */
   def enrichM[A]: MEnricher[A] = new MEnricher
 
   class MEnricher[A]() {

--- a/polynote-server/src/main/resources/META-INF/services/polynote.server.auth.ProviderLoader
+++ b/polynote-server/src/main/resources/META-INF/services/polynote.server.auth.ProviderLoader
@@ -1,0 +1,1 @@
+polynote.server.auth.HeaderIdentityProvider$Loader

--- a/polynote-server/src/main/scala/polynote/server/Server.scala
+++ b/polynote-server/src/main/scala/polynote/server/Server.scala
@@ -93,7 +93,7 @@ class Server(kernelFactory: Kernel.Factory.Service) extends polynote.app.App wit
     url           = s"http://$host:$port"
     interps      <- interpreter.Loader.load.orDie
     broadcastAll <- Topic[Task, Option[Message]](None).orDie
-    _            <- Env.addM[BaseEnv](ZIO.succeed(GlobalEnv(config, interps, kernelFactory)))
+    _            <- Env.add[BaseEnv](GlobalEnv(config, interps, kernelFactory))
     _            <- Env.addM[BaseEnv with GlobalEnv](NotebookManager(broadcastAll).orDie)
     loadIndex    <- indexFileContent(wsKey, config, args.watchUI)
     _            <- Env.addM[BaseEnv with GlobalEnv with NotebookManager](IdentityProvider.load.orDie)

--- a/polynote-server/src/main/scala/polynote/server/auth/HeaderIdentityProvider.scala
+++ b/polynote-server/src/main/scala/polynote/server/auth/HeaderIdentityProvider.scala
@@ -1,0 +1,56 @@
+package polynote.server.auth
+import io.circe.{Decoder, Encoder, Json, JsonObject, ObjectEncoder}
+import io.circe.generic.extras.semiauto.{deriveDecoder, deriveEncoder}
+import org.http4s.util.CaseInsensitiveString
+import org.http4s.{Header, Request, Response}
+import polynote.kernel.{BaseEnv, environment}
+import polynote.kernel.environment.Config
+import zio.{RIO, Task, ZIO}
+import polynote.config.circeConfig
+
+class HeaderIdentityProvider(val config: HeaderIdentityProvider.Config) extends IdentityProvider.Service {
+  override def authRoutes: Option[PartialFunction[Request[Task], RIO[BaseEnv with Config, Response[Task]]]] = None
+
+  override def checkAuth(req: Request[Task]): ZIO[BaseEnv with Config, Response[Task], Option[Identity]] =
+    req.headers.get(CaseInsensitiveString(config.header)) match {
+      case Some(Header(_, name))         => ZIO.succeed(Some(BasicIdentity(name)))
+      case None if config.allowAnonymous => ZIO.succeed(None)
+      case None                          => ZIO.fail(Response[Task](status = org.http4s.Status.Forbidden))
+    }
+
+  override def checkPermission(
+    ident: Option[Identity],
+    permission: Permission
+  ): ZIO[BaseEnv with Config, Permission.PermissionDenied, Unit] = {
+    val matchedUser = ident.map(_.name).getOrElse("*")
+    val permissions = config.permissions.getOrElse(matchedUser, Set.empty)
+    if (permissions contains permission.permissionType)
+      ZIO.unit
+    else
+      ZIO.fail(Permission.PermissionDenied(permission, s"$matchedUser does not have ${permission.permissionType.encoded} access"))
+  }
+
+  override def equals(obj: Any): Boolean = obj match {
+    case that: HeaderIdentityProvider => that.config == config
+    case _ => false
+  }
+}
+
+object HeaderIdentityProvider {
+  case class Config(
+    header: String,
+    permissions: Map[String, Set[PermissionType]] = Map("*" -> PermissionType.All),
+    allowAnonymous: Boolean = false
+  )
+
+  object Config {
+    implicit val encoder: ObjectEncoder[Config] = deriveEncoder
+    implicit val decoder: Decoder[Config] = deriveDecoder
+  }
+
+  class Loader extends ProviderLoader {
+    override val providerKey: String = "header"
+    override def provider(config: JsonObject): RIO[BaseEnv with environment.Config, HeaderIdentityProvider] =
+      ZIO.fromEither(Json.fromJsonObject(config).as[Config]).map(new HeaderIdentityProvider(_))
+  }
+}

--- a/polynote-server/src/main/scala/polynote/server/auth/IdentityProvider.scala
+++ b/polynote-server/src/main/scala/polynote/server/auth/IdentityProvider.scala
@@ -1,0 +1,167 @@
+package polynote.server.auth
+
+import java.util.ServiceLoader
+
+import cats.syntax.either._
+import cats.syntax.traverse._
+import cats.instances.either._
+import cats.instances.option._
+import io.circe.{Decoder, Encoder, Json, JsonObject}
+import org.http4s.{Request, Response}
+import polynote.config.AuthProvider
+import polynote.env.ops.Enrich
+import polynote.kernel.environment.{Config, CurrentNotebook, Env}
+import polynote.kernel.{BaseEnv, TaskB}
+import polynote.messages.CellID
+import polynote.server.Server.Routes
+import zio.{RIO, Task, UIO, URIO, ZIO}
+import polynote.server.auth
+import zio.interop.catz._
+import zio.blocking.effectBlocking
+import ZIO.effectTotal
+
+trait Identity {
+  def name: String
+}
+
+case class BasicIdentity(name: String) extends Identity
+
+sealed abstract class PermissionType(val encoded: String)
+object PermissionType {
+  case object ReadNotebook extends PermissionType("read")
+  case object ModifyNotebook extends PermissionType("modify")
+  case object ExecuteCell extends PermissionType("execute")
+  case object CreateNotebook extends PermissionType("create")
+  case object DeleteNotebook extends PermissionType("delete")
+
+  val All: Set[PermissionType] = Set(ReadNotebook, ModifyNotebook, ExecuteCell, CreateNotebook, DeleteNotebook)
+
+  def fromString(string: String): Either[String, PermissionType] = All.find(_.encoded == string).map(Right(_))
+    .getOrElse(Left(s"$string is not a valid permission type"))
+
+  implicit val decoder: Decoder[PermissionType] = Decoder.decodeString.emap(fromString)
+  implicit val encoder: Encoder[PermissionType] = Encoder.encodeString.contramap(_.encoded)
+
+  private val setStringDecoder: Decoder[Set[PermissionType]] = Decoder.decodeString.flatMap {
+    case "all" => Decoder.const(All)
+    case str   => fromString(str).fold(Decoder.failedWithMessage, Decoder.const).map(Set(_))
+  }
+
+  implicit val setDecoder: Decoder[Set[PermissionType]] = setStringDecoder or Decoder.decodeSet(decoder)
+}
+
+sealed abstract class Permission(val permissionType: PermissionType)
+
+object Permission {
+  case class ReadNotebook(path: String) extends Permission(PermissionType.ReadNotebook)
+  case class ModifyNotebook(path: String) extends Permission(PermissionType.ModifyNotebook)
+  case class ExecuteCell(path: String, id: CellID) extends Permission(PermissionType.ExecuteCell)
+  case class CreateNotebook(path: String) extends Permission(PermissionType.CreateNotebook)
+  case class DeleteNotebook(path: String) extends Permission(PermissionType.DeleteNotebook)
+
+  case class PermissionDenied(permission: Permission, reason: String) extends Throwable(s"Permission denied: $permission ($reason)")
+}
+
+trait IdentityProvider {
+  def identityProvider: IdentityProvider.Service
+}
+
+object IdentityProvider {
+
+  trait Service {
+    /**
+      * Any special endpoints or pages that the provider has to mount, if there are any.
+      */
+    def authRoutes: Option[Routes]
+
+    /**
+      * Check the authorization for a request, failing with a Response (if not authorized) or succeeding with an
+      * Identity (if authorized) or None to indicate authorized anonymous access
+      */
+    def checkAuth(req: Request[Task]): ZIO[BaseEnv with Config, Response[Task], Option[Identity]]
+
+    /**
+      * Check whether the given identity (or None for anonymous) has the given permission. If not, the returned task
+      * should fail with PermissionDenied.
+      */
+    def checkPermission(ident: Option[Identity], permission: Permission): ZIO[BaseEnv with Config, Permission.PermissionDenied, Unit]
+  }
+
+  val noneService: Service = new Service {
+    def authRoutes: Option[Routes] = None
+    def checkAuth(req: Request[Task]): ZIO[BaseEnv with Config, Response[Task], Option[Identity]] = ZIO.succeed(None)
+    def checkPermission(ident: Option[Identity], permission: Permission): ZIO[BaseEnv with Config, Permission.PermissionDenied, Unit] = ZIO.unit
+  }
+
+  val none: IdentityProvider = of(noneService)
+
+  def of(service: Service): IdentityProvider = new IdentityProvider {
+    def identityProvider: Service = service
+  }
+
+  private lazy val loaders: Map[String, ProviderLoader] = {
+    import scala.collection.JavaConverters._
+    val loaders = ServiceLoader.load(classOf[ProviderLoader]).iterator.asScala.toList
+    loaders.map(l => l.providerKey -> l).toMap
+  }
+
+  def find(config: AuthProvider): RIO[BaseEnv with Config, IdentityProvider.Service] = effectBlocking(loaders)
+    .map(_.get(config.provider))
+    .someOrFail(new NoSuchElementException(s"No identity provider could be found with key ${config.provider}"))
+    .flatMap(_.provider(config.config))
+
+  val load: RIO[BaseEnv with Config, IdentityProvider] =
+    ZIO.access[Config](_.polynoteConfig.security.auth).get
+      .foldM(_ => ZIO.succeed(none), config => find(config).map(of))
+
+  def access: URIO[IdentityProvider, Service] = ZIO.access[IdentityProvider](_.identityProvider)
+
+  def authRoutes: RIO[IdentityProvider, Routes] =
+    ZIO.access[IdentityProvider](_.identityProvider.authRoutes.getOrElse(PartialFunction.empty))
+
+  /**
+    * Fail if the current user doesn't have the given permission
+    */
+  def checkPermission(permission: Permission): ZIO[BaseEnv with Config with UserIdentity with IdentityProvider, Permission.PermissionDenied, Unit] = for {
+    service <- access
+    ident   <- UserIdentity.access
+    _       <- service.checkPermission(ident, permission)
+  } yield ()
+
+  /**
+    * Provide a function that will authorize a Request against the configured auth provider
+    */
+  def authorize[Env <: BaseEnv with Config](implicit enrich: Enrich[Env, UserIdentity]): RIO[Env with IdentityProvider, (Request[Task], RIO[Env with UserIdentity, Response[Task]]) => RIO[Env, Response[Task]]] =
+    access.map {
+      provider =>
+        (req, task) =>
+          provider.checkAuth(req).foldM(
+            ZIO.succeed,
+            ident => task.provideSomeM(Env.enrich[Env][UserIdentity](UserIdentity.of(ident))))
+    }
+}
+
+/**
+  * A service interface for loading identity providers from plug-ins.
+  */
+trait ProviderLoader {
+  def providerKey: String
+  def provider(config: JsonObject): RIO[BaseEnv with Config, IdentityProvider.Service]
+}
+
+// An environment for user identity
+trait UserIdentity {
+  def userIdentity: Option[Identity]
+}
+
+object UserIdentity {
+
+  def access: URIO[UserIdentity, Option[Identity]] = ZIO.access[UserIdentity](_.userIdentity)
+
+  def of(maybeIdent: Option[Identity]): UserIdentity = new UserIdentity {
+    val userIdentity: Option[Identity] = maybeIdent
+  }
+
+  final val empty: UserIdentity = of(None)
+
+}

--- a/polynote-server/src/main/scala/polynote/server/package.scala
+++ b/polynote-server/src/main/scala/polynote/server/package.scala
@@ -1,0 +1,8 @@
+package polynote
+
+import polynote.kernel.{BaseEnv, GlobalEnv}
+import polynote.server.auth.{IdentityProvider, UserIdentity}
+
+package object server {
+  type SessionEnv = BaseEnv with GlobalEnv with UserIdentity with IdentityProvider
+}

--- a/polynote-server/src/test/scala/polynote/server/auth/HeaderIdentityProviderSpec.scala
+++ b/polynote-server/src/test/scala/polynote/server/auth/HeaderIdentityProviderSpec.scala
@@ -1,0 +1,141 @@
+package polynote.server.auth
+
+import cats.syntax.traverse._
+import cats.instances.option._
+import io.circe.{Json, JsonObject}
+import io.circe.syntax.EncoderOps
+import org.http4s.util.CaseInsensitiveString
+import org.http4s.{Header, Headers, Request, Response, Status}
+import org.scalatest.{FreeSpec, Matchers}
+import polynote.config.{AuthProvider, PolynoteConfig, Security}
+import polynote.kernel.environment.{Config, Env}
+import polynote.testing.ZIOSpec
+import polynote.messages.CellID
+import zio.{RIO, Task, ZIO}
+import zio.interop.catz._
+
+class HeaderIdentityProviderSpec extends FreeSpec with Matchers with ZIOSpec {
+
+  private def providerConfig(allowAnonymous: Boolean) = HeaderIdentityProvider.Config(
+    "X-User-Name",
+    Map(
+      "bob" -> Set(PermissionType.ReadNotebook, PermissionType.ModifyNotebook),
+      "alice" -> PermissionType.All,
+      "*" -> Set(PermissionType.ReadNotebook)),
+    allowAnonymous
+  )
+
+  private def authConfig(allowAnonymous: Boolean) = PolynoteConfig(security = Security(auth = Some(AuthProvider(
+    provider = "header",
+    config = providerConfig(allowAnonymous).asJsonObject))))
+
+  def loadFrom(config: PolynoteConfig): Option[IdentityProvider.Service] = config.security.auth.map(IdentityProvider.find).sequence.runIO(config)
+
+  "HeaderIdentityProvider" - {
+
+    "loads from config YAML" in {
+      val yaml =
+        s"""security:
+           |  auth:
+           |    provider: header
+           |    config:
+           |      header: X-User-Name
+           |      permissions:
+           |        bob:
+           |             - read
+           |             - modify
+           |        alice: all
+           |        "*"  : read
+           |      allow_anonymous: false
+           |""".stripMargin
+
+      val parsed = PolynoteConfig.parse(yaml).fold(throw _, identity)
+      loadFrom(parsed) shouldEqual loadFrom(authConfig(false))
+    }
+
+    "when specified header is missing" - {
+      val ok = ZIO.effectTotal(Response[Task](Status.Ok))
+
+      "fails when allowMissing = false" in {
+        val config = authConfig(false)
+        val authorize = IdentityProvider.authorize[Environment with Config]
+          .provideSomeM(Env.enrichM[Environment with Config](IdentityProvider.load))
+          .runIO(config)
+        authorize(Request(), ok).runIO(config).status shouldEqual Status.Forbidden
+      }
+
+      "succeeds when allowMissing = true" in {
+        val config = authConfig(true)
+        val authorize = IdentityProvider.authorize[Environment with Config]
+          .provideSomeM(Env.enrichM[Environment with Config](IdentityProvider.load))
+          .runIO(config)
+
+        authorize(Request(), ok).runIO(config).status shouldEqual Status.Ok
+      }
+    }
+
+    "provides a user identity" - {
+      val config = authConfig(true)
+      val authorize = IdentityProvider.authorize[Environment with Config]
+        .provideSomeM(Env.enrichM[Environment with Config](IdentityProvider.load))
+        .runIO(config)
+
+      val response = ZIO.access[UserIdentity](_.userIdentity).map {
+        identity =>
+          Response[Task](headers = Headers(identity.map(id => Header("FoundIdentity", id.name)).toList))
+      }
+
+      def check(name: Option[String]) =
+        authorize(Request(headers = Headers(name.map(Header("X-User-Name", _)).toList)), response).runIO(config)
+          .headers.get(CaseInsensitiveString("FoundIdentity"))
+          .map(_.value)
+
+      "non-empty when header is present" in {
+        check(Some("bob")) shouldEqual Some("bob")
+        check(Some("alice")) shouldEqual Some("alice")
+        check(Some("unknownperson")) shouldEqual Some("unknownperson")
+      }
+
+      "empty when header is absent" in {
+        check(None) shouldEqual None
+      }
+    }
+
+    "checks permissions" - {
+      import Permission._
+      val provider = new HeaderIdentityProvider(providerConfig(true))
+      def check(name: Option[String], permission: Permission): Unit =
+        IdentityProvider.checkPermission(permission)
+          .provideSomeM(Env.enrich[Environment with Config with IdentityProvider](UserIdentity.of(name.map(BasicIdentity.apply))))
+          .provideSomeM(Env.enrich[Environment with Config](IdentityProvider.of(provider)))
+          .runIO(PolynoteConfig())
+
+      def checkFail(name: Option[String], permission: Permission): Unit = a [PermissionDenied] shouldBe thrownBy {
+        check(name, permission)
+      }
+
+      def checkAll(name: Option[String], permissions: Permission*): Unit = permissions.foreach(check(name, _))
+      def checkAllFail(name: Option[String], permissions: Permission*): Unit = permissions.foreach(checkFail(name, _))
+
+      val read = ReadNotebook("/path")
+      val modify = ModifyNotebook("/path")
+      val execute = ExecuteCell("/path", CellID(1))
+      val delete = DeleteNotebook("/path")
+      val create = CreateNotebook("/path")
+
+      "for known users" in {
+        checkAll(Some("bob"), read, modify)
+        checkAllFail(Some("bob"), execute, delete, create)
+        checkAll(Some("alice"), read, modify, execute, delete, create)
+      }
+
+      "for unknown users" in {
+        check(None, read)
+        checkAllFail(None, modify, execute, delete, create)
+      }
+
+    }
+
+  }
+
+}

--- a/polynote-server/src/test/scala/polynote/server/auth/HeaderIdentityProviderSpec.scala
+++ b/polynote-server/src/test/scala/polynote/server/auth/HeaderIdentityProviderSpec.scala
@@ -16,7 +16,7 @@ import zio.interop.catz._
 
 class HeaderIdentityProviderSpec extends FreeSpec with Matchers with ZIOSpec {
 
-  private def providerConfig(allowAnonymous: Boolean) = HeaderIdentityProvider.Config(
+  private def createProvider(allowAnonymous: Boolean) = HeaderIdentityProvider(
     "X-User-Name",
     Map(
       "bob" -> Set(PermissionType.ReadNotebook, PermissionType.ModifyNotebook),
@@ -27,7 +27,7 @@ class HeaderIdentityProviderSpec extends FreeSpec with Matchers with ZIOSpec {
 
   private def authConfig(allowAnonymous: Boolean) = PolynoteConfig(security = Security(auth = Some(AuthProvider(
     provider = "header",
-    config = providerConfig(allowAnonymous).asJsonObject))))
+    config = createProvider(allowAnonymous).asJsonObject))))
 
   def loadFrom(config: PolynoteConfig): Option[IdentityProvider.Service] = config.security.auth.map(IdentityProvider.find).sequence.runIO(config)
 
@@ -103,7 +103,7 @@ class HeaderIdentityProviderSpec extends FreeSpec with Matchers with ZIOSpec {
 
     "checks permissions" - {
       import Permission._
-      val provider = new HeaderIdentityProvider(providerConfig(true))
+      val provider = createProvider(true)
       def check(name: Option[String], permission: Permission): Unit =
         IdentityProvider.checkPermission(permission)
           .provideSomeM(Env.enrich[Environment with Config with IdentityProvider](UserIdentity.of(name.map(BasicIdentity.apply))))


### PR DESCRIPTION
Adds interfaces for supporting identity and permission checks. The only implemented identity provider is `HeaderIdentityProvider`, which pulls from a header and checks against configured permission specs based on the contents of the header. This is useful mainly for running Polynote behind a proxy which handles authentication and passes headers to Polynote.

But the interfaces should make it easy enough to build new identity providers as Polynote plug-ins.

Future work: Presence messages and UI, maybe HTTP authentication support or something like that.