### PR TITLE
Add support for Maven and Ivy2 credentials

### DIFF
--- a/config-template.yml
+++ b/config-template.yml
@@ -141,15 +141,5 @@
 ############################################################################################
 
 #credentials:
-#  - ivy:
-#      base: https://my-artifacts.org/artifacts/
-#      username: user1
-#      password: password0
-#  - ivy:
-#      base: https://my-custom-ivy-repo.org/artifacts/
-#      username: user1
-#      password: password0
-#  - maven:
-#      base: http://central.maven.org/maven2/
-#      username: user1
-#      password: password0
+#  coursier:
+#    path: ~/.config/coursier/credentials.properties

--- a/config-template.yml
+++ b/config-template.yml
@@ -135,3 +135,21 @@
 #  # The URI relative to the server host where Polynote is mounted. You can edit this if mounting Polynote at a
 #  # different location behind a reverse proxy. This value is placed in the <base> tag.
 #  base_uri: /
+
+############################################################################################
+# Credentials. This list contains the list of credentials used to access the repositories
+############################################################################################
+
+#credentials:
+#  - ivy:
+#      base: https://my-artifacts.org/artifacts/
+#      username: user1
+#      password: password0
+#  - ivy:
+#      base: https://my-custom-ivy-repo.org/artifacts/
+#      username: user1
+#      password: password0
+#  - maven:
+#      base: http://central.maven.org/maven2/
+#      username: user1
+#      password: password0

--- a/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
@@ -97,30 +97,14 @@ object UI {
   implicit val decoder: Decoder[UI] = deriveDecoder
 }
 
-sealed trait Credentials
+case class Credentials(
+  coursier: Option[Credentials.Coursier] = None
+)
 object Credentials {
-  final case class ivy(
-    base: String,
-    username: String,
-    password: String
-  ) extends Credentials {
-    override def toString = s"ivy($base,$username,<REDACTED>)"
-  }
-  object ivy {
-    implicit val encoder: ObjectEncoder[maven] = deriveEncoder
-    implicit val decoder: Decoder[maven] = deriveDecoder
-  }
-
-  final case class maven(
-    base: String,
-    username: String,
-    password: String
-  ) extends Credentials {
-    override def toString = s"maven($base,$username,<REDACTED>)"
-  }
-  object maven {
-    implicit val encoder: ObjectEncoder[maven] = deriveEncoder
-    implicit val decoder: Decoder[maven] = deriveDecoder
+  final case class Coursier(path: String)
+  object Coursier {
+    implicit val encoder: ObjectEncoder[Coursier] = deriveEncoder
+    implicit val decoder: Decoder[Coursier] = deriveDecoder
   }
 
   implicit val encoder: ObjectEncoder[Credentials] = deriveEncoder
@@ -137,7 +121,7 @@ final case class PolynoteConfig(
   behavior: Behavior = Behavior(),
   security: Security = Security(),
   ui: UI = UI(),
-  credentials: List[Credentials] = Nil
+  credentials: Credentials = Credentials()
 )
 
 

--- a/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
@@ -97,6 +97,36 @@ object UI {
   implicit val decoder: Decoder[UI] = deriveDecoder
 }
 
+sealed trait Credentials
+object Credentials {
+  final case class ivy(
+    base: String,
+    username: String,
+    password: String
+  ) extends Credentials {
+    override def toString = s"ivy($base,$username,<REDACTED>)"
+  }
+  object ivy {
+    implicit val encoder: ObjectEncoder[maven] = deriveEncoder
+    implicit val decoder: Decoder[maven] = deriveDecoder
+  }
+
+  final case class maven(
+    base: String,
+    username: String,
+    password: String
+  ) extends Credentials {
+    override def toString = s"maven($base,$username,<REDACTED>)"
+  }
+  object maven {
+    implicit val encoder: ObjectEncoder[maven] = deriveEncoder
+    implicit val decoder: Decoder[maven] = deriveDecoder
+  }
+
+  implicit val encoder: ObjectEncoder[Credentials] = deriveEncoder
+  implicit val decoder: Decoder[Credentials] = deriveDecoder
+}
+
 final case class PolynoteConfig(
   listen: Listen = Listen(),
   storage: Storage = Storage(),
@@ -106,7 +136,8 @@ final case class PolynoteConfig(
   spark: Map[String, String] = Map.empty,
   behavior: Behavior = Behavior(),
   security: Security = Security(),
-  ui: UI = UI()
+  ui: UI = UI(),
+  credentials: List[Credentials] = Nil
 )
 
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/dependency/CoursierFetcher.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/dependency/CoursierFetcher.scala
@@ -69,11 +69,7 @@ object CoursierFetcher {
   private def loadCredentials(credentials: CredentialsConfig): URIO[Logging, List[DirectCredentials]] = credentials.coursier match {
     case Some(CredentialsConfig.Coursier(path)) =>
       Task(CoursierCredentials(new File(path), optional = false).get().toList)
-        .catchAllCause(cause => for {
-            log <- Logging.access
-            _   <- log.error("Failed to load credentials", cause)
-          } yield Nil
-        )
+        .catchAll(err => Logging.error("Failed to load credentials", err).as(Nil))
     case None => UIO(Nil)
   }
 

--- a/polynote-kernel/src/test/scala/polynote/config/PolynoteConfigSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/config/PolynoteConfigSpec.scala
@@ -66,18 +66,8 @@ class PolynoteConfigSpec extends FlatSpec with Matchers with EitherValues {
         |# Credentials. This list contains the list of credentials used to access the repositories
         |
         |credentials:
-        |  - ivy:
-        |      base: https://my-artifacts.org/artifacts/
-        |      username: user1
-        |      password: password0
-        |  - ivy:
-        |      base: https://my-custom-ivy-repo.org/artifacts/
-        |      username: user1
-        |      password: password0
-        |  - maven:
-        |      base: http://central.maven.org/maven2/
-        |      username: user1
-        |      password: password0
+        |  coursier:
+        |    path: ~/.config/coursier/credentials.properties
       """.stripMargin
 
     val parsed = yaml.parser.parse(yamlStr).flatMap(_.as[PolynoteConfig])
@@ -102,22 +92,8 @@ class PolynoteConfigSpec extends FlatSpec with Matchers with EitherValues {
       List("org.typelevel", "com.mycompany"),
       Map("scala" -> List("org.typelevel:cats-core_2.11:1.6.0", "com.mycompany:my-library:jar:all:1.0.0")),
       Map("spark.driver.userClasspathFirst" -> "true", "spark.executor.userClasspathFirst" -> "true"),
-      credentials = List(
-        Credentials.ivy(
-          "https://my-artifacts.org/artifacts/",
-          "user1",
-          "password0"
-        ),
-        Credentials.ivy(
-          "https://my-custom-ivy-repo.org/artifacts/",
-          "user1",
-          "password0"
-        ),
-        Credentials.maven(
-          "http://central.maven.org/maven2/",
-          "user1",
-          "password0"
-        )
+      credentials = Credentials(
+        coursier = Some(Credentials.Coursier("~/.config/coursier/credentials.properties"))
       )
     )
 

--- a/polynote-kernel/src/test/scala/polynote/config/PolynoteConfigSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/config/PolynoteConfigSpec.scala
@@ -63,6 +63,21 @@ class PolynoteConfigSpec extends FlatSpec with Matchers with EitherValues {
         |  spark.driver.userClasspathFirst: true
         |  spark.executor.userClasspathFirst: true
         |
+        |# Credentials. This list contains the list of credentials used to access the repositories
+        |
+        |credentials:
+        |  - ivy:
+        |      base: https://my-artifacts.org/artifacts/
+        |      username: user1
+        |      password: password0
+        |  - ivy:
+        |      base: https://my-custom-ivy-repo.org/artifacts/
+        |      username: user1
+        |      password: password0
+        |  - maven:
+        |      base: http://central.maven.org/maven2/
+        |      username: user1
+        |      password: password0
       """.stripMargin
 
     val parsed = yaml.parser.parse(yamlStr).flatMap(_.as[PolynoteConfig])
@@ -86,7 +101,24 @@ class PolynoteConfigSpec extends FlatSpec with Matchers with EitherValues {
       ),
       List("org.typelevel", "com.mycompany"),
       Map("scala" -> List("org.typelevel:cats-core_2.11:1.6.0", "com.mycompany:my-library:jar:all:1.0.0")),
-      Map("spark.driver.userClasspathFirst" -> "true", "spark.executor.userClasspathFirst" -> "true")
+      Map("spark.driver.userClasspathFirst" -> "true", "spark.executor.userClasspathFirst" -> "true"),
+      credentials = List(
+        Credentials.ivy(
+          "https://my-artifacts.org/artifacts/",
+          "user1",
+          "password0"
+        ),
+        Credentials.ivy(
+          "https://my-custom-ivy-repo.org/artifacts/",
+          "user1",
+          "password0"
+        ),
+        Credentials.maven(
+          "http://central.maven.org/maven2/",
+          "user1",
+          "password0"
+        )
+      )
     )
 
   }


### PR DESCRIPTION
Adds a new `credentials` config that stores repository credentials that can be used to access maven and ivy2 repositories.

Fix #698 