### PR TITLE
Fix companion objects in package cell

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/ScalaCompiler.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/ScalaCompiler.scala
@@ -453,9 +453,9 @@ class ScalaCompiler private (
         // TODO: should things you import from inside a package cell be imported elsewhere? Or should it be isolated?
         val selectors = stats.collect {
           case defTree: DefTree => defTree.name
-        }.zipWithIndex.map {
+        }.groupBy(_.toString).values.map(_.maxBy(_.isTermName)).zipWithIndex.map {
           case (name, index) => ImportSelector(name.toTermName, index, name.toTermName, index)
-        }
+        }.toList
 
         if (selectors.nonEmpty) {
           Imports(Nil, List(Import(copyAndReset(pkgId), selectors)))

--- a/polynote-kernel/src/test/scala/polynote/kernel/interpreter/scal/ScalaInterpreterSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/interpreter/scal/ScalaInterpreterSpec.scala
@@ -140,6 +140,22 @@ class ScalaInterpreterSpec extends FreeSpec with Matchers with InterpreterSpec {
       val scopeMap = finalState.scope.map(r => r.name.toString -> r.value).toMap
       scopeMap("b") shouldEqual 20
     }
+
+    "class with explicit companion" in {
+      val test = for {
+        _ <- interp(
+          """package explicitCompanion
+            |sealed abstract class TestClass { def m = 10 }
+            |object TestClass extends TestClass""".stripMargin)
+        _ <- interp("val result = TestClass.m")
+        _ <- interp("val cls = classOf[TestClass]")
+      } yield ()
+
+      val (finalState, _) = test.run(cellState).runIO()
+      val scopeMap = finalState.scope.map(r => r.name.toString -> r.value).toMap
+      scopeMap("result") shouldEqual 10
+      scopeMap("cls").asInstanceOf[Class[_]].getSimpleName shouldEqual "TestClass"
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes an issue where if a package cell defines both a term and type of the same name, future cells all error because of the double-import