### PR TITLE
Removed pyspark from the pip3 install  for dependencies.

### DIFF
--- a/docs/01-installation.md
+++ b/docs/01-installation.md
@@ -62,7 +62,7 @@ cd polynote
   You'll also need to install some Python dependencies `jep`, `jedi`, `virtualenv`:
   
   ```
-  pip3 install jep jedi pyspark virtualenv
+  pip3 install jep jedi virtualenv
   ``` 
   
   For PySpark support you'll want to install `pyspark` as well. 


### PR DESCRIPTION
Since PySpark is mentioned on the next line of the installation guide, and is not required to run Polynote, there's no reason for it to be in the pip3 command for installing dependencies.

This will help keep the install size down for installations that aren't running Spark, or at least which don't require PySpark support.