### PR TITLE
Fix Py4j version handling

### DIFF
--- a/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
@@ -115,14 +115,10 @@ class PySparkInterpreter(
     jep =>
 
       jep.eval("import py4j")
-      val py4jVersion = jep.getValue("py4j.__version__", classOf[String])
-
-      val Version = "(\\d+).(\\d+).(\\d+)".r
-
-      py4jVersion match {
-        case Version(_, _, patch) if patch.toInt >= 7 => true
-        case _ => false
-      }
+      jep.getValue(
+        "tuple(int(x) for x in py4j.__version__.split('.')[:3]) >= (0, 10, 7)",
+        classOf[java.lang.Boolean]
+      ).booleanValue
   }
 
   private lazy val py4jToken: String = RandomStringUtils.randomAlphanumeric(256)

--- a/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
@@ -115,8 +115,9 @@ class PySparkInterpreter(
     jep =>
 
       jep.eval("import py4j")
+      jep.eval("import pkg_resources")
       jep.getValue(
-        "tuple(int(x) for x in py4j.__version__.split('.')[:3]) >= (0, 10, 7)",
+        "pkg_resources.parse_version(py4j.__version__) >= pkg_resources.parse_version('0.10.7')",
         classOf[java.lang.Boolean]
       ).booleanValue
   }


### PR DESCRIPTION
Current implementation of `shouldAuthenticate` cannot handle latest Py4j version, which is 0.10.8.1 (Used by current Spark master).

Proper version parsing PEP-440 compatible parse, like one from `pkg_resources`:

```
pkg_resources.parse_version(py4j.__version__)  >= pkg_resources.parse_version("0.10.7") 
```

but this might be an overkill, if this function will be dropped soon.

A simple workaround is to take version prefix in Python.