### PR TITLE
Better handling of unexpected kernel shutdowns

### DIFF
--- a/polynote-env/src/main/scala/polynote/env/ops/Location.scala
+++ b/polynote-env/src/main/scala/polynote/env/ops/Location.scala
@@ -13,4 +13,6 @@ object Location {
 
   implicit def materialize: Location = macro LocationMacros.materialize
 
+  val Empty: Location = Location("", 0, "", "")
+
 }

--- a/polynote-frontend/polynote/interpreter/vega_interpreter.js
+++ b/polynote-frontend/polynote/interpreter/vega_interpreter.js
@@ -1,7 +1,7 @@
 "use strict";
 
 import * as acorn from "acorn"
-import {Position, KernelReport, CompileErrors, Output, KernelErrorWithCause, RuntimeError} from "../data/result";
+import {Position, KernelReport, CompileErrors, Output, ServerErrorWithCause, RuntimeError} from "../data/result";
 import {DataStream, MIMERepr} from "../data/value_repr";
 import embed from "vega-embed";
 import {ClientResult} from "../data/result";

--- a/polynote-frontend/polynote/ui/component/cell.ts
+++ b/polynote-frontend/polynote/ui/component/cell.ts
@@ -29,7 +29,7 @@ import {
     ClientResult,
     CompileErrors,
     ExecutionInfo,
-    KernelErrorWithCause,
+    ServerErrorWithCause,
     KernelReport,
     Output,
     PosRange,
@@ -283,7 +283,7 @@ export abstract class Cell extends UIMessageTarget {
 }
 
 // TODO: it's a bit hacky to export this, should probably put this in some utils module
-export function errorDisplay(error: KernelErrorWithCause, currentFile: string, maxDepth: number = 0, nested: boolean = false): {el: TagElement<"details"> | TagElement<"div">, messageStr: string, cellLine: number | null} {
+export function errorDisplay(error: ServerErrorWithCause, currentFile: string, maxDepth: number = 0, nested: boolean = false): {el: TagElement<"details"> | TagElement<"div">, messageStr: string, cellLine: number | null} {
     let cellLine: number | null = null;
     const traceItems: TagElement<"li">[] = [];
     const messageStr = `${error.message} (${error.className})`;
@@ -621,7 +621,7 @@ export class CodeCell extends Cell {
         }
     }
 
-    setRuntimeError(error: KernelErrorWithCause) {
+    setRuntimeError(error: ServerErrorWithCause) {
         const {el, messageStr, cellLine} = errorDisplay(error, this.container.id, 3);
 
         this.cellOutputDisplay.classList.add('errors');

--- a/polynote-frontend/polynote/ui/component/nb_cells.ts
+++ b/polynote-frontend/polynote/ui/component/nb_cells.ts
@@ -7,7 +7,7 @@ import * as messages from "../../data/messages";
 import {storage} from "../util/storage";
 import {clientInterpreters} from "../../interpreter/client_interpreter";
 import * as monaco from "monaco-editor";
-import {PosRange} from "../../data/result";
+import {PosRange, ServerErrorWithCause} from "../../data/result";
 import {NotebookUI} from "./notebook";
 import {CurrentNotebook} from "./current_notebook";
 import {NotebookConfig} from "../../data/data";
@@ -53,9 +53,9 @@ export class NotebookCellsUI extends UIMessageTarget {
         this.forEachCell(cell => cell.setDisabled(disabled));
     }
 
-    setLoadingFailure(error: messages.Error) {
+    setLoadingFailure(error: ServerErrorWithCause) {
         this.el.innerHTML = "";
-        this.el.appendChild(blockquote(['error-report'], [errorDisplay(error.error, "").el]));
+        this.el.appendChild(blockquote(['error-report'], [errorDisplay(error, "").el]));
     }
 
     setStatus(id: number, status: TaskInfo) {

--- a/polynote-frontend/polynote/ui/component/notebook.ts
+++ b/polynote-frontend/polynote/ui/component/notebook.ts
@@ -5,7 +5,7 @@ import {EditBuffer} from "../../data/edit_buffer";
 import * as messages from "../../data/messages";
 import {Cell, CodeCell, TextCell} from "./cell";
 import match from "../../util/match";
-import {ClearResults, ClientResult, KernelError, Output, PosRange, Result, ResultValue} from "../../data/result";
+import {ClearResults, ClientResult, ServerError, Output, PosRange, Result, ResultValue} from "../../data/result";
 import {DataRepr, DataStream, StreamingDataRepr} from "../../data/value_repr";
 import {clientInterpreters} from "../../interpreter/client_interpreter";
 import {CellMetadata, NotebookCell, NotebookConfig} from "../../data/data";
@@ -93,7 +93,7 @@ export class NotebookUI extends UIMessageTarget {
                        if (msg instanceof messages.Error) {
                            this.socket.close();
                            this.closed = true;
-                           this.cellUI.setLoadingFailure(msg);
+                           this.cellUI.setLoadingFailure(msg.error);
                        }
                    }
                }
@@ -180,6 +180,7 @@ export class NotebookUI extends UIMessageTarget {
                 removed.forEach(id => { this.removePresenceSelection(id); delete this.otherUsers[id] });
             })
             .when(messages.PresenceSelection, (id, cellId, range) => this.setPresenceSelection(id, cellId, range))
+            .when(messages.KernelError, (err) => console.log(err)) // TODO: need a general UI treatment for kernel-level errors
         );
 
         this.socket.addMessageListener(messages.NotebookUpdate, (update: messages.NotebookUpdate) => {

--- a/polynote-kernel/src/main/scala/polynote/kernel/Kernel.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/Kernel.scala
@@ -74,6 +74,12 @@ trait Kernel {
     * Release a handle. No further data will be available using [[getHandleData()]].
     */
   def releaseHandle(handleType: HandleType, handleId: Int): RIO[BaseEnv with StreamingHandles, Unit]
+
+  /**
+    * @return A task which will wait for the kernel to be closed. Completes with an error if the kernel closes due to
+    *         error.
+    */
+  def awaitClosed: Task[Unit]
 }
 
 object Kernel {

--- a/polynote-kernel/src/main/scala/polynote/kernel/data.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/data.scala
@@ -264,3 +264,8 @@ final case class PresenceSelection(presenceId: Int, cellID: CellID, range: (Int,
   override def isRelevant(subscriber: Int): Boolean = presenceId != subscriber
 }
 object PresenceSelection extends KernelStatusUpdateCompanion[PresenceSelection](6)
+
+final case class KernelError(err: Throwable) extends KernelStatusUpdate with AlwaysRelevant
+object KernelError extends KernelStatusUpdateCompanion[KernelError](7) {
+  implicit val codec: Codec[KernelError] = RuntimeError.throwableWithCausesCodec.xmap(new KernelError(_), _.err)
+}

--- a/polynote-kernel/src/main/scala/polynote/kernel/environment/environment.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/environment/environment.scala
@@ -14,6 +14,7 @@ import zio.blocking.Blocking
 import zio.internal.Executor
 import zio.interop.catz._
 import zio.{RIO, Task, UIO, URIO, ZIO}
+import zio.syntax.zioTuple3Syntax
 
 //////////////////////////////////////////////////////////////////////
 // Environment modules to mix for various layers of the application //

--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/transport.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/transport.scala
@@ -1,12 +1,12 @@
 package polynote.kernel
 package remote
 
-import java.io.IOException
+import java.io.{BufferedReader, IOException, InputStreamReader}
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.nio.channels.{AsynchronousCloseException, ClosedChannelException, ServerSocketChannel, SocketChannel}
 import java.nio.file.Paths
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{Semaphore, TimeUnit}
 
 import cats.effect.concurrent.Deferred
 import fs2.Stream
@@ -28,7 +28,7 @@ import zio.duration.{durationInt, Duration => ZDuration}
 import zio.interop.catz._
 
 import scala.concurrent.TimeoutException
-import scala.concurrent.duration.{Duration, MINUTES, SECONDS}
+import scala.concurrent.duration.{Duration, MILLISECONDS, MINUTES, SECONDS}
 import scala.reflect.{ClassTag, classTag}
 import Update.notebookUpdateCodec
 import cats.arrow.FunctionK
@@ -57,6 +57,8 @@ trait TransportServer[ServerAddress] {
     * Shut down the server and any processes it's deployed
     */
   def close(): TaskB[Unit]
+
+  def awaitClosed: Task[Unit]
 
   /**
     * @return whether the transport is connected (i.e. can a request be sent)
@@ -89,8 +91,8 @@ trait TransportClient {
 class SocketTransportServer private (
   server: ServerSocketChannel,
   channels: SocketTransport.Channels,
-  process: SocketTransport.DeployedProcess,
-  closed: Deferred[Task, Unit]
+  private[polynote] val process: SocketTransport.DeployedProcess,
+  closed: Promise[Throwable, Unit]
 ) extends TransportServer[InetSocketAddress] {
 
   override def sendRequest(req: RemoteRequest): TaskB[Unit] = for {
@@ -106,15 +108,11 @@ class SocketTransportServer private (
   } yield ()
 
   override val responses: Stream[TaskB, RemoteResponse] =
-      Stream.eval(Logging.info("Connected. Decoding incoming messages")).drain ++
         channels.mainChannel.bitVectors
-          .interruptWhen(closed.get.either)
+          .interruptAndIgnoreWhen(closed)
           .through(scodec.stream.decode.pipe[TaskB, RemoteResponse])
-          .handleErrorWith {
-            err => Stream.eval(Logging.error("Response stream terminated due to error", err)).drain
-          } ++ Stream.eval(Logging.info("Response stream terminated")).drain
 
-  override def close(): TaskB[Unit] = Logging.info("Closing remote kernel transport") *> closed.complete(()) *> channels.close() *> process.awaitOrKill(30)
+  override def close(): TaskB[Unit] = closed.succeed(()) *> channels.close() *> process.awaitOrKill(30)
 
   override def isConnected: TaskB[Boolean] = ZIO(channels.isConnected)
 
@@ -122,6 +120,8 @@ class SocketTransportServer private (
     case Some(addr: InetSocketAddress) => ZIO.succeed(addr)
     case _ => ZIO.fail(new RuntimeException("No valid address"))
   }
+
+  override def awaitClosed: Task[Unit] = closed.await
 }
 
 object SocketTransportServer {
@@ -149,12 +149,14 @@ object SocketTransportServer {
     channel2: FramedSocket,
     process: SocketTransport.DeployedProcess
   ): TaskB[SocketTransportServer] = for {
-    closed   <- Deferred[Task, Unit]
+    closed   <- Promise.make[Throwable, Unit]
     channels <- selectChannels(channel1, channel2, server.getLocalAddress.asInstanceOf[InetSocketAddress])
+    _        <- channel1.awaitClosed.to(closed).fork
+    _        <- channel2.awaitClosed.to(closed).fork
   } yield new SocketTransportServer(server, channels, process, closed)
 }
 
-class SocketTransportClient private (channels: SocketTransport.Channels, closed: Deferred[Task, Unit]) extends TransportClient {
+class SocketTransportClient private (channels: SocketTransport.Channels, closed: Promise[Throwable, Unit]) extends TransportClient {
 
   def logError(fn: Cause[Throwable] => ZIO[Logging, Nothing, Unit]): TaskB ~> TaskB = new ~>[TaskB, TaskB] {
     override def apply[A](fa: TaskB[A]): TaskB[A] = fa.onError(fn)
@@ -176,14 +178,14 @@ class SocketTransportClient private (channels: SocketTransport.Channels, closed:
 
   override val requests: Stream[TaskB, RemoteRequest] = requestStream.terminateAfter(_.isInstanceOf[ShutdownRequest])
 
-  override val updates: Stream[TaskB, NotebookUpdate] = updateStream.interruptWhen(closed.get.either)
+  override val updates: Stream[TaskB, NotebookUpdate] = updateStream.interruptAndIgnoreWhen(closed)
 
-  def close(): TaskB[Unit] = closed.complete(()) *> channels.close()
+  def close(): TaskB[Unit] = closed.succeed(()) *> channels.close()
 }
 
 object SocketTransportClient {
   def apply(channels: SocketTransport.Channels): Task[SocketTransportClient] = for {
-    closed <- Deferred[Task, Unit]
+    closed <- Promise.make[Throwable, Unit]
   } yield new SocketTransportClient(channels, closed)
 }
 
@@ -215,18 +217,21 @@ class SocketTransport(
     case None    => ZIO.fail(new TimeoutException(s"Remote kernel process failed to start after ${timeout.asScala}"))
   }
 
-  def serve(): RIO[BaseEnv with GlobalEnv with CurrentNotebook with TaskManager, TransportServer[InetSocketAddress]] =
+  private[polynote] def deployAndServe(): RIO[BaseEnv with GlobalEnv with CurrentNotebook with TaskManager, (TransportServer[InetSocketAddress], SocketTransport.DeployedProcess)] =
     TaskManager.run("RemoteKernel", "Remote kernel", "Starting remote kernel") {
       for {
         socketServer  <- openServerChannel
-        serverAddress  = socketServer.getLocalAddress.asInstanceOf[InetSocketAddress]
-        process       <- deploy.deployKernel(this, serverAddress)
-        _             <- CurrentTask.update(_.progress(0.5, Some("Waiting for remote kernel")))
-        connection    <- startConnection(socketServer)
-        connection2   <- startConnection(socketServer)
-        server        <- SocketTransportServer(socketServer, connection, connection2, process)
-      } yield server
+          serverAddress  = socketServer.getLocalAddress.asInstanceOf[InetSocketAddress]
+          process       <- deploy.deployKernel(this, serverAddress)
+          _             <- CurrentTask.update(_.progress(0.5, Some("Waiting for remote kernel")))
+          connection    <- startConnection(socketServer)
+          connection2   <- startConnection(socketServer)
+          server        <- SocketTransportServer(socketServer, connection, connection2, process)
+      } yield (server, process)
     }
+
+  def serve(): RIO[BaseEnv with GlobalEnv with CurrentNotebook with TaskManager, TransportServer[InetSocketAddress]] =
+    deployAndServe().map(_._1)
 
   def connect(serverAddress: InetSocketAddress): TaskB[TransportClient] = SocketTransport.connectClient(serverAddress)
 }
@@ -283,6 +288,15 @@ object SocketTransport {
     */
   class DeploySubprocess(deployCommand: DeploySubprocess.DeployCommand) extends Deploy {
 
+    private def logProcess(process: Process) = {
+      ZIO(new BufferedReader(new InputStreamReader(process.getInputStream))).flatMap {
+        stream => effectBlocking(stream.readLine()).tap {
+          case null => ZIO.unit
+          case line => Logging.remote(line)
+        }.repeat(ZSchedule.doUntil(line => line == null)).unit
+      }
+    }
+
     override def deployKernel(
       transport: SocketTransport,
       serverAddress: InetSocketAddress
@@ -292,10 +306,11 @@ object SocketTransport {
           str => if (str contains " ") s""""$str"""" else str
         }.mkString(" ")
 
-        val processBuilder = new ProcessBuilder(command: _*).inheritIO()
+        val processBuilder = new ProcessBuilder(command: _*).redirectErrorStream(true)
         for {
           _       <- Logging.info(s"Deploying with command:\n$displayCommand")
           process <- effectBlocking(processBuilder.start())
+          _       <- logProcess(process).fork
         } yield new DeploySubprocess.Subprocess(process)
     }
   }
@@ -350,9 +365,13 @@ object SocketTransport {
     */
   // TODO: Maybe fs2.io.tcp.Socket methods could be made to work, just seems over-complicated for single-client server?
   // TODO: If this introduces allocation/GC latency, could try to use a shared, reused buffer
-  class FramedSocket(socketChannel: SocketChannel) {
+  class FramedSocket(socketChannel: SocketChannel, closed: Promise[Throwable, Unit]) {
     private val incomingLengthBuffer = ByteBuffer.allocate(4)
     private val outgoingLengthBuffer = ByteBuffer.allocate(4)
+
+    // using primitive j.u.concurrent Semaphore here, because I need tryAcquire (zio Semaphore doesn't have it)
+    // TODO: When zio Sempaphore has tryAcquire, use that instead
+    private val writeLock = new Semaphore(1)
 
     private def readBuffer(): Option[Option[ByteBuffer]] = incomingLengthBuffer.synchronized {
       incomingLengthBuffer.rewind()
@@ -379,59 +398,65 @@ object SocketTransport {
     }
 
     def read(): TaskB[Option[Option[ByteBuffer]]] = effectBlocking(readBuffer()).uninterruptible.catchSome {
-      case err: AsynchronousCloseException => Logging.info("Remote peer closed connection") *> ZIO.succeed(None)
-    }.onError {
-      err => Logging.error(s"Connection error ${err.getClass.getName}", err)
+      case err: AsynchronousCloseException => Logging.info("Remote peer closed connection") *> close() *> ZIO.succeed(None)
+    }.catchSome {
+      case err if err.getClass.getSimpleName == "AsynchronousCloseException" => Logging.info("WTFBRO") *> close() *> ZIO.succeed(None)
+    }.tapError {
+      err => closed.fail(err)
     }
 
-    def write(msg: BitVector): TaskB[Unit] = effectBlocking {
-      val byteVector = msg.toByteVector
-      val size = byteVector.size.toInt
-      val byteBuffer = byteVector.toByteBuffer
-
-      outgoingLengthBuffer.synchronized {
-        outgoingLengthBuffer.rewind()
-        outgoingLengthBuffer.putInt(0, size)
-        socketChannel.write(outgoingLengthBuffer)
-
+    def write(msg: BitVector): TaskB[Unit] = ZIO.effectTotal(writeLock.acquire()).bracket(_ => ZIO.effectTotal(writeLock.release())) {
+      _ => effectBlocking {
+        val byteVector = msg.toByteVector
+        val size = byteVector.size.toInt
+        writeSize(size)
+        val byteBuffer = byteVector.toByteBuffer
         while (byteBuffer.hasRemaining) {
           socketChannel.write(byteBuffer)
         }
-      }
-    }.uninterruptible
+      }.uninterruptible
+    }.tapError {
+      case err: ClosedChannelException => close()
+      case err => closed.fail(err) *> close()
+    }
 
-    def close(): TaskB[Unit] = ZIO(outgoingLengthBuffer.synchronized(socketChannel.close()))
+    // MUST SYNCHRONIZE on writeLock to invoke this!
+    private def writeSize(size: Int) = {
+      outgoingLengthBuffer.rewind()
+      outgoingLengthBuffer.putInt(0, size)
+      socketChannel.write(outgoingLengthBuffer)
+    }
+
+    // send a keepalive, but if the channel is already being written, do nothing (don't queue a keepalive)
+    def sendKeepalive(): TaskB[Unit] = ZIO.effectTotal(writeLock.tryAcquire(0, TimeUnit.SECONDS)).bracket(
+      acquired => if (acquired) ZIO.effectTotal(writeLock.release()) else ZIO.unit).apply {
+      acquired => if (acquired) effectBlocking(writeSize(0)) else ZIO.unit
+    }
+
+    def close(): TaskB[Unit] =  ZIO.effectTotal(writeLock.acquire()).bracket(_ => ZIO.effectTotal(writeLock.release())) {
+      _ => effectBlocking(socketChannel.close()).uninterruptible <* closed.succeed(())
+    }
 
     def isConnected: Boolean = socketChannel.isConnected
 
+    def awaitClosed: Task[Unit] = closed.await
+
     val bitVectors: Stream[TaskB, BitVector] =
       Stream.repeatEval(read())
-        .handleErrorWith(err => Stream.eval(Logging.error("Remote kernel connection failure", err)).drain)
+        .handleErrorWith(err => Stream.eval(Logging.error("Remote kernel connection failure", err) *> closed.fail(err)).drain)
         .unNoneTerminate.unNone
         .map(BitVector.view)
   }
 
   object FramedSocket {
     def apply(socketChannel: SocketChannel, keepalive: Boolean = true): TaskB[FramedSocket] = {
-      import zio.interop.catz.implicits.ioTimer
-      import zio.interop.catz._
-      // send 0-length frames to keep connection alive
       for {
-        framedSocket <- ZIO.succeed(new FramedSocket(socketChannel))
         closed       <- Promise.make[Throwable, Unit]
+        framedSocket  = new FramedSocket(socketChannel, closed)
         doKeepalive  <- if (keepalive) {
-          Stream.awakeEvery[Task](Duration(5, SECONDS)).evalMap { _ =>
-              framedSocket.write(BitVector.empty).catchAll {
-                case err: ClosedChannelException => closed.succeed(())
-                case err =>
-                  // the keepalive needn't throw this error
-                  ZIO.unit
-              }
-            }
-            .interruptWhen(closed.await.either)
-            .compile
-            .drain
-            .fork
+          // This sends a keepalive quite frequently, because it's the only way we can detect if the remote peer dies.
+          // It only sends 16 bytes per second, though, and they only send if the channel isn't being written.
+          framedSocket.sendKeepalive().repeat(ZSchedule.spaced(ZDuration(250, TimeUnit.MILLISECONDS))).ignore.fork
         } else ZIO.unit
       } yield framedSocket
     }

--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/transport.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/transport.scala
@@ -221,12 +221,12 @@ class SocketTransport(
     TaskManager.run("RemoteKernel", "Remote kernel", "Starting remote kernel") {
       for {
         socketServer  <- openServerChannel
-          serverAddress  = socketServer.getLocalAddress.asInstanceOf[InetSocketAddress]
-          process       <- deploy.deployKernel(this, serverAddress)
-          _             <- CurrentTask.update(_.progress(0.5, Some("Waiting for remote kernel")))
-          connection    <- startConnection(socketServer)
-          connection2   <- startConnection(socketServer)
-          server        <- SocketTransportServer(socketServer, connection, connection2, process)
+        serverAddress  = socketServer.getLocalAddress.asInstanceOf[InetSocketAddress]
+        process       <- deploy.deployKernel(this, serverAddress)
+        _             <- CurrentTask.update(_.progress(0.5, Some("Waiting for remote kernel")))
+        connection    <- startConnection(socketServer)
+        connection2   <- startConnection(socketServer)
+        server        <- SocketTransportServer(socketServer, connection, connection2, process)
       } yield (server, process)
     }
 

--- a/polynote-kernel/src/test/scala/polynote/kernel/remote/RemoteKernelSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/remote/RemoteKernelSpec.scala
@@ -23,7 +23,7 @@ import zio.interop.catz._
 
 import scala.concurrent.TimeoutException
 
-class RemoteKernelSpec extends FreeSpec with Matchers with ZIOSpec with BeforeAndAfterAll with BeforeAndAfterEach with MockFactory with ScalaCheckDrivenPropertyChecks {
+class RemoteKernelSpec extends FreeSpec with Matchers with ZIOSpec with BeforeAndAfterEach with MockFactory with ScalaCheckDrivenPropertyChecks {
   private val kernel        = mock[Kernel]
   private val kernelFactory = new Factory.LocalService {
     def apply(): RIO[BaseEnv with GlobalEnv with CellEnv, Kernel] = ZIO.succeed(kernel)

--- a/polynote-server/src/main/scala/polynote/server/package.scala
+++ b/polynote-server/src/main/scala/polynote/server/package.scala
@@ -7,7 +7,7 @@ import polynote.kernel.environment.PublishMessage
 import polynote.kernel.{BaseEnv, GlobalEnv, TaskG}
 import polynote.messages.Message
 import polynote.server.auth.{IdentityProvider, UserIdentity}
-import zio.{RIO, Task, UIO}
+import zio.{RIO, Task, UIO, ZIO}
 
 package object server {
   type SessionEnv = BaseEnv with GlobalEnv with UserIdentity with IdentityProvider
@@ -18,6 +18,7 @@ package object server {
   implicit val taskMonadError: MonadError[Task, Throwable] = interop.monadErrorInstance[Any, Throwable]
   implicit val taskConcurrent: Concurrent[Task] = interop.taskConcurrentInstance[Any]
   implicit val taskGConcurrent: Concurrent[TaskG] = interop.taskConcurrentInstance[BaseEnv with GlobalEnv]
+  implicit val sessionConcurrent: Concurrent[RIO[SessionEnv, ?]] = interop.taskConcurrentInstance[SessionEnv]
   implicit val contextShiftTask: ContextShift[Task] = interop.zioContextShift[Any, Throwable]
   implicit val uioConcurrent: Concurrent[UIO] = interop.taskConcurrentInstance[Any].asInstanceOf[Concurrent[UIO]]
   implicit val rioApplicativeGlobal: Applicative[TaskG] = interop.taskConcurrentInstance[BaseEnv with GlobalEnv]

--- a/polynote-server/src/test/scala/polynote/server/KernelPublisherIntegrationTest.scala
+++ b/polynote-server/src/test/scala/polynote/server/KernelPublisherIntegrationTest.scala
@@ -82,12 +82,12 @@ class KernelPublisherIntegrationTest extends FreeSpec with Matchers with ExtConf
 
       val notebook        = Notebook("/i/am/fake.ipynb", ShortList(Nil), None)
       val kernelPublisher = KernelPublisher(notebook).runWith(failingKernelFactory)
+      val collectStatus = kernelPublisher.status.subscribe(5).interruptWhen(kernelPublisher.closed.await.either).compile.toList.fork.runIO()
 
       a [FailedToStart] should be thrownBy {
         kernelPublisher.kernel.runWith(failingKernelFactory)
       }
 
-      val collectStatus = kernelPublisher.status.subscribe(5).interruptWhen(kernelPublisher.closed.await.either).compile.toList.fork.runIO()
       val kernel2 = kernelPublisher.kernel.runWith(failingKernelFactory)
       assert(kernel2 eq stubKernel)
       kernelPublisher.close().runIO()

--- a/polynote-server/src/test/scala/polynote/server/KernelPublisherIntegrationTest.scala
+++ b/polynote-server/src/test/scala/polynote/server/KernelPublisherIntegrationTest.scala
@@ -1,0 +1,102 @@
+package polynote.server
+
+import java.net.InetSocketAddress
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{FreeSpec, Matchers}
+import polynote.config.PolynoteConfig
+import polynote.kernel.Kernel.Factory
+import polynote.kernel.environment.{Config, Env, NotebookUpdates}
+import polynote.kernel.interpreter.Interpreter
+import polynote.kernel.remote.SocketTransport.DeploySubprocess
+import polynote.kernel.remote.{RemoteKernel, SocketTransport, SocketTransportServer}
+import polynote.kernel.remote.SocketTransport.DeploySubprocess.DeployJava
+import polynote.kernel.{BaseEnv, CellEnv, GlobalEnv, Kernel, KernelBusyState, KernelError, KernelInfo, LocalKernelFactory}
+import polynote.messages.{Notebook, ShortList}
+import polynote.testing.{ConfiguredZIOSpec, ExtConfiguredZIOSpec}
+import zio.{Promise, RIO, Task, ZIO}
+
+class KernelPublisherIntegrationTest extends FreeSpec with Matchers with ExtConfiguredZIOSpec[Interpreter.Factories] with MockFactory {
+
+  val Environment: Environment = Env.enrichWith[BaseEnv with Config, Interpreter.Factories](baseEnv, new Interpreter.Factories {
+    override val interpreterFactories: Map[String, List[Interpreter.Factory]] = Map.empty
+  })
+
+  "KernelPublisher" - {
+
+    "gracefully handles death of kernel" in {
+      val deploy          = new DeploySubprocess(new DeployJava[LocalKernelFactory])
+      val transport       = new SocketTransport(deploy, Some("127.0.0.1"))
+      val notebook        = Notebook("/i/am/fake.ipynb", ShortList(Nil), None)
+      val kernelFactory   = RemoteKernel.factory(transport)
+      val kernelPublisher = KernelPublisher(notebook).runWith(kernelFactory)
+      val kernel          = kernelPublisher.kernel.runWith(kernelFactory).asInstanceOf[RemoteKernel[InetSocketAddress]]
+      val process         = kernel.transport.asInstanceOf[SocketTransportServer].process
+
+      val collectStatus = kernelPublisher.status.subscribe(5).interruptWhen(kernelPublisher.closed.await.either).compile.toList.fork.runIO()
+
+      val waitForDeath  = kernelPublisher.status.subscribe(5)
+        .terminateAfterEquals(KernelBusyState(busy = false, alive = false))
+        .covary[Task]
+        .compile.drain.fork.runIO()
+
+      process.kill().runIO()
+
+      waitForDeath.join.runIO()
+
+      val kernel2 = kernelPublisher.kernel.runWith(kernelFactory)
+      assert(!(kernel2 eq kernel), "Kernel should have changed")
+      kernelPublisher.close().runIO()
+      val statusUpdates = collectStatus.join.runIO()
+
+      // should have gotten a notification that the kernel became dead
+      statusUpdates should contain (KernelBusyState(busy = false, alive = false))
+
+      // should have gotten some kernel error
+      statusUpdates.collect {
+        case KernelError(err) => err
+      }.size shouldEqual 1
+
+    }
+
+    "gracefully handles startup failure of kernel" in {
+      val stubKernel = stub[Kernel]
+      stubKernel.shutdown _ when () returns ZIO.unit
+      stubKernel.awaitClosed _ when () returns ZIO.unit
+      stubKernel.init _ when () returns ZIO.unit
+      stubKernel.info _ when () returns ZIO.succeed(KernelInfo())
+
+      case class FailedToStart() extends Exception("The kernel fails to start. What do you do?")
+
+      val failingKernelFactory: Kernel.Factory = new Kernel.Factory {
+        override val kernelFactory: Factory.Service = new Factory.Service {
+          private var attempted = 0
+          override def apply(): RIO[BaseEnv with GlobalEnv with CellEnv with NotebookUpdates, Kernel] =
+            ZIO(attempted).bracket(n => ZIO.effectTotal(attempted = n + 1)) {
+              case 0 => ZIO.fail(FailedToStart())
+              case n => ZIO.succeed(stubKernel)
+            }
+        }
+      }
+
+      val notebook        = Notebook("/i/am/fake.ipynb", ShortList(Nil), None)
+      val kernelPublisher = KernelPublisher(notebook).runWith(failingKernelFactory)
+
+      a [FailedToStart] should be thrownBy {
+        kernelPublisher.kernel.runWith(failingKernelFactory)
+      }
+
+      val collectStatus = kernelPublisher.status.subscribe(5).interruptWhen(kernelPublisher.closed.await.either).compile.toList.fork.runIO()
+      val kernel2 = kernelPublisher.kernel.runWith(failingKernelFactory)
+      assert(kernel2 eq stubKernel)
+      kernelPublisher.close().runIO()
+      val statusUpdates = collectStatus.join.runIO()
+
+      // should have gotten the original startup error in status updates
+      statusUpdates should contain (KernelError(FailedToStart()))
+
+    }
+
+  }
+
+}

--- a/polynote-server/src/test/scala/polynote/server/KernelPublisherIntegrationTest.scala
+++ b/polynote-server/src/test/scala/polynote/server/KernelPublisherIntegrationTest.scala
@@ -42,7 +42,7 @@ class KernelPublisherIntegrationTest extends FreeSpec with Matchers with ExtConf
 
       val kernel2 = kernelPublisher.kernel
         .repeat(ZSchedule.doUntil[Kernel](_ ne kernel))
-        .timeout(Duration(5, TimeUnit.SECONDS))
+        .timeout(Duration(20, TimeUnit.SECONDS))
         .someOrFail(new Exception("Kernel should have changed; didn't change after 5 seconds"))
         .runWith(kernelFactory)
 

--- a/polynote-server/src/test/scala/polynote/server/KernelPublisherIntegrationTest.scala
+++ b/polynote-server/src/test/scala/polynote/server/KernelPublisherIntegrationTest.scala
@@ -1,6 +1,7 @@
 package polynote.server
 
 import java.net.InetSocketAddress
+import java.util.concurrent.TimeUnit
 
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FreeSpec, Matchers}
@@ -14,6 +15,7 @@ import polynote.kernel.remote.SocketTransport.DeploySubprocess.DeployJava
 import polynote.kernel.{BaseEnv, CellEnv, GlobalEnv, Kernel, KernelBusyState, KernelError, KernelInfo, LocalKernelFactory}
 import polynote.messages.{Notebook, ShortList}
 import polynote.testing.{ConfiguredZIOSpec, ExtConfiguredZIOSpec}
+import zio.duration.Duration
 import zio.{Promise, RIO, Task, ZIO}
 
 class KernelPublisherIntegrationTest extends FreeSpec with Matchers with ExtConfiguredZIOSpec[Interpreter.Factories] with MockFactory {
@@ -42,7 +44,7 @@ class KernelPublisherIntegrationTest extends FreeSpec with Matchers with ExtConf
 
       process.kill().runIO()
 
-      waitForDeath.join.runIO()
+      waitForDeath.join.timeout(Duration(2, TimeUnit.SECONDS)).runIO()
 
       val kernel2 = kernelPublisher.kernel.runWith(kernelFactory)
       assert(!(kernel2 eq kernel), "Kernel should have changed")


### PR DESCRIPTION
Propagate kernel shutdown errors such that the KernelPublisher can react to them by disposing of the failed kernel. Fixes some issues with kernels getting "stuck" in a failed state and being unable to restart.