### PR TITLE
Retry notebook writes

### DIFF
--- a/polynote-server/src/main/scala/polynote/server/KernelPublisher.scala
+++ b/polynote-server/src/main/scala/polynote/server/KernelPublisher.scala
@@ -211,6 +211,7 @@ class KernelPublisher private (
 
   def close(): TaskB[Unit] =
     closed.succeed(()).unit *>
+      subscribers.values.flatMap(_.map(_.close()).sequence).unit *>
       kernelRef.get.flatMap(_.fold[TaskB[Unit]](ZIO.unit)(_.shutdown())) *>
       taskManager.shutdown()
 

--- a/polynote-server/src/main/scala/polynote/server/repository/fs/LocalFilesystem.scala
+++ b/polynote-server/src/main/scala/polynote/server/repository/fs/LocalFilesystem.scala
@@ -19,7 +19,8 @@ class LocalFilesystem(maxDepth: Int = 4) extends NotebookFilesystem {
 
   override def writeStringToPath(path: Path, content: String): RIO[BaseEnv, Unit] = for {
     _ <- createDirs(path)
-  } yield Files.write(path, content.getBytes(StandardCharsets.UTF_8))
+    _ <- effectBlocking(Files.write(path, content.getBytes(StandardCharsets.UTF_8))).uninterruptible
+  } yield ()
 
   private def readBytes(is: => InputStream): RIO[BaseEnv, Chunk.Bytes] = {
     for {


### PR DESCRIPTION
- Retry notebook writes if they fail
- Use ZIO primitives for the notebook write loop instead of fs2
- Notify users if notebook writing fails
- Disable editing when writing has failed for a while