### PR TITLE
Configuration / validation changes

### DIFF
--- a/config-template.yml
+++ b/config-template.yml
@@ -111,17 +111,27 @@
 ###
 ###################################################################################################################
 
-#################################################################################
+###################################################################################################################
 # Spark config params can be set by uncommenting and editing the following lines.
+# To add additional spark configuration properties, add them as keys under `properties`.
+# To set additional arguments to `spark-submit`, you can use the `spark_submit_args` property.
 #
-# To set additional arguments to `spark-submit`, you can use the `sparkSubmitArgs` key. 
+# By default, not all jars in SPARK_DIST_CLASSPATH are available to the Polynote compiler (i.e., to user-code
+# inside cells). To use these jars (for example, if you want to use Hadoop APIs in your notebook without adding
+# a Hadoop dependency), set the `dist_classpath_filter` to a valid regular expression that selects which JARs
+# you want to use (there can be a huge number of JARs in SPARK_DIST_CLASSPATH, so it would be burdensome to
+# include all of them by default.)
 #
 #################################################################################
 
 #spark:
-#  sparkSubmitArgs: "--some --arguments"
-#  spark.driver.userClasspathFirst: true
-#  spark.executor.userClasspathFirst: true
+#  properties:
+#    spark.driver.memory: 28g
+#    spark.executor.memory: 60g
+#    spark.driver.userClasspathFirst: true
+#    spark.executor.userClasspathFirst: true
+#  spark_submit_args: "--some --arguments"
+#  dist_classpath_filter: hadoop.*\.jar
 
 
 ########## Front-end Configuration ################################################################################
@@ -144,10 +154,3 @@
 #  coursier:
 #    path: ~/.config/coursier/credentials.properties
 
-###############################################################################################
-# Extra jars to add from SPARK_DIST_CLASSPATH. By default, not all jars in SPARK_DIST_CLASSPATH
-# are available to the Polynote compiler (i.e., to user-code inside cells). All jars present on
-# SPARK_DIST_CLASSPATH that match the regex will be added to the compiler classpath.
-###############################################################################################
-
-#spark_dist_classpath_filter: "(hadoop-common-2.7.3-mycompany-.*.jar)"

--- a/polynote-kernel/src/main/scala/polynote/config/package.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/package.scala
@@ -1,15 +1,24 @@
 package polynote
 
-import io.circe.{Decoder, Json, ObjectEncoder}
+import java.util.regex.Pattern
+
+import cats.data.{NonEmptyList, Validated, ValidatedNel}
+import io.circe.{CursorOp, Decoder, DecodingFailure, Encoder, HCursor, Json, ObjectEncoder}
 import polynote.messages.{TinyList, TinyMap, TinyString}
 import scodec.codecs.{Discriminated, Discriminator, byte}
 import io.circe.generic.extras.{Configuration, JsonKey}
 import io.circe.generic.extras.semiauto._
-
 import cats.syntax.traverse._
 import cats.syntax.either._
 import cats.instances.list._
 import cats.instances.either._
+import io.circe.Decoder.Result
+import io.circe.generic.extras.decoding.{ConfiguredDecoder, ReprDecoder}
+import io.circe.generic.extras.util.RecordToMap
+import shapeless.labelled.FieldType
+import shapeless.ops.hlist.{Mapped, Mapper, RightFolder, ToTraversable, Zip, ZipWithKeys}
+import shapeless.ops.record.{Keys, Values}
+import shapeless.{::, Annotations, Default, HList, HNil, LabelledGeneric, Lazy, Poly1, Poly2, Witness}
 
 package object config {
   //                               lang      , deps
@@ -59,6 +68,71 @@ package object config {
   implicit val circeConfig: Configuration =
     Configuration.default.withSnakeCaseConstructorNames.withSnakeCaseMemberNames.withDefaults
 
+  abstract class ValidatedConfigDecoder[A] extends ConfiguredDecoder[A](circeConfig.copy(useDefaults = false))
+
+  object ValidatedConfigDecoder {
+    object optionalOrDefault extends Poly2 {
+      implicit def someDefault[K, A, OutT <: HList]: Case.Aux[(FieldType[K, Option[A]], Some[A]), ValidatedNel[DecodingFailure, OutT], ValidatedNel[DecodingFailure, A :: OutT]] =
+        at[(FieldType[K, Option[A]], Some[A]), ValidatedNel[DecodingFailure, OutT]] {
+          case ((in, default), accum) => accum.andThen(outT => Validated.validNel(in.getOrElse(default.get) :: outT))
+        }
+
+      implicit def noDefault[K <: Symbol, A, OutT <: HList](implicit name: Witness.Aux[K]): Case.Aux[(FieldType[K, Option[A]], None.type), ValidatedNel[DecodingFailure, OutT], ValidatedNel[DecodingFailure, A :: OutT]] =
+        at[(FieldType[K, Option[A]], None.type), ValidatedNel[DecodingFailure, OutT]] {
+          (in, accum) => in._1.asInstanceOf[Option[A]] match {
+            case Some(a) => accum.andThen(outT => Validated.Valid(a :: outT))
+            case None =>
+              val failure = DecodingFailure(s"Missing non-optional field ${name.value.name}", List(CursorOp.Field(name.value.name)))
+              Validated.Invalid(accum.swap.map(failure :: _).getOrElse(NonEmptyList(failure, Nil)))
+          }
+        }
+    }
+
+    /**
+      * This complex machine is for allowing us to keep our default values for the config ADT, but still validate the
+      * configs properly during decoding. Circe (at least the version available to us given Scala 2.11 constraint) silently
+      * drops decoding errors when there's a default value, and just uses the default instead. This derivation does
+      * something different:
+      * - Derive the shapeless record type `OR` that corresponds to the case class `A`, but with all values wrapped in `Option`.
+      * - Derive the circe decoder for `OR`, which allows values to be unspecified but does not drop validation errors.
+      * - Put the optionalized record together with the defaults from the case class constructor, and do another round of
+      *   validation where a `None` is replaced by the default (if it exists) or a validation error (if there is no default).
+      * - Within the validated structure, go back to the original record type `R` that corresponds to the case class and
+      *   use the shapeless LabelledGeneric to translate it to a validated case class instance.
+      */
+    implicit def deriveConfigDecoder[A, R <: HList, F <: HList, V <: HList, OV <: HList, OR <: HList, D <: HList, ZD <: HList, K <: HList](
+      implicit
+      gen: LabelledGeneric.Aux[A, R],
+      fields: Keys.Aux[R, F],
+      values: Values.Aux[R, V],
+      optionized: Mapped.Aux[V, Option, OV],
+      optionizedRecord: ZipWithKeys.Aux[F, OV, OR],
+      decodeR: Lazy[ReprDecoder[OR]],
+      defaults: Default.Aux[A, D],
+      fieldsToList: ToTraversable.Aux[F, List, Symbol],
+      keys: Annotations.Aux[JsonKey, A, K],
+      keysToList: ToTraversable.Aux[K, List, Option[JsonKey]],
+      zipWithDefaults: Zip.Aux[OR :: D :: HNil, ZD],
+      mapper: RightFolder.Aux[ZD, ValidatedNel[DecodingFailure, HNil], optionalOrDefault.type, ValidatedNel[DecodingFailure, V]],
+      relabel: ZipWithKeys.Aux[F, V, R]
+    ): ValidatedConfigDecoder[A] = new ValidatedConfigDecoder[A] {
+      override def apply(c: HCursor): Result[A] = decodeR.value.configuredDecodeAccumulating(c)(circeConfig.transformMemberNames, circeConfig.transformConstructorNames, Map.empty, circeConfig.discriminator).andThen {
+        OR => mapper(zipWithDefaults(OR :: defaults() :: HNil), Validated.valid(HNil))
+      }.map {
+        V => gen.from(relabel(V))
+      }.toEither.leftMap {
+        errs =>
+          val errsList = errs.toList
+          val combinedErrs = ("" :: errsList.map(_.message)).mkString("\n- ")
+          DecodingFailure(s"Configuration is invalid:$combinedErrs", errsList.flatMap(_.history))
+      }
+    }
+  }
+
+  def deriveConfigDecoder[A](implicit decoder: Lazy[ValidatedConfigDecoder[A]]): Decoder[A] = decoder.value
+
+  case class Test(first: Int = 10, second: String = "hi")
+
   implicit val mapStringStringDecoder: Decoder[Map[String, String]] = Decoder[Map[String, Json]].emap {
     jsonMap => jsonMap.toList.map {
       case (key, json) => json.fold(
@@ -72,4 +146,9 @@ package object config {
     }.sequence.map(_.toMap)
   }
 
+  implicit val patternDecoder: Decoder[Pattern] = Decoder.decodeString.emap {
+    regex => Either.catchNonFatal(Pattern.compile(regex)).leftMap(err => s"Invalid regular expression: ${err.getMessage}")
+  }
+
+  implicit val patternEncoder: Encoder[Pattern] = Encoder.encodeString.contramap(_.pattern())
 }

--- a/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
+++ b/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
@@ -9,7 +9,7 @@ import scodec.bits.{BitVector, ByteVector}
 import scodec.codecs._
 import scodec.codecs.implicits._
 import io.circe.generic.semiauto._
-import polynote.config.{DependencyConfigs, PolynoteConfig, RepositoryConfig}
+import polynote.config.{DependencyConfigs, PolynoteConfig, RepositoryConfig, SparkConfig}
 import polynote.data.Rope
 import polynote.runtime.{StreamingDataRepr, TableOp}
 import shapeless.cachedImplicit
@@ -83,20 +83,7 @@ final case class NotebookConfig(
   exclusions: Option[TinyList[TinyString]],
   repositories: Option[TinyList[RepositoryConfig]],
   sparkConfig: Option[ShortMap[String, String]]
-) {
-
-  def asPolynoteConfig: PolynoteConfig = {
-    val unTinyDependencies = dependencies.map(_.map {
-      case (k, v) => k.toString -> v
-    }).getOrElse(Map.empty)
-    PolynoteConfig(
-      repositories = repositories.getOrElse(Nil),
-      dependencies = unTinyDependencies,
-      exclusions = exclusions.getOrElse(Nil).map(_.toString),
-      spark = sparkConfig.getOrElse(Map.empty)
-    )
-  }
-}
+)
 
 object NotebookConfig {
   implicit val encoder: Encoder[NotebookConfig] = deriveEncoder[NotebookConfig]
@@ -113,7 +100,7 @@ object NotebookConfig {
       dependencies = Option(veryTinyDependencies),
       exclusions = Option(config.exclusions),
       repositories = Option(config.repositories),
-      sparkConfig = Option(config.spark)
+      sparkConfig = config.spark.map(SparkConfig.toMap)
     )
   }
 

--- a/polynote-server/src/main/scala/polynote/server/repository/format/ipynb/ZeppelinConverter.scala
+++ b/polynote-server/src/main/scala/polynote/server/repository/format/ipynb/ZeppelinConverter.scala
@@ -4,6 +4,7 @@ import io.circe.{Decoder, Json, JsonObject, Printer}
 import io.circe.syntax._
 import io.circe.generic.semiauto._
 import io.circe.parser.parse
+import polynote.config.SparkConfig
 import polynote.kernel.environment.Config
 import polynote.kernel.{BaseEnv, GlobalEnv}
 import polynote.messages.{Notebook, NotebookConfig}
@@ -26,7 +27,7 @@ class ZeppelinToIpynbFormat extends NotebookFormat {
       zep <- ZIO.fromEither(parsed.as[ZeppelinNotebook])
       config <- Config.access
     } yield {
-      val nbConfig = Option(NotebookConfig.empty.copy(sparkConfig = Option(config.spark)))
+      val nbConfig = Option(NotebookConfig.empty.copy(sparkConfig = config.spark.map(SparkConfig.toMap)))
       val content = JupyterNotebook.toNotebook(zep.toJupyterNotebook).copy(config = nbConfig)
       content.toNotebook(s"$noExtPath.ipynb") // Note the extension being overridden to ipynb here.
     }

--- a/polynote-spark/src/main/scala/polynote/kernel/remote/DeploySparkSubmit.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/remote/DeploySparkSubmit.scala
@@ -4,6 +4,7 @@ import java.io.File
 import java.net.InetSocketAddress
 
 import polynote.buildinfo.BuildInfo
+import polynote.config.SparkConfig
 import polynote.kernel.{Kernel, LocalSparkKernelFactory, ScalaCompiler, remote}
 import polynote.kernel.environment.{Config, CurrentNotebook}
 import polynote.kernel.remote.SocketTransport.DeploySubprocess.DeployCommand
@@ -64,7 +65,7 @@ object DeploySparkSubmit extends DeployCommand {
     config   <- Config.access
     nbConfig <- CurrentNotebook.config
   } yield build(
-    sparkConfig = config.spark ++ nbConfig.sparkConfig.getOrElse(Map.empty),
+    sparkConfig = config.spark.map(SparkConfig.toMap).getOrElse(Map.empty) ++ nbConfig.sparkConfig.getOrElse(Map.empty),
     serverArgs =
       "--address" :: serverAddress.getAddress.getHostAddress ::
       "--port" :: serverAddress.getPort.toString ::


### PR DESCRIPTION
- Currently the configuration doesn't validate at all; circe's `useDefaults` feature actually silently replaces invalid results with the default. Adds some machinery to derive decoders in a different way which doesn't do this. Fixes #781.
- Creates a structure for spark configurations.  `spark_dist_classpath_filter` is moved here (as `dist_classpath_filter` under `spark`). The old way (just keys/values under `spark`) is still supported, as long as you don't have a `properties` key there.
- Adds some configuration for spark "recipes" which will be implemented in a future PR.
- Updated the config-template.yml to reflect these changes (and correct a bad regex example)