### PR TITLE
Fix hanging StructDataEncoder macro

### DIFF
--- a/polynote-frontend/polynote/ui/component/display_content.ts
+++ b/polynote-frontend/polynote/ui/component/display_content.ts
@@ -134,7 +134,7 @@ export function displayData(data: any, fieldName?: string, expandObjects: boolea
             fields.appendChild(tag('li', [], {}, [displayData(val, key, expandNext)]));
         }
         return details;
-    } else if (typeof data === "object" && !(data instanceof String)) {
+    } else if (data && typeof data === "object" && !(data instanceof String)) {
         const keys = Object.keys(data);
         const summarySpan = span(['summary-content'], []);
         const summary = tag('summary', ['object-summary'], {}, [summarySpan]);
@@ -158,10 +158,16 @@ export function displayData(data: any, fieldName?: string, expandObjects: boolea
         return details;
     } else {
         let result;
-        switch (typeof data) {
-            case "number": result = span(['number'], [truncate(data.toString())]); break;
-            case "boolean": result = span(['boolean'], [data.toString()]); break;
-            default: result = span(['string'], [data.toString()]);
+        if (data !== null && data !== undefined) {
+            switch (typeof data) {
+                case "number": result = span(['number'], [truncate(data.toString())]); break;
+                case "boolean": result = span(['boolean'], [data.toString()]); break;
+                default: result = span(['string'], [data.toString()]);
+            }
+        } else if (data == null) {
+            result = span(['null'], ['null'])
+        } else {
+            result = span(['undefined'], ['undefined'])
         }
         if (fieldName) {
             return span(['object-field'], [span(['field-name'], [fieldName]), result]);

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -3071,6 +3071,11 @@ button.dialog-button {
     color: #c42426;
   }
 
+  .null {
+    color: #888888;
+    font-style: italic;
+  }
+
   .string::before, .string::after {
     color: #c42426;
     content: '"';


### PR DESCRIPTION
The StructDataEncoder macro relied on `fieldsOf` from shapeless in order to find all the encodable fields of a class. But, in cases where you had a `var` member of a class, that method was returning the setters for the var as fields, which means that the generated StructDataEncoder was ill-typed.

For some reason, when this happened, the JVM would get stuck in the `fillInStackTrace` native method for that error. Since it's a native method, it can't be interrupted, and the result is that the cell just hangs while it makes a futile attempt to get the `ReprsOf` for some value in the cell.

This fixes the macro at least, by filtering out any `Unit`-typed accessors as well as anything that actually has parameters. It doesn't fix the general problem that any error that occurs in that macro can cause everything to hang. I'll make another PR after this which reworks how `ReprsOf` are inferred (at least for Scala cells) - like, maybe we should just remove all the auto-derived stuff and just do that completely in the kernel (directly with the compiler, not through macros) when it's applicable, in addition to the implicit search.