### PR TITLE
Python goodies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Build
       run: |
         echo "Setting up Python dependencies"
-        pip install virtualenv ipython nbconvert jedi numpy scipy jep==3.9.0
+        pip install virtualenv ipython nbconvert jedi numpy scipy pandas jep==3.9.0
         jep_site_packages_path=`pip show jep | grep "^Location:" | cut -d ':' -f 2 | cut -d ' ' -f 2`
         jep_path=${jep_site_packages_path}/jep
         jep_lib_path=`realpath ${jep_site_packages_path}/../../`

--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/python/PythonInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/python/PythonInterpreter.scala
@@ -27,7 +27,7 @@ import scala.reflect.{ClassTag, classTag}
 import scala.util.Try
 
 class PythonInterpreter private[python] (
-  compiler: ScalaCompiler,
+  val compiler: ScalaCompiler,
   jepInstance: Jep,
   jepExecutor: Executor,
   jepThread: AtomicReference[Thread],
@@ -45,6 +45,12 @@ class PythonInterpreter private[python] (
       runtime.unsafeRun(effectBlocking(task).lock(jepExecutor).provide(jepBlockingService))
     }
 
+    override def runJep[T](task: Jep => T): T = if (Thread.currentThread() eq jepThread.get()) {
+      task(jepInstance)
+    } else {
+      runtime.unsafeRun(effectBlocking(task(jepInstance)).lock(jepExecutor).provide(jepBlockingService))
+    }
+
     def hasAttribute(obj: PythonObject, name: String): Boolean = run {
       hasAttr(obj.unwrap, name)
     }
@@ -52,7 +58,7 @@ class PythonInterpreter private[python] (
     def asScalaList(obj: PythonObject): List[PythonObject] = run {
       val pyObj = obj.unwrap
       val getItem = pyObj.getAttr("__getitem__", classOf[PyCallable])
-      val length = len(pyObj)
+      val length = pyApi.len(pyObj)
 
       List.tabulate(length)(i => getItem.callAs(classOf[PyObject], Int.box(i))).map(obj => new PythonObject(obj, this))
     }
@@ -66,7 +72,7 @@ class PythonInterpreter private[python] (
       val V = classTag[V].runtimeClass.asInstanceOf[Class[V]]
       val items = dictToItemsList(obj.unwrap)
       val getItem = items.getAttr("__getitem__", classOf[PyCallable])
-      val length = len(items)
+      val length = pyApi.len(items)
       val tuples = List.tabulate(length)(i => getItem.callAs(classOf[PyObject], Int.box(i)))
       val result = tuples.map {
         tup =>
@@ -75,6 +81,32 @@ class PythonInterpreter private[python] (
       }.toMap
       result
     }
+
+    override def asTuple2(obj: PythonObject): (PythonObject, PythonObject) = run {
+      val pyobj = obj.unwrap
+      val getItem = pyobj.getAttr("__getitem__", classOf[PyCallable])
+      val _1 = new PythonObject(getItem.callAs(classOf[PyObject], Int.box(0)), this)
+      val _2 = new PythonObject(getItem.callAs(classOf[PyObject], Int.box(1)), this)
+      (_1, _2)
+    }
+
+    override def asTuple2Of[A: ClassTag, B: ClassTag](obj: PythonObject): (A, B) = run {
+      val pyobj = obj.unwrap
+      val getItem = pyobj.getAttr("__getitem__", classOf[PyCallable])
+      val _1 = getItem.callAs(classTag[A].runtimeClass.asInstanceOf[Class[A]], Int.box(0))
+      val _2 = getItem.callAs(classTag[B].runtimeClass.asInstanceOf[Class[B]], Int.box(1))
+      (_1, _2)
+    }
+
+    override def typeName(obj: PythonObject): String = run(pyApi.typeName(obj.unwrap))
+    override def qualifiedTypeName(obj: PythonObject): String = run(pyApi.qualifiedTypeName(obj.unwrap))
+    override def len(obj: PythonObject): Int = run(pyApi.len(obj.unwrap))
+    override def len64(obj: PythonObject): Long = run(pyApi.len64(obj.unwrap))
+    override def list(obj: AnyRef): PythonObject = new PythonObject(run(pyApi.list(obj)), this)
+    override def listOf(objs: AnyRef*): PythonObject = new PythonObject(run(pyApi.list(objs.map(PythonObject.unwrapArg).toArray)), this)
+    override def tupleOf(objs: AnyRef*): PythonObject = new PythonObject(run(pyApi.tuple(pyApi.list(objs.map(PythonObject.unwrapArg).toArray))), this)
+    override def dictOf(kvs: (AnyRef, AnyRef)*): PythonObject = new PythonObject(run(pyApi.dictOf(kvs: _*)), this)
+    override def str(obj: AnyRef): PythonObject = new PythonObject(run(pyApi.str(obj)), this)
   }
 
   def run(code: String, state: State): RIO[InterpreterEnv, State] = for {
@@ -229,6 +261,10 @@ class PythonInterpreter private[python] (
       |        else:
       |            return node
       |
+      |def __polynote_mkindex__(l1, l2):
+      |    import pandas as pd
+      |    return pd.MultiIndex.from_arrays([[x for x in list(l1)], [x for x in list(l2)]])
+      |
       |def __polynote_parse__(code, cell):
       |    try:
       |        return { 'result': ast.fix_missing_locations(LastExprAssigner().visit(ast.parse(code, cell, 'exec'))) }
@@ -360,15 +396,26 @@ class PythonInterpreter private[python] (
 
       val addGlobal = globalsDict.getAttr("__setitem__", classOf[PyCallable])
 
+      val convert = convertToPython(jep) orElse PartialFunction(defaultConvertToPython)
+
       rest.map(_.values).map {
         values => values.map(v => v.name -> v.value).toMap
       }.foldLeft(Map.empty[String, Any])(_ ++ _).foreach {
-        case (name, value: PythonObject) => addGlobal.call(name, value.unwrap)
-        case (name, value) => addGlobal.call(name, value.asInstanceOf[AnyRef])
+        case nv@(name, value) => addGlobal.call(name, convert(nv))
       }
 
       globalsDict
   }
+
+  protected def defaultConvertToPython(nv: (String, Any)): Task[AnyRef] =
+    ZIO.succeed(nv._2.asInstanceOf[AnyRef])
+
+  protected def convertToPython(jep: Jep): PartialFunction[(String, Any), AnyRef] = {
+    case (_, value: PythonObject) => value.unwrap
+  }
+
+  protected def convertFromPython(jep: Jep): PartialFunction[(String, PyObject), (compiler.global.Type, Any)] =
+    PartialFunction.empty
 
   protected def parse(code: String, cell: String): Task[PyObject] = jep {
     jep =>
@@ -396,7 +443,7 @@ class PythonInterpreter private[python] (
           val run = jep.getValue("__polynote_run__", classOf[PyCallable])
           val result = run.callAs(classOf[PyObject], compiled, globals, locals, kernelRuntime)
           val get = result.getAttr("get", classOf[PyCallable])
-
+          val convert = convertFromPython(jep)
           get.callAs(classOf[util.ArrayList[Object]], "stack_trace") match {
             case null =>
               val globals = get.callAs(classOf[PyObject], "globals")
@@ -432,10 +479,15 @@ class PythonInterpreter private[python] (
                         val typ = runtime.unsafeRun(compiler.reflect(jValue)).symbol.info
                         (typ, jValue)
                       case other =>
-                        // should we use the qualified type? It's confusing that both Spark and Pandas have a "DataFrame".
-                        // But in every other case it's just noise.
-                        val typ = appliedType(typeOf[TypedPythonObject[Nothing]].typeConstructor, compiler.global.internal.constantType(Constant(other)))
-                        (typ, new TypedPythonObject[String](valueAs(classOf[PyObject]), runner))
+                        val pyObj = valueAs(classOf[PyObject])
+                        if (convert.isDefinedAt((typeStr, pyObj))) {
+                          convert((typeStr, pyObj))
+                        } else {
+                          // should we use the qualified type? It's confusing that both Spark and Pandas have a "DataFrame".
+                          // But in every other case it's just noise.
+                          val typ = appliedType(typeOf[TypedPythonObject[Nothing]].typeConstructor, compiler.global.internal.constantType(Constant(other)))
+                          (typ, new TypedPythonObject[String](valueAs(classOf[PyObject]), runner))
+                        }
                     }
                     Some(new ResultValue(key, compiler.unsafeFormatType(typ.asInstanceOf[Type]), Nil, state.id, value, typ.asInstanceOf[Type], None))
                   } else None
@@ -480,11 +532,16 @@ class PythonInterpreter private[python] (
 object PythonInterpreter {
 
   private[python] class PythonAPI(jep: Jep) {
+    import PythonObject.unwrapArg
     private val typeFn: PyCallable = jep.getValue("type", classOf[PyCallable])
     private val lenFn: PyCallable = jep.getValue("len", classOf[PyCallable])
     private val listFn: PyCallable = jep.getValue("list", classOf[PyCallable])
+    private val tupleFn: PyCallable = jep.getValue("tuple", classOf[PyCallable])
+    private val dictFn: PyCallable = jep.getValue("dict", classOf[PyCallable])
+    private val zipFn: PyCallable = jep.getValue("zip", classOf[PyCallable])
     private val dictToItemsListFn: PyCallable = jep.getValue("lambda x: list(x.items())", classOf[PyCallable])
     private val hasAttrFn: PyCallable = jep.getValue("hasattr", classOf[PyCallable])
+    private val strFn: PyCallable = jep.getValue("str", classOf[PyCallable])
 
     jep.exec(
       """def __polynote_qualified_type__(o):
@@ -499,8 +556,17 @@ object PythonInterpreter {
     def typeName(obj: PyObject): String = typeFn.callAs(classOf[PyObject], obj).getAttr("__name__", classOf[String])
     def qualifiedTypeName(obj: PyObject): String = qualifiedTypeFn.callAs(classOf[String], obj)
     def len(obj: PyObject): Int = lenFn.callAs(classOf[java.lang.Number], obj).intValue()
-    def list(obj: PyObject): PyObject = listFn.callAs(classOf[PyObject], obj)
+    def len64(obj: PyObject): Long = lenFn.callAs(classOf[java.lang.Number], obj).longValue()
+    def list(obj: AnyRef): PyObject = listFn.callAs(classOf[PyObject], unwrapArg(obj))
+    def tuple(obj: AnyRef): PyObject = tupleFn.callAs(classOf[PyObject], unwrapArg(obj))
     def dictToItemsList(obj: PyObject): PyObject = dictToItemsListFn.callAs(classOf[PyObject], obj)
+    def dictOf(kvs: (AnyRef, AnyRef)*): PyObject = {
+      val (ks, vs) = kvs.unzip
+      dict(zip(ks.map(unwrapArg).toArray, vs.map(unwrapArg).toArray))
+    }
+    def dict(obj: AnyRef): PyObject = dictFn.callAs(classOf[PyObject], unwrapArg(obj))
+    def zip(list1: AnyRef, list2: AnyRef): PyObject = zipFn.callAs(classOf[PyObject], unwrapArg(list1), unwrapArg(list2))
+    def str(obj: AnyRef): PyObject = strFn.callAs(classOf[PyObject], unwrapArg(obj))
     def hasAttr(obj: PyObject, name: String): Boolean = hasAttrFn.callAs(classOf[java.lang.Boolean], obj, name).booleanValue()
   }
 

--- a/polynote-kernel/src/test/scala/polynote/kernel/interpreter/python/PandasSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/interpreter/python/PandasSpec.scala
@@ -1,0 +1,133 @@
+package polynote.kernel.interpreter.python
+
+import org.scalatest.{FreeSpec, Matchers}
+import polynote.kernel.{ResultValue, ScalaCompiler}
+import polynote.kernel.interpreter.State
+import polynote.runtime.python.TypedPythonObject
+import polynote.runtime.{DoubleType, GroupAgg, IntType, LongType, StreamingDataRepr, StructField, StructType}
+import polynote.testing.InterpreterSpec
+import polynote.testing.kernel.MockEnv
+import shapeless.Witness
+
+class PandasSpec extends FreeSpec with Matchers with InterpreterSpec {
+  val interpreter: PythonInterpreter = PythonInterpreter(None).provide(ScalaCompiler.Provider.of(compiler)).runIO()
+  interpreter.init(State.Root).provideSomeM(MockEnv(-1)).runIO()
+
+  "Pandas interop" - {
+
+    "StreamingDataRepr of a pandas DataFrame" - {
+
+      "encodes data correctly" in {
+
+        val result = interp1(
+          """import pandas as pd
+            |pd.DataFrame([[1.1, 1], [2.2, 2], [3.3, 3]], columns=['floatcol', 'intcol'])
+            |""".stripMargin)
+
+        result.state.scope.head match {
+          case ResultValue(name, typeName, _, _, value: TypedPythonObject[Witness.`"DataFrame"`.T @unchecked], _, _) =>
+            name shouldEqual "Out"
+            typeName shouldEqual "TypedPythonObject[DataFrame]"
+            val reprs = TypedPythonObject.dataFrameReprs(value)
+
+            val Some(handle) = reprs.collectFirst {
+              case s: StreamingDataRepr =>
+                s.dataType shouldEqual StructType(List(
+                  StructField("floatcol", DoubleType),
+                  StructField("intcol", LongType)
+                ))
+
+                StreamingDataRepr.getHandle(s.handle)
+            }.flatten
+
+            val List(row1, row2, row3) = handle.iterator.toList.map {
+              buf =>
+                val d = buf.getDouble()
+                val i = buf.getLong()
+                buf.rewind()
+                (d, i)
+            }
+
+            row1 shouldEqual (1.1, 1)
+            row2 shouldEqual (2.2, 2)
+            row3 shouldEqual (3.3, 3)
+        }
+
+      }
+
+      "aggregates correctly" in {
+        val result = interp1(
+          """import pandas as pd
+            |pd.DataFrame([[1.0, 1], [2.0, 1], [3.0, 1], [2.0, 1], [2.0, 2], [4.0, 2]], columns=['floatcol', 'intcol'])
+            |""".stripMargin)
+
+        result.state.scope.head match {
+          case ResultValue(name, typeName, _, _, value: TypedPythonObject[Witness.`"DataFrame"`.T@unchecked], _, _) =>
+            name shouldEqual "Out"
+            typeName shouldEqual "TypedPythonObject[DataFrame]"
+            val reprs = TypedPythonObject.dataFrameReprs(value)
+
+            val Some(handle) = reprs.collectFirst {
+              case s: StreamingDataRepr =>
+                s.dataType shouldEqual StructType(
+                  List(
+                    StructField("floatcol", DoubleType),
+                    StructField("intcol", LongType)
+                  ))
+
+                StreamingDataRepr.getHandle(s.handle)
+            }.flatten
+
+            val handle2 = StreamingDataRepr.getHandle(
+              StreamingDataRepr.fromHandle(
+                handle.modify(
+                  List(
+                    GroupAgg(
+                      List("intcol"),
+                      List("floatcol" -> "quartiles", "floatcol" -> "mean", "floatcol" -> "count")
+                    )
+                  )).right.get
+              ).handle
+            ).get
+
+            handle2.dataType shouldEqual StructType(
+              List(
+                StructField("intcol", LongType),
+                StructField(
+                  "quartiles(floatcol)", StructType(
+                    List(
+                      StructField("min", DoubleType), StructField("q1", DoubleType), StructField("median", DoubleType),
+                      StructField("q3", DoubleType), StructField("max", DoubleType), StructField("mean", DoubleType))
+                  )),
+                StructField("mean(floatcol)", DoubleType),
+                StructField("count(floatcol)", DoubleType) // not sure why pandas count is double
+              ))
+
+            val List(row1, row2) = handle2.iterator.map {
+              buf =>
+                val struct = (buf.getLong(), (buf.getDouble(), buf.getDouble(), buf.getDouble(), buf.getDouble(), buf.getDouble(), buf.getDouble()), buf.getDouble(), buf.getDouble())
+                buf.rewind()
+                struct
+            }.toList
+
+            row1 shouldEqual (
+              1,
+              (1.0, 1.75, 2.0, 2.25, 3.0, 2.0),
+              2.0,
+              4.0
+            )
+
+            row2 shouldEqual (
+              2,
+              (2.0, 2.5, 3.0, 3.5, 4.0, 3.0),
+              3.0,
+              2.0
+            )
+        }
+      }
+
+    }
+
+  }
+
+}

--- a/polynote-runtime/src/main/scala/polynote/runtime/python/pandas/PandasHandle.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/python/pandas/PandasHandle.scala
@@ -98,6 +98,7 @@ class PandasHandle(val handle: Int, df: PythonObject) extends StreamingDataRepr.
             }
             override def numeric: Option[Numeric[PythonObject]] = None
           }
+        case _ => throw new IllegalStateException(s"Can't handle $dataType for pandas")
       }
   }
 
@@ -175,7 +176,7 @@ class PandasHandle(val handle: Int, df: PythonObject) extends StreamingDataRepr.
           tryEither {
             df.__getitem__(df.runner.listOf(cols: _*))
           }
-        case op => Left(new UnsupportedOperationException(s"$op not yet supported by pandas"))
+        case op => Left(new UnsupportedOperationException(s"$op not yet supported for pandas"))
       }
     }
   }.right.map {

--- a/polynote-runtime/src/main/scala/polynote/runtime/python/pandas/PandasHandle.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/python/pandas/PandasHandle.scala
@@ -1,0 +1,195 @@
+package polynote.runtime.python.pandas
+
+import java.io.DataOutput
+import java.nio.ByteBuffer
+
+import jep.python.{PyCallable, PyObject}
+import polynote.runtime._
+import polynote.runtime.python.{PythonObject, TypedPythonObject}
+import shapeless.Witness
+
+import scala.collection.immutable.ListMap
+import scala.reflect.ClassTag
+
+class PandasHandle(val handle: Int, df: PythonObject) extends StreamingDataRepr.Handle {
+
+  private def typeFor(pandasType: String): Option[DataType] = pandasType match {
+    case "int64" => Some(LongType)
+    case "int32" => Some(IntType)
+    case "int16" => Some(ShortType)
+    case "int8"  => Some(ByteType)
+    // TODO: we don't have unsigned integer types, but pandas does.
+    case "boolean" => Some(BoolType)
+    case "float64" => Some(DoubleType)
+    case "float32" => Some(FloatType)
+    case "string" | "category" => Some(StringType)
+    case _ => None
+  }
+
+  override lazy val dataType: StructType = {
+    val fields1 = df.runner.list(df.dtypes.items()).asScalaList.flatMap {
+      field => field.asTuple2 match {
+        case (field, dtype) =>
+          typeFor(dtype.name.as[String]).flatMap {
+            pandasType =>
+              df.runner.typeName(field) match {
+                case "tuple" =>
+                  val path = field.asScalaList.map(_.as[String]).filterNot(_.isEmpty)
+                  path match {
+                    case Nil => None
+                    case one :: Nil => Some((one, None, pandasType))
+                    case one :: more => Some((one, Some(more.head), pandasType))
+                  }
+                case _ =>
+                  Some((field.as[String], None, pandasType))
+              }
+          }.toList
+      }
+    }.foldLeft(ListMap.empty[String, Either[DataType, List[StructField]]]) {
+      case (accum, (field, Some(subfield), dtype)) =>
+        accum.getOrElse(field, Right(Nil)) match {
+          case Right(existingFields) => accum + (field -> Right((existingFields :+ StructField(subfield, dtype))))
+          case Left(_) => accum - field // the field is misbehaved - we think it's both a struct and not-a-struct. Discard it.
+        }
+      case (accum, (field, None, dtype)) =>
+        accum + (field -> Left(dtype))
+    }.toList.map {
+      case (field, Right(List(StructField("", dtype)))) => StructField(field, dtype) // in a multi-index, even scalars get turned into multilevel thingies
+      case (field, Right(structFields)) => StructField(field, StructType(structFields))
+      case (field, Left(dtype)) => StructField(field, dtype)
+    }
+
+    StructType(fields1)
+  }
+
+  private def fieldEncoder(field: StructField): DataEncoder[PythonObject] = field match {
+    case StructField(name, dataType) =>
+      def fe[A >: Null : ClassTag, R](enc: DataEncoder[R], from: A => R): DataEncoder[PythonObject] =
+        enc.contramap[PythonObject] {
+          obj =>
+            val pyValue = obj.__getitem__(name)
+            // sigh... turns out simple things like float64 are actually numpy boxed things. Need to call item() to unbox them so jep can convert
+            val a = if (df.runner.hasAttribute(pyValue, "item"))
+              pyValue.item().as[A]
+            else
+              pyValue.as[A]
+            from(a)
+        }
+
+      dataType match {
+        case LongType => fe[java.lang.Number, Long](DataEncoder.long, _.longValue())
+        case IntType  => fe[java.lang.Number, Int](DataEncoder.int, _.intValue())
+        case ShortType => fe[java.lang.Number, Short](DataEncoder.short, _.shortValue())
+        case ByteType  => fe[java.lang.Number, Byte](DataEncoder.byte, _.byteValue())
+        case BoolType => fe[java.lang.Boolean, Boolean](DataEncoder.boolean, _.booleanValue())
+        case DoubleType => fe[java.lang.Double, Double](DataEncoder.double, _.doubleValue())
+        case StringType => fe[String, String](DataEncoder.string, identity)
+        case st@StructType(fields) =>
+          val fieldEncoders = fields.map(fieldEncoder).toArray
+          new DataEncoder[PythonObject] {
+            override def encode(dataOutput: DataOutput, value: PythonObject): Unit = {
+              val struct = value.__getitem__(name)
+              fieldEncoders.foreach(_.encode(dataOutput, struct))
+            }
+            override def dataType: DataType = st
+            override def sizeOf(t: PythonObject): Int = {
+              val struct = t.__getitem__(name)
+              fieldEncoders.map(_.sizeOf(struct)).sum
+            }
+            override def numeric: Option[Numeric[PythonObject]] = None
+          }
+      }
+  }
+
+  private lazy val encoder: DataEncoder[PythonObject] = {
+    val fieldEncoders: Array[DataEncoder[PythonObject]] = dataType.fields.map(fieldEncoder).toArray
+
+    new DataEncoder[PythonObject] {
+      override def encode(dataOutput: DataOutput, row: PythonObject): Unit = fieldEncoders.foreach(_.encode(dataOutput, row))
+      override lazy val dataType: DataType = PandasHandle.this.dataType
+      override def sizeOf(row: PythonObject): Int = fieldEncoders.map(_.sizeOf(row)).sum
+      override def numeric: Option[Numeric[PythonObject]] = None
+    }
+  }
+
+  private lazy val size: Long = df.runner.len64(df)
+
+  override lazy val knownSize: Option[Int] = Some(size).filter(_ <= Int.MaxValue.toLong).map(_.toInt)
+
+  override def iterator: Iterator[ByteBuffer] = new PyGeneratorIterator(df.iterrows(), size).map {
+    row => DataEncoder.writeSized(row.__getitem__(1))(encoder)  // iterrows gives tuples of row_index, row
+  }
+
+  @inline private def tryEither[T](thunk: => T): Either[Throwable, T] = try Right(thunk) catch {
+    case err: Throwable => Left(err)
+  }
+
+  private def mkAggs(col: String, aggs: List[String]) = {
+    def namedLambda(code: String, name: String) = df.runner.runJep {
+      j =>
+        val obj = j.getValue(code, classOf[PyObject])
+        obj.setAttr("__name__", name)
+        obj
+    }
+
+    col -> aggs.flatMap {
+      case "quartiles" => List(
+        namedLambda("lambda x: x.min()", s"quartiles($col).min"),
+        namedLambda("lambda x: x.quantile(0.25)", s"quartiles($col).q1"),
+        namedLambda("lambda x: x.quantile(0.5)", s"quartiles($col).median"),
+        namedLambda("lambda x: x.quantile(0.75)", s"quartiles($col).q3"),
+        namedLambda("lambda x: x.max()", s"quartiles($col).max"),
+        namedLambda("lambda x: x.mean()", s"quartiles($col).mean")
+      )
+      case agg => List(namedLambda(s"lambda x: x.$agg()", s"$agg($col)"))
+    }
+  }
+
+  override def modify(ops: List[TableOp]): Either[Throwable, Int => StreamingDataRepr.Handle] = ops.foldLeft(tryEither(df)) {
+    (dfOrErr, op) => dfOrErr.right.flatMap {
+      df => op match {
+        case GroupAgg(cols, aggs) =>
+          tryEither {
+            val pandasAggs = aggs.groupBy(_._1).mapValues(_.map(_._2)).map((mkAggs _).tupled).mapValues(aggs => df.runner.listOf(aggs: _*))
+            val next = df.groupby(df.runner.listOf(cols: _*), as_index = false)
+              .agg(df.runner.dictOf(pandasAggs.toSeq: _*))
+
+            val aggCols = next.columns.asScalaList
+            val (l1, l2) = aggCols.map {
+              col =>
+                col.asTuple2Of[String, String] match {
+                  case t@(_, "") => t
+                  case (_, agg) => agg.split('.').toList match {
+                    case Nil => throw new IllegalStateException()
+                    case List(one) => (one, "")
+                    case one :: more => (one, more.head)
+                  }
+                }
+            }.unzip
+
+            val index = df.runner.runJep(j => j.getValue("__polynote_mkindex__", classOf[PyCallable]).callAs(classOf[PyObject], l1.toArray, l2.toArray))
+            next.updateDynamic("columns")(index)
+            next
+          }
+        case Select(cols) =>
+          tryEither {
+            df.__getitem__(df.runner.listOf(cols: _*))
+          }
+        case op => Left(new UnsupportedOperationException(s"$op not yet supported by pandas"))
+      }
+    }
+  }.right.map {
+    df => new PandasHandle(_, df)
+  }
+}
+
+class PyGeneratorIterator(obj: PythonObject, count: Long) extends Iterator[PythonObject] {
+  @volatile private var consumed = 0
+
+  override def hasNext: Boolean = consumed < count
+
+  override def next(): PythonObject = {
+    consumed += 1
+    obj.__next__()
+  }
+}

--- a/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
@@ -8,7 +8,7 @@ import jep.Jep
 import jep.python.{PyCallable, PyObject}
 import org.apache.commons.lang3.RandomStringUtils
 import org.apache.spark.launcher.SparkLauncher
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
 import polynote.kernel.{BaseEnv, GlobalEnv, InterpreterEnv, ScalaCompiler, TaskManager}
 import polynote.kernel.environment.{Config, CurrentNotebook, CurrentRuntime, CurrentTask}
 import polynote.kernel.interpreter.{Interpreter, State}
@@ -22,7 +22,7 @@ import zio.internal.Executor
 import scala.util.Properties
 
 class PySparkInterpreter(
-  compiler: ScalaCompiler,
+  _compiler: ScalaCompiler,
   jepInstance: Jep,
   jepExecutor: Executor,
   jepThread: AtomicReference[Thread],
@@ -30,9 +30,11 @@ class PySparkInterpreter(
   runtime: Runtime[Any],
   pyApi: PythonInterpreter.PythonAPI,
   venvPath: Option[Path]
-) extends PythonInterpreter(compiler, jepInstance, jepExecutor, jepThread, jepBlockingService, runtime, pyApi, venvPath) {
+) extends PythonInterpreter(_compiler, jepInstance, jepExecutor, jepThread, jepBlockingService, runtime, pyApi, venvPath) {
 
   val gatewayRef = new AtomicReference[GatewayServer]()
+
+  private val dataFrameType = compiler.global.ask(() => compiler.global.typeOf[Dataset[Row]])
 
   override protected def injectGlobals(globals: PyObject): RIO[CurrentRuntime, Unit] = super.injectGlobals(globals) *> jep {
       jep =>
@@ -208,6 +210,22 @@ class PySparkInterpreter(
           |sqlContext = spark._wrapped
           |from pyspark.sql import DataFrame
           |""".stripMargin)
+  }
+
+  override protected def convertToPython(jep: Jep): PartialFunction[(String, Any), AnyRef] = super.convertToPython(jep) orElse {
+    case (name, dataFrame: Dataset[_]) =>
+        // should this go through py4j instead? We could use gateway.getGateway.putObject, but how to retrieve it on python side?
+        // will just pass directly to the DataFrame constructor
+      val pyDf = gatewayRef.get().getGateway.putObject(name, dataFrame)
+      jep.getValue("DataFrame", classOf[PyCallable]).callAs(classOf[PyObject], jep.getValue("gateway.java_gateway_server.getGateway().getObject", classOf[PyCallable]).callAs(classOf[PyObject], name), jep.getValue("sqlContext", classOf[PyObject]))
+  }
+
+  override protected def convertFromPython(jep: Jep): PartialFunction[(String, PyObject), (compiler.global.Type, Any)] = super.convertFromPython(jep) orElse {
+    case ("DataFrame", obj) if jep.getValue("hasattr", classOf[PyCallable]).callAs(classOf[java.lang.Boolean], obj, "_jdf").booleanValue() =>
+      // it's a Spark DataFrame
+      jep.getValue("gateway.java_gateway_server.getGateway().putObject", classOf[PyCallable]).call("_jdf", obj.getAttr("_jdf", classOf[PyObject]))
+      val df = gatewayRef.get().getGateway().getObject("_jdf").asInstanceOf[Dataset[Row]]
+      (dataFrameType, df)
   }
 
   override protected def errorCause(get: PyCallable): Option[Throwable] = {


### PR DESCRIPTION
- Automatically convert DataFrames to pyspark DataFrames on their way into the globals dict (no more `DataFrame(df, sqlContext)` needed, and they are marshalled with py4j instead of jep so they behave correctly!)
- Automatically convert pyspark DataFrames back to Scala DataFrames on their way into the result scope (they won't be `TypedPythonObject`s anymore!)
- Add streaming ops for Pandas DataFrames (I'm sure it's not perfect, but it's a start...)