### PR TITLE
[WIP] [#779] Don't prune references in type parameters

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/ScalaCompiler.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/ScalaCompiler.scala
@@ -483,6 +483,16 @@ class ScalaCompiler private (
           // type trees don't get traversed in a useful way by default; traverse its original tree if it has one
           tree match {
             case tree@TypeTree() if tree.original != null => super.traverse(tree.original)
+            case tree@TypeTree() =>
+              // HACKY: check types in type args and search symbol chains to see whether they originate in previous cells.
+              val typeChains = tree.tpe.typeArgs.flatMap(_.prefixChain)
+              typeChains.foreach {
+                tpe =>
+                  val name = tpe.termSymbol.name
+                  if (inputCellSymbolNames.contains(name)) {
+                    used.add(name)
+                  }
+              }
             case _ =>
           }
 

--- a/polynote-kernel/src/test/scala/polynote/kernel/interpreter/scal/ScalaInterpreterSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/interpreter/scal/ScalaInterpreterSpec.scala
@@ -77,16 +77,16 @@ class ScalaInterpreterSpec extends FreeSpec with Matchers with InterpreterSpec {
         res3 <- interp("object Bar { class Baz }")
         res4 <- interp("val bazCls = classOf[Bar.Baz]")
 //        res5 <- interp("val bar = Bar")
-//        res6 <- interp("val bar2 = bar; val barBazCls = classOf[bar.Baz]")
-      } yield (res2, res4/*, res6*/)
+//        res6 <- interp("val barBazCls = classOf[bar.Baz]")
+      } yield (res2, res4 /* , res6 */)
 
       val (finalState, res) = test.run(cellState).runIO()
 
-      (res._1.state.values ++ res._2.state.values /* ++ res._3.state.value */) match {
+      (res._1.state.values ++ res._2.state.values /* ++ res._3.state.values */) match {
         case ValueMap(values) =>
           values("fooCls").toString.contains("$Foo") shouldBe true
           values("bazCls").toString.contains("$Bar$Baz") shouldBe true
-//          values("barBazCls").toString shouldEqual "class notebook.Cell1$2$Foo"
+//          values("barBazCls").toString.contains("$Bar$Baz") shouldBe true
       }
     }
   }

--- a/polynote-kernel/src/test/scala/polynote/kernel/interpreter/scal/ScalaInterpreterSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/interpreter/scal/ScalaInterpreterSpec.scala
@@ -57,16 +57,37 @@ class ScalaInterpreterSpec extends FreeSpec with Matchers with InterpreterSpec {
     }
   }
 
-  "bring values from previous cells" in {
-    val test = for {
-      res1 <- interp("val foo = 22")
-      res2 <- interp("val bar = foo + 10")
-    } yield (res1, res2)
+  "bring values from previous cells" - {
+    "when referenced directly" in {
+      val test = for {
+        res1 <- interp("val foo = 22")
+        res2 <- interp("val bar = foo + 10")
+      } yield (res1, res2)
 
-    val (finalState, (res1, res2)) = test.run(cellState).runIO()
+      val (finalState, (res1, res2)) = test.run(cellState).runIO()
 
-    res2.state.values match {
-      case ValueMap(values) => values("bar") shouldEqual 32
+      res2.state.values match {
+        case ValueMap(values) => values("bar") shouldEqual 32
+      }
+    }
+    "when referenced by type only" in {
+      val test = for {
+        res1 <- interp("class Foo")
+        res2 <- interp("val fooCls = classOf[Foo]")
+        res3 <- interp("object Bar { class Baz }")
+        res4 <- interp("val bazCls = classOf[Bar.Baz]")
+//        res5 <- interp("val bar = Bar")
+//        res6 <- interp("val bar2 = bar; val barBazCls = classOf[bar.Baz]")
+      } yield (res2, res4/*, res6*/)
+
+      val (finalState, res) = test.run(cellState).runIO()
+
+      (res._1.state.values ++ res._2.state.values /* ++ res._3.state.value */) match {
+        case ValueMap(values) =>
+          values("fooCls").toString shouldEqual "class notebook.Cell1$2$Foo"
+          values("bazCls").toString shouldEqual "class notebook.Cell3$2$Bar$Baz"
+//          values("barBazCls").toString shouldEqual "class notebook.Cell1$2$Foo"
+      }
     }
   }
 

--- a/polynote-kernel/src/test/scala/polynote/kernel/interpreter/scal/ScalaInterpreterSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/interpreter/scal/ScalaInterpreterSpec.scala
@@ -84,8 +84,8 @@ class ScalaInterpreterSpec extends FreeSpec with Matchers with InterpreterSpec {
 
       (res._1.state.values ++ res._2.state.values /* ++ res._3.state.value */) match {
         case ValueMap(values) =>
-          values("fooCls").toString shouldEqual "class notebook.Cell1$2$Foo"
-          values("bazCls").toString shouldEqual "class notebook.Cell3$2$Bar$Baz"
+          values("fooCls").toString.contains("$Foo") shouldBe true
+          values("bazCls").toString.contains("$Bar$Baz") shouldBe true
 //          values("barBazCls").toString shouldEqual "class notebook.Cell1$2$Foo"
       }
     }


### PR DESCRIPTION
Resolves #779 

Make sure to check type parameters for references when pruning.

TODO:
- [ ] Doesn't work for the following case:

  Cell1:
  ```
  object Bar { class Baz }
  ```

  Cell2:
  ```
  val bar = Bar
  ```

  Cell3:
  ```
  val bazCls = classOf[bar.Baz]
  ```