### PR TITLE
Add run to cursor hotkey

### DIFF
--- a/polynote-frontend/polynote/ui/component/cell.ts
+++ b/polynote-frontend/polynote/ui/component/cell.ts
@@ -353,6 +353,10 @@ export class CodeCell extends Cell {
         [monaco.KeyMod.Shift | monaco.KeyCode.F10,
             new KeyAction((pos, range, selection, cell) => CurrentNotebook.get.runAllCells())
                 .withDesc("Run all cells.")],
+        // run to cursor
+        [monaco.KeyMod.CtrlCmd | monaco.KeyMod.Alt | monaco.KeyCode.F9,
+            new KeyAction((pos, range, selection, cell) => CurrentNotebook.get.runToCursor())
+                .withDesc("Run to cursor.")],
         // run cell on enter
         [monaco.KeyMod.Shift | monaco.KeyCode.Enter,
             new KeyAction((pos, range, selection, cell) => CurrentNotebook.get.runCells(cell.id))


### PR DESCRIPTION
### What is this PR?
Add run to cursor hotkey

### Related issue
https://github.com/polynote/polynote/issues/413

### Describe
key bindings
`ctrl + alt + F9` (like intellij)


