### PR TITLE
Some Repr ergonomics

### DIFF
--- a/polynote-frontend/polynote/data/result.ts
+++ b/polynote-frontend/polynote/data/result.ts
@@ -260,61 +260,35 @@ export class ResultValue extends Result {
         index = this.reprs.findIndex(repr => repr instanceof StreamingDataRepr);
         if (index >= 0) {
             const repr = this.reprs[index] as StreamingDataRepr;
-            if (repr.dataType instanceof StructType) {
-                // surprisingly using monaco.editor.colorizeElement breaks the theme of the whole app! WAT?
-                return monaco.editor.colorize(this.typeName, "scala", {}).then(typeHTML => {
-                    const streamingRepr = this.reprs[index] as StreamingDataRepr;
-                    const frag = document.createDocumentFragment();
-                    const resultType = span(['result-type'], []).attr("data-lang" as any, "scala");
-                    resultType.innerHTML = typeHTML;
-                    // Why do they put a <br> in there?
-                    [...resultType.getElementsByTagName("br")].forEach(br => {
-                        if (br && br.parentNode) br.parentNode.removeChild(br)
-                    });
-                    const el = div([], [
-                        h4(['result-name-and-type'], [
-                            span(['result-name'], [this.name]), ': ', resultType,
-                            iconButton(['view-data'], 'View data', 'table', '[View]')
-                                .click(_ => valueInspector.inspect(this, cell.notebook, 'View data')),
-                            iconButton(['plot-data'], 'Plot data', 'chart-bar', '[Plot]')
+            // surprisingly using monaco.editor.colorizeElement breaks the theme of the whole app! WAT?
+            return monaco.editor.colorize(this.typeName, cell.language, {}).then(typeHTML => {
+                const streamingRepr = this.reprs[index] as StreamingDataRepr;
+                const frag = document.createDocumentFragment();
+                const resultType = span(['result-type'], []).attr("data-lang" as any, "scala");
+                resultType.innerHTML = typeHTML;
+                // Why do they put a <br> in there?
+                [...resultType.getElementsByTagName("br")].forEach(br => {
+                    if (br && br.parentNode) br.parentNode.removeChild(br)
+                });
+
+                const el = div([], [
+                    h4(['result-name-and-type'], [
+                        span(['result-name'], [this.name]), ': ', resultType,
+                        iconButton(['view-data'], 'View data', 'table', '[View]')
+                            .click(_ => valueInspector.inspect(this, cell.notebook, 'View data')),
+                        repr.dataType instanceof StructType
+                            ? iconButton(['plot-data'], 'Plot data', 'chart-bar', '[Plot]')
                                 .click(_ => {
                                     valueInspector.setParent(cell);
                                     valueInspector.inspect(this, cell.notebook, 'Plot data');
                                 })
-                        ]),
-                        displaySchema(streamingRepr.dataType)
-                    ]);
-                    frag.appendChild(el);
-                    return ["text/html", frag];
-                })
-            } else if (repr.knownSize && repr.knownSize > 0 && repr.knownSize < 1000) {
-                return monaco.editor.colorize(this.typeName, cell.language, {}).then(typeHTML => {
-                    const dataRepr = this.reprs[index] as StreamingDataRepr;
-                    const frag = document.createDocumentFragment();
-                    const resultType = span(['result-type'], []).attr("data-lang" as any, "scala");
-                    resultType.innerHTML = typeHTML;
-                    let resultData = span([], 'Awaiting result...');
-                    const fragContents = div([], [
-                        h4(['result-name-and-type'], [span(['result-name'], [this.name]), ': ', resultType]),
-                        resultData
-                    ]);
-                    frag.appendChild(fragContents);
-
-                    const stream = new DataStream(SocketSession.fromRelativeURL(`ws/${cell.path}`), repr);
-                    const data: any[] = [];
-                    stream
-                        .to(batch => {
-                            data.push(...batch);
-                            const newResults = displayData(data, undefined, 1);
-                            fragContents.replaceChild(newResults, resultData);
-                            resultData = newResults;
-                        })
-                        .run()
-                        .catch(reason => console.log("Error streaming results", reason));
-
-                    return ["text/html", frag];
-                })
-            }
+                            : undefined
+                    ]),
+                    repr.dataType instanceof StructType ? displaySchema(streamingRepr.dataType) : undefined
+                ]);
+                frag.appendChild(el);
+                return ["text/html", frag];
+            })
         }
 
         index = this.reprs.findIndex(repr => repr instanceof DataRepr);

--- a/polynote-frontend/polynote/interpreter/vega_interpreter.js
+++ b/polynote-frontend/polynote/interpreter/vega_interpreter.js
@@ -109,7 +109,7 @@ export class VegaClientResult extends ClientResult {
         return plot.view.toCanvas()
             .then(canvas => canvas.toDataURL("image/png"))
             .then(fromDataURL)
-            .catch(_ => plot.toSVG().then(svgStr => new Output("image/svg", svgStr)))
+            .catch(_ => plot.toSVG().then(svgStr => new Output("image/svg+xml", svgStr)))
     }
 
     toOutput() {

--- a/polynote-frontend/polynote/ui/component/cell.ts
+++ b/polynote-frontend/polynote/ui/component/cell.ts
@@ -814,8 +814,7 @@ export class CodeCell extends Cell {
                     inspectIcon = [
                         iconButton(['inspect'], 'Inspect', 'search', 'Inspect').click(
                             evt => {
-                                ValueInspector.get().setParent(this);
-                                ValueInspector.get().inspect(result, this.notebook)
+                                ValueInspector.get().setParent(this).inspect(result, this.notebook)
                             }
                         )
                     ]
@@ -825,7 +824,7 @@ export class CodeCell extends Cell {
                 this.cellResultMargin.innerHTML = '';
                 this.cellResultMargin.appendChild(outLabel);
 
-                result.displayRepr(this, ValueInspector.get()).then(display => {
+                result.displayRepr(this, ValueInspector.get().setParent(this)).then(display => {
                     const [mime, content] = display;
                     const [mimeType, args] = parseContentType(mime);
                     this.buildOutput(mime, args, content).then((el: MIMEElement) => {

--- a/polynote-frontend/polynote/ui/component/display_content.ts
+++ b/polynote-frontend/polynote/ui/component/display_content.ts
@@ -55,6 +55,7 @@ export function contentTypeName(contentType: string) {
         case "text/plain": return "Text";
         case "text/html": return "HTML";
         case "image/svg": return "SVG";
+        case "image/svg+xml": return "SVG";
         default:
             if (mime.startsWith("image/")) return "Image";
             return mime;

--- a/polynote-frontend/polynote/ui/component/symbol_table.ts
+++ b/polynote-frontend/polynote/ui/component/symbol_table.ts
@@ -52,8 +52,7 @@ export class KernelSymbolsUI extends UIMessageTarget {
             type: span([], [resultValue.typeName]).attr('title', resultValue.typeName)
         }, whichBody) as ResultRow;
         tr.onclick = (evt) => {
-            ValueInspector.get().setParent(this);
-            ValueInspector.get().inspect(tr.resultValue, this.notebook);
+            ValueInspector.get().setParent(this).inspect(tr.resultValue, this.notebook);
         };
         tr.data = {name: resultValue.name, type: resultValue.typeName};
         tr.resultValue = resultValue;

--- a/polynote-frontend/polynote/ui/component/table_view.ts
+++ b/polynote-frontend/polynote/ui/component/table_view.ts
@@ -32,9 +32,9 @@ export class TableView {
 
     constructor(readonly repr: StreamingDataRepr, readonly notebook: NotebookUI) {
         const dataType = repr.dataType;
-        this.fields = dataType.fields;
-        const fieldClasses = dataType.fields.map(field => field.name);
-        const fieldNames = dataType.fields.map(field => `${field.name}: ${field.dataType.typeName()}`);
+        this.fields = dataType.fields || [new StructField("entries", dataType)]; // if dataType is not a StructType, create a dummy entry for it.
+        const fieldClasses = this.fields.map(field => field.name);
+        const fieldNames = this.fields.map(field => `${field.name}: ${field.dataType.typeName()}`);
 
         if (!notebook.socket.isOpen) {
             this.el = div(['table-view', 'disconnected'], [
@@ -80,7 +80,7 @@ export class TableView {
         start = Math.max(start, 0);
         this.table.tBodies.item(0)!.innerHTML = '';
         for (let i = start; i < end && i < this.rows.length; i++) {
-            const row = this.fields.map(field => renderData(field.dataType, this.rows[i][field.name]));
+            const row = this.fields.map(field => renderData(field.dataType, this.rows[i][field.name] || this.rows[i]));
             this.table.addRow(row);
         }
         this.currentPos = start;

--- a/polynote-frontend/polynote/ui/component/value_inspector.ts
+++ b/polynote-frontend/polynote/ui/component/value_inspector.ts
@@ -52,14 +52,14 @@ export class ValueInspector extends FullScreenModal {
                     })
                     .when(StreamingDataRepr, (handle, dataType, knownSize) => {
                         const repr = new StreamingDataRepr(handle, dataType, knownSize);
-                        if (dataType instanceof StructType) {
-                            tabs['Schema'] = displaySchema(dataType);
-                            try {
+                        try {
+                            if (dataType instanceof StructType) {
+                                tabs['Schema'] = displaySchema(dataType);
                                 tabs['Plot data'] = new PlotEditor(repr, notebook, resultValue.name, resultValue.sourceCell, () => this.hide()).container;
-                                tabs['View data'] = new TableView(repr, notebook).el;
-                            } catch(err) {
-                                console.log(err);
                             }
+                            tabs['View data'] = new TableView(repr, notebook).el;
+                        } catch(err) {
+                            console.log(err);
                         }
                     });
                 return tabs;


### PR DESCRIPTION
Minor fixes to how we display data in Polynote:

* Change precedence rules to favor `*DataReprs`, images, LaTeX, HTML over plaintext reprs
* Show Table paging view for `StreamingDataReprs` of non-struct data. 
* Also address #767 by adding support for the following standard IPython display methods: 
  * `_repr_svg_`
  * `_repr_jpeg_`
  * `_repr_png_`
  * `_repr_mimebundle_`

![Screen Shot 2020-03-04 at 4 42 47 PM](https://user-images.githubusercontent.com/5430417/75936601-79544700-5e37-11ea-9d09-8b30cb6425d9.png)
