### PR TITLE
restrict autocomplete fuzzy match filter text

### DIFF
--- a/polynote-frontend/polynote/ui/component/notebook.ts
+++ b/polynote-frontend/polynote/ui/component/notebook.ts
@@ -706,6 +706,7 @@ export class NotebookUI extends UIMessageTarget {
                     kind: isMethod ? 1 : 9,
                     label: label,
                     insertText: insertText,
+                    filterText: insertText,
                     insertTextRules: 4,
                     sortText: ("" + index).padStart(indexStrLen, '0'),
                     detail: candidate.type,


### PR DESCRIPTION
#769 was caused by the autocomplete filtering being done on the entirety of the autocomplete result, including type parameters. 

This meant that, for example, the word `else:` was matching the completion `eval(source: , globals: , locals: )` because the `:`, etc., was matching the type parameter. We just needed to set the `filterText` to be the same as the `insertText` (in this case, it would be `eval`) and thus the completion started making a lot more sense. 

This should also improve the quality of our completions in general since there won't be as many superfluous matches. 😄 