### PR TITLE
Update to jedi 0.16.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 polynote*
+tmp
+target/scala-2.11/polynote/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Build
       run: |
         echo "Setting up Python dependencies"
-        pip install virtualenv ipython nbconvert jedi numpy scipy pandas jep==3.9.0
+        pip install -r ./requirements.txt
         jep_site_packages_path=`pip show jep | grep "^Location:" | cut -d ':' -f 2 | cut -d ' ' -f 2`
         jep_path=${jep_site_packages_path}/jep
         jep_lib_path=`realpath ${jep_site_packages_path}/../../`

--- a/build.sbt
+++ b/build.sbt
@@ -236,6 +236,7 @@ lazy val polynote = project.in(file(".")).aggregate(`polynote-env`, `polynote-ru
 
         val files = jars ++ examples ++ List(
           (file(".") / "config-template.yml") -> "polynote/config-template.yml",
+          (file(".") / "requirements.txt") -> "polynote/requirements.txt",
           (file(".") / "scripts" / "plugin") -> "polynote/plugin",
           (file(".") / "scripts" / "polynote.py") -> "polynote/polynote.py")
 

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -7,14 +7,15 @@ ARG DIST_TAR="polynote-dist.tar.gz"
 WORKDIR /opt
 
 RUN apt update -y && \
-    apt install -y wget python3 python3-dev python3-pip build-essential && \
-    pip3 install jep jedi virtualenv
+    apt install -y wget python3 python3-dev python3-pip build-essential
 
 RUN if test "${SCALA_VERSION}" = "2.12"; then export DIST_TAR="polynote-dist-2.12.tar.gz"; fi && \
     wget -q https://github.com/polynote/polynote/releases/download/$POLYNOTE_VERSION/$DIST_TAR && \
     tar xfzp $DIST_TAR && \
     echo "DIST_TAR=$DIST_TAR" && \
     rm $DIST_TAR
+
+RUN pip3 install -r ./polynote/requirements.txt
 
 # to wrap up, we create (safe)user
 ENV UID 1000

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -5,8 +5,7 @@ ARG SCALA_VERSION="2.11"
 WORKDIR /opt
 
 RUN apt update -y && \
-    apt install -y wget python3 python3-dev python3-pip build-essential && \
-    pip3 install jep jedi virtualenv
+    apt install -y wget python3 python3-dev python3-pip build-essential
 
 COPY docker/spark-2.4/install_spark.sh .
 RUN ./install_spark.sh
@@ -25,6 +24,8 @@ ENV PATH="$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin"
 COPY target/scala-$SCALA_VERSION/polynote-dist*.tar.gz .
 RUN tar xfzp polynote-dist*.tar.gz && \
     rm polynote-dist*.tar.gz
+
+RUN pip3 install -r ./polynote/requirements.txt
 
 # to wrap up, we create (safe)user
 ENV UID 1000

--- a/docs/01-installation.md
+++ b/docs/01-installation.md
@@ -61,13 +61,11 @@ cd polynote
   [Python's installation instructions](https://wiki.python.org/moin/BeginnersGuide/Download){:target="_blank"} for
   instructions on installing these packages.
   
-  You'll also need to install some Python dependencies `jep`, `jedi`, `virtualenv`:
+  You'll also need to install Polynote's Python dependencies:
   
   ```
-  pip3 install jep jedi virtualenv
+  pip3 install -r ./requirements.txt
   ``` 
-  
-  Additionally, you will probably want to install `numpy` and `pandas`. 
   
 
 ## Configure

--- a/polynote-frontend/polynote/ui/component/ui.ts
+++ b/polynote-frontend/polynote/ui/component/ui.ts
@@ -406,7 +406,7 @@ monaco.languages.registerCompletionItemProvider('scala', {
 });
 
 monaco.languages.registerCompletionItemProvider('python', {
-  triggerCharacters: ['.'],
+  triggerCharacters: ['.', "["],
   provideCompletionItems: (doc, pos, cancelToken, context) => {
       return (doc as CodeCellModel).cellInstance.requestCompletion(doc.getOffsetAt(pos));
   }

--- a/polynote-kernel/src/main/scala/polynote/messages/package.scala
+++ b/polynote-kernel/src/main/scala/polynote/messages/package.scala
@@ -37,6 +37,8 @@ package object messages {
   implicit def truncateShortString(str: String): ShortString = ShortString(
     if (str.length > Short.MaxValue) str.substring(0, Short.MaxValue) else str)
 
+  implicit def optionShortString(o: Option[String]): Option[ShortString] = o.map(ShortString)
+
   implicit val shortStringCodec: Codec[ShortString] =
     variableSizeBytes(uint16, string(StandardCharsets.UTF_8)).xmap(ShortString, x => x)
 

--- a/polynote-kernel/src/test/scala/polynote/kernel/interpreter/python/PythonInterpreterSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/interpreter/python/PythonInterpreterSpec.scala
@@ -1,7 +1,7 @@
 package polynote.kernel.interpreter.python
 
 import org.scalatest.{FreeSpec, Matchers}
-import polynote.kernel.{CompileErrors, Completion, CompletionType, KernelReport, Output, Pos, Result, ScalaCompiler}
+import polynote.kernel.{CompileErrors, Completion, CompletionType, KernelReport, Output, ParameterHint, ParameterHints, Pos, Result, ScalaCompiler, Signatures}
 import polynote.kernel.interpreter.State
 import polynote.messages.TinyList
 import polynote.runtime.MIMERepr
@@ -248,7 +248,16 @@ class PythonInterpreterSpec extends FreeSpec with Matchers with InterpreterSpec 
 
     "completions" in {
       val completions = interpreter.completionsAt("dela", 4, State.id(1)).runIO()
-      completions shouldEqual List(Completion("delattr", Nil, TinyList(List(TinyList(List(("o", ""), ("name", ""))))), "", CompletionType.Method))
+      completions shouldEqual List(Completion("delattr", Nil, TinyList(List(TinyList(List(("o", ""), ("name", "str"))))), "", CompletionType.Method))
+      val keywordCompletion = interpreter.completionsAt("d={'foo': 'bar'}; d['']", 21, State.id(1)).runIO()
+      keywordCompletion shouldEqual List(Completion("'foo", Nil, Nil, "", CompletionType.Unknown, None))
+    }
+
+    "parameters" in {
+      val params = interpreter.parametersAt("delattr(", 8, State.id(1)).runIO()
+      params shouldEqual Option(Signatures(List(
+        ParameterHints("delattr(o, name: str)", Option("Deletes the named attribute from the given object."),
+          List(ParameterHint("o", "", None), ParameterHint("name", "str", None)))),0,0))
     }
   }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+virtualenv
+ipython
+nbconvert
+jedi>=0.16.0
+numpy
+pandas
+jep==3.9.0


### PR DESCRIPTION
* Update jedi to 0.16.0 for all sorts of goodies
  * better tensorflow, numpy, pandas completions
  * better type inference for params
  * key completions for dictionaries
  * and more, see
  https://github.com/davidhalter/jedi/blob/master/CHANGELOG.rst#0160-2020-01-26
* use requirements.txt file for our python dependencies