### PR TITLE
Fix numeric format issue in SparkConfig properties

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/config/package.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/package.scala
@@ -139,7 +139,7 @@ package object config {
         n =>
           n.toLong
             .map(_.toString).orElse(n.toBigDecimal.map(_.toString()))
-            .fold(Left("Only values"): Either[String, (String, String)])(v => Right(key -> v)),
+            .fold(Left("No invalid numeric values allowed in this map"): Either[String, (String, String)])(v => Right(key -> v)),
         s => Right(key -> s),
         _ => Left("No array values allowed in this map"),
         _ => Left("No object values allowed in this map")

--- a/polynote-kernel/src/main/scala/polynote/config/package.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/package.scala
@@ -131,14 +131,15 @@ package object config {
 
   def deriveConfigDecoder[A](implicit decoder: Lazy[ValidatedConfigDecoder[A]]): Decoder[A] = decoder.value
 
-  case class Test(first: Int = 10, second: String = "hi")
-
   implicit val mapStringStringDecoder: Decoder[Map[String, String]] = Decoder[Map[String, Json]].emap {
     jsonMap => jsonMap.toList.map {
       case (key, json) => json.fold(
         Left("No null values allowed in this map"),
         b => Right(key -> b.toString),
-        n => Right(key -> n.toString),
+        n =>
+          n.toLong
+            .map(_.toString).orElse(n.toBigDecimal.map(_.toString()))
+            .fold(Left("Only values"): Either[String, (String, String)])(v => Right(key -> v)),
         s => Right(key -> s),
         _ => Left("No array values allowed in this map"),
         _ => Left("No object values allowed in this map")

--- a/polynote-kernel/src/test/scala/polynote/config/PolynoteConfigSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/config/PolynoteConfigSpec.scala
@@ -179,4 +179,24 @@ class PolynoteConfigSpec extends FlatSpec with Matchers with EitherValues {
     val defaultConfig = PolynoteConfig()
     parsed shouldEqual Right(defaultConfig)
   }
+
+  it should "parse spark config int values properly" in {
+    val yamlStr =
+      """
+        |spark:
+        |  spark.executor.instances: 10
+        |""".stripMargin
+    val parsed = PolynoteConfig.parse(yamlStr)
+    parsed.right.value.spark.get.properties("spark.executor.instances") shouldEqual "10"
+  }
+
+  it should "parse spark config decimal values properly" in {
+    val yamlStr =
+      """
+        |spark:
+        |  spark.some.decimal: 1.523432422343
+        |""".stripMargin
+    val parsed = PolynoteConfig.parse(yamlStr)
+    parsed.right.value.spark.get.properties("spark.some.decimal") shouldEqual "1.523432422343"
+  }
 }


### PR DESCRIPTION
Attempt at a fix from issue reported in #719 .

Issue arises from toString on underlying Circe BiggerDecimal class which is ultimately used by circe-yaml. The format of the numeric value from this call doesn't have the expected formatting for float and int types in SparkConfig properties.

Changes:
- Support numeric values in SparkConfig properties map
- Remove Test class in PolyNote Config package