### PR TITLE
fix orphaned kernel bug due to rename

### DIFF
--- a/polynote-server/src/main/scala/polynote/server/NotebookManager.scala
+++ b/polynote-server/src/main/scala/polynote/server/NotebookManager.scala
@@ -121,7 +121,8 @@ object NotebookManager {
                 writer.stop() *> repository.renameNotebook(path, newPath).foldM(
                   err => startWriter(publisher) *> Logging.error("Unable to rename notebook", err) *> ZIO.fail(err),
                   realPath => publisher.rename(realPath).as(realPath) *> startWriter(publisher).flatMap {
-                    writer => openNotebooks.put(path, (publisher, writer)).as(realPath)
+                    writer =>
+                      openNotebooks.put(newPath, (publisher, writer)) *> openNotebooks.remove(path).as(realPath)
                   }
                 )
             }


### PR DESCRIPTION
We observed some "orphaned" kernels in our deployments. This fix addresses kernels that could be orphaned under these specific circumstances:
1. Open notebook A and launch its kernel
2. Rename notebook A to B
3. Open notebook B in a new session (typically by reloading the page, could also be by opening another client to B). 
4. Due to this bug, the kernel for B is viewed as "off", so you launch a new kernel for B
5. Voila! Kernel for A is now gonna sit there until the polynote server is restarted!