### PR TITLE
Move static files out of JAR

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -144,7 +144,7 @@ val `polynote-server` = project.settings(
     "com.vladsch.flexmark" % "flexmark-ext-yaml-front-matter" % "0.34.32",
     "org.slf4j" % "slf4j-simple" % "1.7.25"
   ),
-  unmanagedResourceDirectories in Compile += (ThisBuild / baseDirectory).value / "polynote-frontend" / "dist",
+  //unmanagedResourceDirectories in Compile += (ThisBuild / baseDirectory).value / "polynote-frontend" / "dist",
   packageBin := {
     val _ = distUI.value
     (packageBin in Compile).value
@@ -246,6 +246,8 @@ lazy val polynote = project.in(file(".")).aggregate(`polynote-env`, `polynote-ru
         }
 
         IO.copy(resolvedFiles, overwrite = true, preserveLastModified = true, preserveExecutable = true)
+
+        IO.copyDirectory(file(".") / "polynote-frontend" / "dist" / "static", targetDir / "static")
 
         val rootPath = crossTarget.value.toPath
         def relative(file: File): String = rootPath.relativize(file.toPath).toString

--- a/polynote-frontend/package.json
+++ b/polynote-frontend/package.json
@@ -38,6 +38,6 @@
   "scripts": {
     "clean": "rm dist/static/*.js dist/static/*.map dist/static/*.gz || echo Nothing to clean",
     "build": "webpack --config webpack.config.js && node_modules/.bin/lessc style/styles.less dist/static/style/styles.css",
-    "dist": "rm -r dist/ && webpack --config webpack.config.js --mode production && node_modules/.bin/lessc style/styles.less dist/static/style/styles.css && gzip -r -q dist && gunzip dist/static/index.html",
+    "dist": "rm -r dist/; webpack --config webpack.config.js --mode production && node_modules/.bin/lessc style/styles.less dist/static/style/styles.css && gzip -r -q dist && gunzip dist/static/index.html",
     "watch": "webpack --config webpack.config.js --watch & node_modules/.bin/less-watch-compiler style dist/static/style styles.less"  }
 }

--- a/polynote-frontend/package.json
+++ b/polynote-frontend/package.json
@@ -36,8 +36,8 @@
     "webpack-cli": "3.3.11"
   },
   "scripts": {
-    "clean": "rm dist/static/*.js dist/static/*.map || echo Nothing to clean",
+    "clean": "rm dist/static/*.js dist/static/*.map dist/static/*.gz || echo Nothing to clean",
     "build": "webpack --config webpack.config.js && node_modules/.bin/lessc style/styles.less dist/static/style/styles.css",
-    "dist": "webpack --config webpack.config.js --mode production && node_modules/.bin/lessc style/styles.less dist/style/styles.css",
+    "dist": "rm -r dist/ && webpack --config webpack.config.js --mode production && node_modules/.bin/lessc style/styles.less dist/static/style/styles.css && gzip -r -q dist && gunzip dist/static/index.html",
     "watch": "webpack --config webpack.config.js --watch & node_modules/.bin/less-watch-compiler style dist/static/style styles.less"  }
 }

--- a/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
@@ -1,6 +1,8 @@
 package polynote.config
 
 import java.io.{File, FileNotFoundException, FileReader}
+import java.net.URI
+import java.nio.file.Path
 import java.util.UUID
 import java.util.regex.Pattern
 
@@ -160,6 +162,16 @@ object SparkConfig {
   implicit val encoder: Encoder[SparkConfig] = deriveEncoder
 }
 
+final case class StaticConfig(
+  path: Option[Path] = None,
+  url: Option[URI] = None
+)
+
+object StaticConfig {
+  implicit val encoder: Encoder[StaticConfig] = deriveEncoder
+  implicit val decoder: Decoder[StaticConfig] = deriveDecoder
+}
+
 final case class PolynoteConfig(
   listen: Listen = Listen(),
   storage: Storage = Storage(),
@@ -171,7 +183,8 @@ final case class PolynoteConfig(
   security: Security = Security(),
   ui: UI = UI(),
   credentials: Credentials = Credentials(),
-  env: Map[String, String] = Map.empty
+  env: Map[String, String] = Map.empty,
+  static: StaticConfig = StaticConfig()
 )
 
 

--- a/polynote-kernel/src/main/scala/polynote/config/package.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/package.scala
@@ -1,5 +1,8 @@
 package polynote
 
+import java.io.File
+import java.net.URI
+import java.nio.file.{Path, Paths}
 import java.util.regex.Pattern
 
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
@@ -152,4 +155,14 @@ package object config {
   }
 
   implicit val patternEncoder: Encoder[Pattern] = Encoder.encodeString.contramap(_.pattern())
+
+  implicit val pathEncoder: Encoder[Path] = Encoder.encodeString.contramap(_.toString())
+  implicit val pathDecoder: Decoder[Path] = Decoder.decodeString.emap {
+    pathStr => Either.catchNonFatal(new File(pathStr).toPath).leftMap(err => s"Malformed path: ${err.getMessage}")
+  }
+
+  implicit val uriEncoder: Encoder[URI] = Encoder.encodeString.contramap(_.toString())
+  implicit val uriDecoder: Decoder[URI] = Decoder.decodeString.emap {
+    uriStr => Either.catchNonFatal(new URI(uriStr)).leftMap(err => s"Malformed URI: ${err.getMessage}")
+  }
 }


### PR DESCRIPTION
Move the static files out of the JAR and into the package distribution instead. This is for three reasons:

1. It's way more efficient to serve these directly off of disk than from the JAR
2. We can gzip them and have it be even more efficient
3. Also added a configuration to specify the static path and/or URL, so you can host it even with a different server or CDN if you like.

For me, just moving the files out and using them directly instead of from the JAR results in a large reduction in initial load time.