### PR TITLE
Fix plugin script

### DIFF
--- a/scripts/plugin
+++ b/scripts/plugin
@@ -13,7 +13,7 @@ fi
 
 case $1 in
   enable)
-    ln -s "plugins/$2.jar" "plugins.d/$2.jar"
+    ln -s "../plugins/$2.jar" plugins.d/
     ;;
   disable)
     unlink "plugins.d/$2.jar"


### PR DESCRIPTION
Wasn't linking correctly due to incorrect `ln -s` usage. One of these days I'll figure out the right way to use it.