### PR TITLE
Add missing encoding type to bar charts with multiple Y fields

### DIFF
--- a/polynote-frontend/polynote/ui/component/plot_editor.ts
+++ b/polynote-frontend/polynote/ui/component/plot_editor.ts
@@ -544,7 +544,8 @@ function normalSpec(this: PlotEditor, plotType: string, xField: StructField, yMe
             fold: yMeas.map(measure => measure.agg ? `${measure.agg}(${measure.field.name})` : measure.field.name)
         }];
         spec.encoding.y = {
-            field: 'value'
+            field: 'value',
+            type: 'quantitative'
         };
         spec.encoding.color = {
             field: 'key',


### PR DESCRIPTION
Fix #848

The bar charts now support multiple fields in the Y axis, as expected.

<img width="854" alt="Screenshot 2020-03-28 at 19 44 07" src="https://user-images.githubusercontent.com/1187242/77832245-890c3600-712c-11ea-8cdc-b8785c4bf3dc.png">
