### PR TITLE
Fix listen host regression

### DIFF
--- a/polynote-server/src/main/scala/polynote/server/Server.scala
+++ b/polynote-server/src/main/scala/polynote/server/Server.scala
@@ -120,7 +120,7 @@ class Server(kernelFactory: Kernel.Factory.Service) extends polynote.app.App {
       _            <- Env.addM[BaseEnv with GlobalEnv with NotebookManager](IdentityProvider.load.orDie)
       _            <- Logging.warn(securityWarning)
       _            <- Logging.info(banner)
-      _            <- serve(args.watchUI, wsKey, loadIndex, broadcastAll, uzhttp.server.Server.builder(new InetSocketAddress(host, port))).use {
+      _            <- serve(args.watchUI, wsKey, loadIndex, broadcastAll, uzhttp.server.Server.builder(new InetSocketAddress(address, port))).use {
         server => server.awaitShutdown
       }.orDie
     } yield 0


### PR DESCRIPTION
Fixes #851

Accidentally changed the listening server to use the `getLocalHost.getHostAddress` in `0.0.0.0` case – this should be used for presentation only, not for binding.