### PR TITLE
Monitor remote kernel process

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/logging/package.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/logging/package.scala
@@ -139,7 +139,7 @@ package object logging {
             val remotePrefix = s"[REMOTE | $path]\n$remoteIndent"
             printWithPrefix(remotePrefix, remoteIndent, msg)(Location.Empty)
           } else {
-            printWithPrefix("", remoteIndent, msg)(Location.Empty)
+            printWithPrefix(remoteIndent, remoteIndent, msg)(Location.Empty)
           }
         }
       }


### PR DESCRIPTION
- If remote kernel process dies before startup, surface a generic error
- Fix indent of remote logging