### PR TITLE
Fix a bunch of regressions and issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ metastore_db
 *.log
 tmp
 npm-debug.log.*
+run-jar.sh

--- a/polynote-frontend/package.json
+++ b/polynote-frontend/package.json
@@ -39,5 +39,6 @@
     "clean": "rm dist/static/*.js dist/static/*.map dist/static/*.gz || echo Nothing to clean",
     "build": "webpack --config webpack.config.js && node_modules/.bin/lessc style/styles.less dist/static/style/styles.css",
     "dist": "rm -r dist/; webpack --config webpack.config.js --mode production && node_modules/.bin/lessc style/styles.less dist/static/style/styles.css && gzip -r -q dist && gunzip dist/static/index.html",
-    "watch": "webpack --config webpack.config.js --watch & node_modules/.bin/less-watch-compiler style dist/static/style styles.less"  }
+    "watch": "webpack --config webpack.config.js --watch & node_modules/.bin/less-watch-compiler style dist/static/style styles.less"
+  }
 }

--- a/polynote-frontend/polynote/ui/component/notebook.ts
+++ b/polynote-frontend/polynote/ui/component/notebook.ts
@@ -735,12 +735,12 @@ export class NotebookUI extends UIMessageTarget {
                         const params = sig.parameters.map(param => {
                             return {
                                 label: param.typeName ? `${param.name}: ${param.typeName}` : param.name,
-                                documentation: param.docString
+                                documentation: param.docString || undefined
                             }
                         });
 
                         return {
-                            documentation: sig.docString,
+                            documentation: sig.docString || undefined,
                             label: sig.name,
                             parameters: params
                         }

--- a/polynote-kernel/src/main/scala/polynote/kernel/Kernel.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/Kernel.scala
@@ -16,6 +16,7 @@ trait Kernel {
   def queueCell(id: CellID): TaskC[Task[Unit]]
 
   def cancelAll(): RIO[BaseEnv with TaskManager, Unit] = TaskManager.access.flatMap(_.cancelAll())
+  def tasks(): RIO[BaseEnv with TaskManager, List[TaskInfo]] = TaskManager.access.flatMap(_.list)
 
   /**
     * Provide completions for the given position in the given cell

--- a/polynote-kernel/src/main/scala/polynote/kernel/LocalKernel.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/LocalKernel.scala
@@ -151,7 +151,7 @@ class LocalKernel private[kernel] (
   override def shutdown(): Task[Unit] = for {
     _            <- busyState.update(_.setBusy)
     interpreters <- interpreters.values
-    _            <- interpreters.map(_.shutdown()).sequence.unit
+    _            <- ZIO.foreachPar_(interpreters)(_.shutdown())
     _            <- busyState.set(KernelBusyState(busy = false, alive = false))
     _            <- closed.succeed(())
   } yield ()

--- a/polynote-kernel/src/main/scala/polynote/kernel/package.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/package.scala
@@ -56,6 +56,8 @@ package object kernel {
     def interruptAndIgnoreWhen(signal: Promise[Throwable, Unit])(implicit concurrent: Concurrent[RIO[R, ?]]): Stream[RIO[R, ?], A] =
       stream.interruptWhen(signal.await.either.as(Right(()): Either[Throwable, Unit]))
 
+    def terminateWhen[E <: Throwable, A1](signal: Promise[E, A1])(implicit concurrent: Concurrent[RIO[R, ?]]): Stream[RIO[R, ?], A] =
+      Stream(stream.map(Some(_)), Stream.eval(signal.await: RIO[R, A1]).map(_ => None)).parJoinUnbounded.unNoneTerminate
   }
 
   final implicit class StreamUIOps[A](val stream: Stream[UIO, A]) {

--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/RemoteKernel.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/RemoteKernel.scala
@@ -21,7 +21,7 @@ import polynote.kernel.task.TaskManager
 import polynote.kernel.util.Publish
 import polynote.messages._
 import polynote.runtime.{StreamingDataRepr, TableOp}
-import zio.{Cause, Layer, Promise, RIO, Task, UIO, ZIO, ZLayer}
+import zio.{Cause, Layer, Promise, RIO, Semaphore, Task, UIO, URIO, ZIO, ZLayer}
 import zio.blocking.effectBlocking
 import zio.duration.Duration
 import zio.interop.catz._
@@ -31,6 +31,7 @@ import scala.collection.JavaConverters._
 class RemoteKernel[ServerAddress](
   private[polynote] val transport: TransportServer[ServerAddress],
   updates: Stream[Task, NotebookUpdate],
+  closing: Semaphore,
   closed: Promise[Throwable, Unit]
 ) extends Kernel {
 
@@ -116,6 +117,10 @@ class RemoteKernel[ServerAddress](
     case UnitResponse(reqId) => done(reqId, ())
   }
 
+  override def tasks(): RIO[BaseEnv with TaskManager, List[TaskInfo]] = request(ListTasksRequest(nextReq)) {
+    case ListTasksResponse(reqId, result) => done(reqId, result)
+  }
+
   def completionsAt(id: CellID, pos: Int): RIO[BaseEnv with GlobalEnv with CellEnv, List[Completion]] =
     request(CompletionsAtRequest(nextReq, id, pos)) {
       case CompletionsAtResponse(reqId, result) => done(reqId, result)
@@ -126,14 +131,21 @@ class RemoteKernel[ServerAddress](
       case ParametersAtResponse(reqId, result) => done(reqId, result)
     }
 
-  def shutdown(): TaskB[Unit] = request(ShutdownRequest(nextReq)) {
-    case ShutdownResponse(reqId) => done(reqId, ())
-  }.timeout(Duration(10, TimeUnit.SECONDS)).flatMap {
-    case Some(()) => ZIO.succeed(())
-    case None =>
-      Logging.warn("Waited for remote kernel to shut down for 10 seconds; killing the process")
-  }.ensuring {
-    close().orDie
+  def shutdown(): TaskB[Unit] = closing.withPermit {
+    closed.isDone.flatMap {
+      alreadyClosed =>
+        ZIO.when(!alreadyClosed) {
+          request(ShutdownRequest(nextReq)) {
+            case ShutdownResponse(reqId) => done(reqId, ())
+          }.timeout(Duration(10, TimeUnit.SECONDS)).flatMap {
+            case Some(()) => ZIO.succeed(())
+            case None =>
+              Logging.warn("Waited for remote kernel to shut down for 10 seconds; killing the process")
+          }
+        }
+    }.ensuring {
+      close().orDie
+    }
   }
 
   def status(): TaskB[KernelBusyState] = request(StatusRequest(nextReq)) {
@@ -169,11 +181,11 @@ class RemoteKernel[ServerAddress](
     case KernelInfoResponse(reqId, info) => done(reqId, info)
   }
 
-  private def close(): TaskB[Unit] = for {
+  private[this] def close(): TaskB[Unit] = for {
     _ <- closed.succeed(())
+    _ <- transport.close()
     _ <- waiting.values().asScala.toList.map(_.promise.interrupt).sequence
     _ <- ZIO.effectTotal(waiting.clear())
-    _ <- transport.close()
   } yield ()
 
   override def awaitClosed: Task[Unit] = closed.await
@@ -183,10 +195,11 @@ class RemoteKernel[ServerAddress](
 object RemoteKernel extends Kernel.Factory.Service {
   def apply[ServerAddress](transport: Transport[ServerAddress]): RIO[BaseEnv with GlobalEnv with CellEnv with NotebookUpdates, RemoteKernel[ServerAddress]] = for {
     closed  <- Promise.make[Throwable, Unit]
+    closing <- Semaphore.make(1L)
     server  <- transport.serve()
     updates <- NotebookUpdates.access
-    kernel   = new RemoteKernel(server, updates, closed)
-    _       <- (server.awaitClosed.to(closed).ensuring(kernel.close().ignore)).forkDaemon
+    kernel   = new RemoteKernel(server, updates, closing, closed)
+    _       <- (server.awaitClosed.to(closed).ensuring(kernel.shutdown().ignore)).forkDaemon
   } yield kernel
 
   override def apply(): RIO[BaseEnv with GlobalEnv with CellEnv with NotebookUpdates, Kernel] = apply(
@@ -207,7 +220,7 @@ class RemoteKernelClient(
   kernel: Kernel,
   requests: Stream[TaskB, RemoteRequest],
   publishResponse: Publish[Task, RemoteResponse],
-  close: TaskB[Unit],
+  cleanup: TaskB[Unit],
   private[remote] val notebookRef: SignallingRef[Task, (Int, Notebook)] // for testing
 ) {
 
@@ -220,7 +233,7 @@ class RemoteKernelClient(
       .parJoinUnbounded
       .terminateAfter(_.isInstanceOf[ShutdownResponse])
       .evalMap(publishResponse.publish1)
-      .compile.drain.as(0) <* close
+      .compile.drain.uninterruptible.as(0)
 
   private def handleRequest(req: RemoteRequest): RIO[BaseEnv with GlobalEnv with CellEnv with PublishRemoteResponse, RemoteResponse] = {
       val response = req match {
@@ -231,10 +244,11 @@ class RemoteKernelClient(
               .ensuring(publishResponse.publish1(RunCompleteResponse(reqId)).orDie)
               .forkDaemon
         }.as(UnitResponse(reqId))
+        case ListTasksRequest(reqId)                      => kernel.tasks().map(ListTasksResponse(reqId, _))
         case CancelAllRequest(reqId)                      => kernel.cancelAll().as(UnitResponse(reqId))
         case CompletionsAtRequest(reqId, cellID, pos)     => kernel.completionsAt(cellID, pos).map(CompletionsAtResponse(reqId, _))
         case ParametersAtRequest(reqId, cellID, pos)      => kernel.parametersAt(cellID, pos).map(ParametersAtResponse(reqId, _))
-        case ShutdownRequest(reqId)                       => kernel.shutdown().as(ShutdownResponse(reqId))
+        case ShutdownRequest(reqId)                       => kernel.shutdown().as(ShutdownResponse(reqId)).uninterruptible
         case StatusRequest(reqId)                         => kernel.status().map(StatusResponse(reqId, _))
         case ValuesRequest(reqId)                         => kernel.values().map(ValuesResponse(reqId, _))
         case GetHandleDataRequest(reqId, sid, ht, hid, c) => kernel.getHandleData(ht, hid, c).map(GetHandleDataResponse(reqId, _)).provideSomeLayer(streamingHandles(sid))
@@ -245,7 +259,7 @@ class RemoteKernelClient(
         case req => ZIO.succeed(UnitResponse(req.reqId))
       }
 
-      response.provideSomeLayer[BaseEnv with GlobalEnv with CellEnv with PublishRemoteResponse](RemoteKernelClient.mkResultPublisher(req.reqId))
+      response.interruptible.provideSomeLayer[BaseEnv with GlobalEnv with CellEnv with PublishRemoteResponse](RemoteKernelClient.mkResultPublisher(req.reqId))
   }.catchAll {
     err => ZIO.succeed(ErrorResponse(req.reqId, err))
   }
@@ -266,6 +280,8 @@ class RemoteKernelClient(
         }
       }
     }
+
+  def close(): URIO[BaseEnv, Unit] = cleanup.orDie
   
 }
 
@@ -296,13 +312,13 @@ object RemoteKernelClient extends polynote.app.App {
       .compile.drain
       .forkDaemon
     interpFactories <- interpreter.Loader.load
-    kernelEnv        = mkEnv(notebookRef, firstRequest.reqId, publishResponse, interpFactories, kernelFactory, initial.config)
-    kernel          <- kernelFactory.apply().provideSomeLayer[BaseEnv](kernelEnv)
+    _               <- Env.addLayer(mkEnv(notebookRef, firstRequest.reqId, publishResponse, interpFactories, kernelFactory, initial.config))
+    kernel          <- kernelFactory.apply()
     client           = new RemoteKernelClient(kernel, requests, publishResponse, transport.close(), notebookRef)
     _               <- tapClient.fold(ZIO.unit)(_.set(client))
-    _               <- kernel.init().provideSomeLayer[BaseEnv](kernelEnv)
+    _               <- kernel.init()
     _               <- publishResponse.publish1(Announce(initial.reqId, localAddress))
-    exitCode        <- client.run().provideSomeLayer[BaseEnv](kernelEnv)
+    exitCode        <- client.run().ensuring(client.close())
   } yield exitCode
 
   def mkEnv(
@@ -312,7 +328,7 @@ object RemoteKernelClient extends polynote.app.App {
     interpreterFactories: Map[String, List[Interpreter.Factory]],
     kernelFactory: Factory.Service,
     polynoteConfig: PolynoteConfig
-  ): Layer[Throwable, GlobalEnv with CellEnv with PublishRemoteResponse] = {
+  ): ZLayer[BaseEnv, Throwable, GlobalEnv with CellEnv with PublishRemoteResponse] = {
     val publishStatus = PublishStatus.layer(publishResponse.contramap(KernelStatusResponse.apply))
     val publishRemote: Layer[Nothing, PublishRemoteResponse] = ZLayer.succeed(publishResponse)
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/protocol.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/protocol.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
 import polynote.config.PolynoteConfig
-import polynote.kernel.{Completion, KernelBusyState, KernelInfo, KernelStatusUpdate, Result, ResultValue, RuntimeError, Signatures}
+import polynote.kernel.{Completion, KernelBusyState, KernelInfo, KernelStatusUpdate, Result, ResultValue, RuntimeError, Signatures, TaskInfo}
 import polynote.messages._
 import polynote.runtime.{StreamingDataRepr, TableOp}
 import scodec.codecs.{Discriminated, Discriminator, byte}
@@ -95,6 +95,9 @@ object ModifyStreamRequest extends RemoteRequestCompanion[ModifyStreamRequest](9
 final case class ReleaseHandleRequest(reqId: Int, sessionId: Int, handleType: HandleType, handleId: Int) extends RemoteRequest
 object ReleaseHandleRequest extends RemoteRequestCompanion[ReleaseHandleRequest](10)
 
+final case class ListTasksRequest(reqId: Int) extends RemoteRequest
+object ListTasksRequest extends RemoteRequestCompanion[ListTasksRequest](11)
+
 final case class CancelAllRequest(reqId: Int) extends RemoteRequest
 object CancelAllRequest extends RemoteRequestCompanion[CancelAllRequest](12)
 
@@ -158,6 +161,9 @@ object GetHandleDataResponse extends RemoteResponseCompanion[GetHandleDataRespon
 
 final case class ModifyStreamResponse(reqId: Int, result: Option[StreamingDataRepr]) extends RemoteRequestResponse
 object ModifyStreamResponse extends RemoteResponseCompanion[ModifyStreamResponse](9)
+
+final case class ListTasksResponse(reqId: Int, result: List[TaskInfo]) extends RemoteRequestResponse
+object ListTasksResponse extends RemoteResponseCompanion[ListTasksResponse](11)
 
 final case class KernelInfoResponse(reqId: Int, info: KernelInfo) extends RemoteRequestResponse
 object KernelInfoResponse extends RemoteResponseCompanion[KernelInfoResponse](13)

--- a/polynote-kernel/src/main/scala/polynote/kernel/task/package.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/task/package.scala
@@ -4,14 +4,13 @@ import java.util.concurrent.{ConcurrentHashMap, LinkedBlockingQueue}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 
 import scala.collection.JavaConverters._
-
 import cats.effect.concurrent.Ref
 import fs2.concurrent.SignallingRef
 import polynote.kernel.environment.{CurrentTask, PublishStatus}
 import polynote.kernel.logging.Logging
 import polynote.kernel.util.Publish
 import polynote.messages.TinyString
-import zio.{Cause, Fiber, Has, Promise, Queue, RIO, Schedule, Semaphore, Task, UIO, ZIO, ZLayer}
+import zio.{Cause, Fiber, Has, Promise, Queue, RIO, Schedule, Semaphore, Task, UIO, ZIO, ZLayer, ZManaged}
 import zio.blocking.Blocking
 import zio.clock.Clock
 import zio.interop.catz._
@@ -163,38 +162,43 @@ package object task {
 
       override def register(id: String, label: String = "", detail: String = "", parent: Option[String], errorWith: DoneStatus)(cancelCallback: ((TaskInfo => TaskInfo) => Unit) => ZIO[Logging, Nothing, Unit]): RIO[Blocking with Clock with Logging, Fiber[Throwable, Unit]] =
         for {
+          runtime     <- ZIO.runtime[Any]
           statusRef   <- SignallingRef[Task, TaskInfo](TaskInfo(id, lbl(id, label), detail, Running, progress = 0, parent = parent.map(TinyString(_))))
-            updateTasks  = new LinkedBlockingQueue[TaskInfo => TaskInfo]()
-            completed    = new AtomicBoolean(false)
-            updater     <- statusRef.discrete
-              .terminateAfter(_.status.isDone)
-              .through(updates.publish)
-              .compile.drain
-              .uninterruptible
-              .ensuring(ZIO.effectTotal(completed.set(true)))
-              .forkDaemon
-            onUpdate     = (fn: TaskInfo => TaskInfo) => updateTasks.put(fn)
-            cancel       = cancelCallback(onUpdate)
-            process     <- zio.blocking.effectBlocking(updateTasks.take()).flatMap(statusRef.update)
-              .repeat(Schedule.doUntil(_ => completed.get()))
-              .ensuring(ZIO.effectTotal(tasks.remove(id)))
-              .onInterrupt(statusRef.update(_.done(errorWith)).orDie.ensuring(cancel))
-              .forkDaemon
-            descriptor   = (statusRef, process, taskCounter.getAndIncrement())
-            _           <- Option(tasks.put(id, descriptor)).map(_._2.interrupt).getOrElse(ZIO.unit)
+          updateTasks <- Queue.unbounded[TaskInfo => TaskInfo]
+          completed    = new AtomicBoolean(false)
+          updater     <- statusRef.discrete
+            .terminateAfter(_.status.isDone)
+            .through(updates.publish)
+            .compile.drain
+            .uninterruptible
+            .ensuring(ZIO.effectTotal(completed.set(true)))
+            .forkDaemon
+          onUpdate     = (fn: TaskInfo => TaskInfo) => runtime.unsafeRun(updateTasks.offer(fn).unit)
+          cancel       = cancelCallback(onUpdate)
+          process     <- updateTasks.take.flatMap(updater => statusRef.update(updater) *> statusRef.get)
+            .doUntil(_.status.isDone).unit
+            .ensuring(ZIO.effectTotal(tasks.remove(id)))
+            .onInterrupt(statusRef.update(_.done(errorWith)).orDie.ensuring(cancel))
+            .forkDaemon
+          descriptor   = (statusRef, process, taskCounter.getAndIncrement())
+          _           <- Option(tasks.put(id, descriptor)).map(_._2.interrupt).getOrElse(ZIO.unit)
         } yield process
 
       override def cancelAll(): UIO[Unit] = {
-        ZIO.collectAll {tasks.values().asScala.toList.reverse.map {
-          case (status, fiber, _) => fiber.interrupt
-        }} zipPar readyQueue.takeAll.flatMap {
-          brokenPromises => ZIO.collectAll {
-            brokenPromises.map {
-              case (ready, done) => ready.interrupt *> done.interrupt
-            }
-          }
+        val runningFibers    = ZIO.effectTotal(tasks.values().asScala.map(_._2))
+        val interruptRunning = runningFibers.flatMap {
+          fibers => ZIO.foreachPar_(fibers)(_.interruptFork)
         }
-      }.unit
+
+        val interruptQueued = for {
+          promises <- readyQueue.takeAll
+          _        <- ZIO.foreachPar_(promises) {
+            case (ready, done) => ready.interrupt &> done.interrupt
+          }
+        } yield ()
+
+        interruptQueued *> interruptRunning
+      }
 
       override def list: UIO[List[TaskInfo]] = ZIO.collectAll(tasks.values().asScala.toList.sortBy(_._3).map(_._1.get.orDie))
 
@@ -211,7 +215,12 @@ package object task {
       }.forever.forkDaemon
     } yield new Impl(queueing, statusUpdates, queue, run)
 
-    def layer: ZLayer[PublishStatus, Throwable, TaskManager] = ZLayer.fromEffect(ZIO.access[PublishStatus](_.get) >>= TaskManager.apply)
+    def make: ZManaged[PublishStatus, Throwable, TaskManager.Service] = for {
+      statusUpdates <- ZIO.access[PublishStatus](_.get).toManaged_
+      taskManager   <- apply(statusUpdates).toManaged(_.shutdown())
+    } yield taskManager
+
+    def layer: ZLayer[PublishStatus, Throwable, TaskManager] = ZLayer.fromManaged(make)
 
     def access: RIO[TaskManager, TaskManager.Service] = ZIO.access[TaskManager](_.get)
 

--- a/polynote-kernel/src/test/scala/polynote/testing/ZIOSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/testing/ZIOSpec.scala
@@ -16,6 +16,12 @@ import zio.random.Random
 import zio.system.System
 import zio.{Has, RIO, Runtime, Tagged, ZIO, ZLayer}
 
+abstract class TestRuntime
+object TestRuntime {
+  val runtime: Runtime.Managed[zio.ZEnv with Logging] = ZIOSpecBase.runtime
+  def fiberDump(): List[zio.Fiber.Dump] = runtime.unsafeRun(zio.Fiber.dumpAll).toList
+}
+
 trait ZIOSpecBase[Env <: Has[_]] {
   import ZIOSpecBase.BaseEnv
   type Environment = Env

--- a/polynote-kernel/src/test/scala/polynote/testing/kernel/remote/InProcessDeploy.scala
+++ b/polynote-kernel/src/test/scala/polynote/testing/kernel/remote/InProcessDeploy.scala
@@ -2,11 +2,13 @@ package polynote.testing.kernel.remote
 
 import java.net.InetSocketAddress
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 import polynote.kernel.{BaseEnv, GlobalEnv, Kernel}
 import polynote.kernel.environment.CurrentNotebook
+import polynote.kernel.logging.Logging
 import polynote.kernel.remote.{RemoteKernelClient, SocketTransport}
-import zio.{Fiber, Ref, RIO, ZIO}
+import zio.{Fiber, RIO, Ref, ZIO}
 import zio.duration.Duration
 
 class InProcessDeploy(kernelFactory: Kernel.Factory.LocalService, clientRef: Ref[RemoteKernelClient]) extends SocketTransport.Deploy {

--- a/polynote-server/src/main/scala/polynote/server/NotebookSession.scala
+++ b/polynote-server/src/main/scala/polynote/server/NotebookSession.scala
@@ -135,6 +135,7 @@ object NotebookSession {
 
   def stream(path: String, input: Stream[Throwable, Frame]): ZIO[SessionEnv with NotebookManager, HTTPError, Stream[Throwable, Frame]] = {
     for {
+      _                <- NotebookManager.assertValidPath(path)
       publisher        <- NotebookManager.open(path).orElseFail(NotFound(path))
       output           <- ZQueue.unbounded[Take[Nothing, Message]]
       publishMessage   <- Env.add[SessionEnv with NotebookManager](Publish(output): Publish[Task, Message])

--- a/polynote-server/src/main/scala/polynote/server/NotebookSession.scala
+++ b/polynote-server/src/main/scala/polynote/server/NotebookSession.scala
@@ -108,16 +108,17 @@ class NotebookSession(subscriber: KernelSubscriber, streamingHandles: StreamingH
 
   private def sendStatus: RIO[BaseEnv with GlobalEnv with PublishMessage, Unit] = subscriber.publisher.kernelStatus().flatMap {
     status => PublishMessage(KernelStatus(status)) *> ZIO.when(status.alive) {
-      subscriber.publisher.kernel.flatMap {
-        kernel => kernel.values().flatMap {
-          values => ZIO.foreach_(values.filter(_.sourceCell < 0))(value => PublishMessage(CellResult(value.sourceCell, value)))
-        } *> (kernel.info().map(KernelStatus(_)) >>= PublishMessage)
-      }
+      for {
+        kernel <- subscriber.publisher.kernel
+        values <- kernel.values()
+        _      <- ZIO.foreach(values.filter(_.sourceCell < 0))(value => PublishMessage(CellResult(value.sourceCell, value)))
+        _      <- kernel.info().map(KernelStatus(_)) >>= PublishMessage
+      } yield ()
     }
   }
 
-  private def sendTasks: RIO[PublishMessage, Unit] =
-    subscriber.publisher.taskManager.list.map(tasks => KernelStatus(UpdatedTasks(tasks))) >>= PublishMessage
+  private def sendTasks: RIO[BaseEnv with PublishMessage, Unit] =
+    subscriber.publisher.tasks().map(tasks => KernelStatus(UpdatedTasks(tasks))) >>= PublishMessage
 
   private def sendPresence: RIO[PublishMessage, Unit] = subscriber.publisher.subscribersPresent.flatMap {
     presence =>

--- a/polynote-server/src/main/scala/polynote/server/Server.scala
+++ b/polynote-server/src/main/scala/polynote/server/Server.scala
@@ -181,7 +181,7 @@ class Server(kernelFactory: Kernel.Factory.Service) extends polynote.app.App {
             val path = uri.getPath
             val query = uri.getQuery
             if ((path startsWith "/ws") && (query == s"key=$wsKey")) {
-              path.stripPrefix("/ws") match {
+              path.stripPrefix("/ws").stripPrefix("/") match {
                 case "" => authorize(req, SocketSession(inputFrames, broadcastAll).flatMap(output => Response.websocket(req, output)))
                 case rest => authorize(req, NotebookSession.stream(rest, inputFrames).flatMap(output => Response.websocket(req, output)))
               }

--- a/polynote-server/src/main/scala/polynote/server/Server.scala
+++ b/polynote-server/src/main/scala/polynote/server/Server.scala
@@ -171,9 +171,9 @@ class Server(kernelFactory: Kernel.Factory.Service) extends polynote.app.App {
       for {
         authRoutes    <- IdentityProvider.authRoutes.toManaged_
         broadcastAll  <- Topic[Task, Option[Message]](None).toManaged_  // used to broadcast messages to all connected clients
-        nbManager      = NotebookManager.layer(broadcastAll)
-        authorize     <- IdentityProvider.authorize[RequestEnv].toManaged_.provideSomeLayer[BaseEnv with ServerEnv with MainArgs](nbManager)
-        staticHandler <- staticFiles.provideSomeLayer[BaseEnv with ServerEnv with MainArgs](nbManager)
+        _             <- Env.addManagedLayer(NotebookManager.layer[BaseEnv with ServerEnv with MainArgs](broadcastAll))
+        authorize     <- IdentityProvider.authorize[RequestEnv].toManaged_
+        staticHandler <- staticFiles
         address       <- ZIO(config.listen.toSocketAddress).toManaged_
         getIndex      <- indexFileContent(wsKey).toManaged_
         server        <- uzhttp.server.Server.builder(address).handleSome {
@@ -199,7 +199,6 @@ class Server(kernelFactory: Kernel.Factory.Service) extends polynote.app.App {
           .logErrors((msg, err) => Logging.error(msg, err))
           .logInfo(msg => Logging.info(msg))
           .serve
-          .provideSomeLayer[BaseEnv with ServerEnv with MainArgs](nbManager)
       } yield server
     }
   }

--- a/polynote-server/src/main/scala/polynote/server/SocketSession.scala
+++ b/polynote-server/src/main/scala/polynote/server/SocketSession.scala
@@ -45,19 +45,22 @@ object SocketSession {
       }
 
     case CreateNotebook(path, maybeContent) =>
-      checkPermission(Permission.CreateNotebook(path)) *> NotebookManager.create(path, maybeContent).as(None)
+      NotebookManager.assertValidPath(path) *>
+        checkPermission(Permission.CreateNotebook(path)) *> NotebookManager.create(path, maybeContent).as(None)
 
     case RenameNotebook(path, newPath) =>
-      checkPermission(Permission.CreateNotebook(newPath)) *>
-        checkPermission(Permission.DeleteNotebook(path)) *>
+      (NotebookManager.assertValidPath(path) &> NotebookManager.assertValidPath(newPath)) *>
+        checkPermission(Permission.CreateNotebook(newPath)) *> checkPermission(Permission.DeleteNotebook(path)) *>
         NotebookManager.rename(path, newPath).as(None)
 
     case CopyNotebook(path, newPath) =>
-      checkPermission(Permission.CreateNotebook(newPath)) *>
+      (NotebookManager.assertValidPath(path) &> NotebookManager.assertValidPath(newPath)) *>
+        checkPermission(Permission.CreateNotebook(newPath)) *>
         NotebookManager.copy(path, newPath).as(None)
 
     case DeleteNotebook(path) =>
-      checkPermission(Permission.DeleteNotebook(path)) *> NotebookManager.delete(path).as(None)
+      NotebookManager.assertValidPath(path) *>
+        checkPermission(Permission.DeleteNotebook(path)) *> NotebookManager.delete(path).as(None)
 
     case RunningKernels(_) => for {
       paths          <- NotebookManager.listRunning()

--- a/polynote-server/src/test/scala/polynote/server/KernelPublisherIntegrationTest.scala
+++ b/polynote-server/src/test/scala/polynote/server/KernelPublisherIntegrationTest.scala
@@ -15,7 +15,7 @@ import polynote.kernel.interpreter.Interpreter
 import polynote.kernel.remote.SocketTransport.DeploySubprocess
 import polynote.kernel.remote.{RemoteKernel, SocketTransport, SocketTransportServer}
 import polynote.kernel.remote.SocketTransport.DeploySubprocess.DeployJava
-import polynote.kernel.{BaseEnv, CellEnv, GlobalEnv, Kernel, KernelBusyState, KernelError, KernelInfo, LocalKernel, LocalKernelFactory, Output}
+import polynote.kernel.{BaseEnv, CellEnv, GlobalEnv, Kernel, KernelBusyState, KernelError, KernelInfo, KernelStatusUpdate, LocalKernel, LocalKernelFactory, Output}
 import polynote.messages.{CellID, Message, Notebook, NotebookCell, ShortList}
 import polynote.testing.ExtConfiguredZIOSpec
 import zio.duration.Duration

--- a/polynote-spark/src/main/scala/polynote/kernel/KernelListener.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/KernelListener.scala
@@ -59,13 +59,15 @@ class KernelListener(taskManager: TaskManager.Service, session: SparkSession, ru
     }
   }
 
-  private def cancelJob(jobId: Int): ZIO[Logging, Nothing, Unit] = ZIO.effect {
-    session.sparkContext.cancelJob(jobId)
-  }.catchAll(Logging.error("Unable to cancel job", _))
+  private def cancelJob(jobId: Int): ZIO[Logging, Nothing, Unit] =
+    Logging.info(s"Attempting to cancel Spark Job $jobId") *> ZIO.effect {
+      session.sparkContext.cancelJob(jobId)
+    }.catchAll(Logging.error("Unable to cancel job", _))
 
-  private def cancelStage(stageId: Int): ZIO[Logging, Nothing, Unit] = ZIO.effect {
-    session.sparkContext.cancelStage(stageId)
-  }.catchAll(Logging.error("Unable to cancel stage", _))
+  private def cancelStage(stageId: Int): ZIO[Logging, Nothing, Unit] =
+    Logging.info(s"Attempting to cancel Spark Stage $stageId") *> ZIO.effect {
+      session.sparkContext.cancelStage(stageId)
+    }.catchAll(Logging.error("Unable to cancel stage", _))
 
   private def sparkJobTaskId(jobId: Int) = s"SparkJob$jobId"
   private def sparkStageTaskId(stageId: Int) = s"SparkStage$stageId"


### PR DESCRIPTION
- Fix client-side error when doing parameter hints (doc string has to be undefined, not null)
- Monitor the remote kernel when it's starting up (and when it's running) and surface error if it dies
- Fix race condition in kernel closing
- Fix cancel button not working for remote kernels
- Fix crash in SQL interpreter
- Migrate some more things to `ZManaged` to ensure cleanup