### PR TITLE
FIX pandas "object" dtype columns are ignored in UI display

### DIFF
--- a/polynote-runtime/src/main/scala/polynote/runtime/python/pandas/PandasHandle.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/python/pandas/PandasHandle.scala
@@ -22,7 +22,7 @@ class PandasHandle(val handle: Int, df: PythonObject) extends StreamingDataRepr.
     case "boolean" => Some(BoolType)
     case "float64" => Some(DoubleType)
     case "float32" => Some(FloatType)
-    case "string" | "category" => Some(StringType)
+    case "string" | "category" | "object" => Some(StringType)
     case _ => None
   }
 


### PR DESCRIPTION
In python, when use pandas.read_csv(file),   the "string" columns are returned as "object" dtype,  but in polynote UI, those columns are simply ignored, which may cause many confusion.  So, I think we could treat those "object" as a fallback type "string", instead of ignore them totally.