### PR TITLE
FIX #859, fix no module named jep error by set PYTHONHOME

### DIFF
--- a/scripts/polynote.py
+++ b/scripts/polynote.py
@@ -4,6 +4,9 @@ from pathlib import Path
 import os
 import shlex
 
+if not os.environ.get('PYTHONHOME'):
+    os.environ['PYTHONHOME'] = sys.prefix
+
 polynote_dir = os.path.dirname(os.path.realpath(__file__))
 os.chdir(polynote_dir)
 


### PR DESCRIPTION
Please see detailed information in issue #859,  I don't know whether set this environment variable is acceptable in official repo, but it really solved my issue.  

Please feel free to close this PR if it is not a good solution. Thanks.