### PR TITLE
put version in log

### DIFF
--- a/polynote-server/src/main/scala/polynote/server/Server.scala
+++ b/polynote-server/src/main/scala/polynote/server/Server.scala
@@ -101,6 +101,7 @@ class Server {
       wsKey         = config.security.websocketKey.getOrElse(UUID.randomUUID().toString)
       _            <- Logging.warn(securityWarning)
       _            <- Logging.info(banner)
+      _            <- Logging.info(s"Polynote version ${BuildInfo.version}")
       _            <- serve(wsKey).orDie
     } yield 0
   }.provideSomeLayer[AppEnv](IdentityProvider.layer.orDie)


### PR DESCRIPTION
I thought we used to have this but I guess it was lost. Useful to know what version was running while looking through logs. 