### PR TITLE
Allow pasting images as data URI

### DIFF
--- a/polynote-frontend/polynote/ui/util/html_to_md.ts
+++ b/polynote-frontend/polynote/ui/util/html_to_md.ts
@@ -71,7 +71,8 @@ export const htmlToMarkdown = (function () {
 
                     case 'img':
                         const img = node as HTMLImageElement;
-                        accum += '![' + img.getAttribute('alt') + '](' + img.src + ')';
+                        //accum += '![' + img.getAttribute('alt') + '](' + img.src + ')';
+                        accum += img.outerHTML;
                         break;
 
                     case 'code':


### PR DESCRIPTION
Allows pasting images in Chrome into a text cell.

We should really have an actual UI for inserting an image (there's a button for it but it's just grayed out; we've been kicking that can down the road for a while). But this is a quick & dirty thing to enable some usable way to get an image into your text cell (by pasting it).

It seems to be quite slow when you paste the image (and if you subsequently delete the image). Not sure if this is from the markdown diff that happens, or it's just a slow thing to do. But it's a start, anyway.