### PR TITLE
Incrementally load notebook

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
+++ b/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
@@ -189,7 +189,15 @@ final case class Notebook(path: ShortString, cells: ShortList[NotebookCell], con
       }
   }
 
+  /**
+    * @return A copy of this notebook without any results
+    */
   def withoutResults: Notebook = copy(cells = ShortList(cells.map(_.copy(results = ShortList.Nil))))
+
+  /**
+    * @return All of the results in this notebook, in order, as [[CellResult]]s.
+    */
+  def results: List[CellResult] = cells.flatMap(cell => cell.results.map(CellResult(cell.id, _)))
 
   def setResults(id: CellID, results: List[Result]): Notebook = updateCell(id) {
     cell => cell.copy(results = ShortList(results))

--- a/polynote-server/src/main/scala/polynote/server/NotebookSession.scala
+++ b/polynote-server/src/main/scala/polynote/server/NotebookSession.scala
@@ -142,8 +142,7 @@ class NotebookSession(subscriber: KernelSubscriber, streamingHandles: StreamingH
     _       <- PublishMessage(KernelStatus(UpdatedTasks(List(taskInfo))))
     _       <- PublishMessage(nb.withoutResults)
     _       <- PublishMessage(KernelStatus(UpdatedTasks(List(taskInfo.progress(0.5)))))
-    results  = nb.cells.flatMap(cell => cell.results.map(CellResult(cell.id, _)))
-    _       <- sendCellResults(results, taskInfo)
+    _       <- sendCellResults(nb.results, taskInfo)
   } yield ()
 
   def sendNotebookInfo: RIO[BaseEnv with GlobalEnv with PublishMessage, Unit] =


### PR DESCRIPTION
Changes notebook loading, so that instead of sending one big message (which can take quite a while if there's a ton of output), it loads everything else first and then loads the results one by one. Has a progress bar to indicate loading progress.

This should help the perception of slow notebook loading somewhat.