### PR TITLE
Handle empty ivy artifact/metadata config

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/config/package.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/package.scala
@@ -35,8 +35,8 @@ package object config {
     changing: Option[Boolean] = None
   ) extends RepositoryConfig {
 
-    def artifactPattern: String = artifactPatternOpt.getOrElse("[orgPath]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]")
-    def metadataPattern: String = metadataPatternOpt.getOrElse("[orgPath]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[module](_[scalaVersion])(_[sbtVersion])-[revision]-ivy.xml")
+    def artifactPattern: String = artifactPatternOpt.filter(s => s.nonEmpty).getOrElse("[orgPath]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[artifact]-[revision](-[classifier]).[ext]")
+    def metadataPattern: String = metadataPatternOpt.filter(s => s.nonEmpty).getOrElse("[orgPath]/[module](_[scalaVersion])(_[sbtVersion])/[revision]/[module](_[scalaVersion])(_[sbtVersion])-[revision]-ivy.xml")
 
   }
 


### PR DESCRIPTION
Recently ran into a bug where (for some reason still to-be-determined) the `artifact_pattern` and `metadata_pattern` of a notebook was somehow set to `""` rather than not being present at all in the config. This lead to some odd errors resolving dependencies.  