### PR TITLE
Fix the notebook actived tab grabled title bug.

### DIFF
--- a/polynote-frontend/polynote/main.ts
+++ b/polynote-frontend/polynote/main.ts
@@ -28,7 +28,7 @@ SocketSession.global;
 const mainUI = new MainUI();
 const mainEl = document.getElementById('Main');
 mainEl?.appendChild(mainUI.el);
-const path = unescape(window.location.pathname.replace(new URL(document.baseURI).pathname, ''));
+const path = unescape(decodeURIComponent(window.location.pathname.replace(new URL(document.baseURI).pathname, '')));
 const notebookBase = 'notebook/';
 if (path.startsWith(notebookBase)) {
   mainUI.loadNotebook(path.substring(notebookBase.length));

--- a/polynote-frontend/polynote/main.ts
+++ b/polynote-frontend/polynote/main.ts
@@ -28,7 +28,7 @@ SocketSession.global;
 const mainUI = new MainUI();
 const mainEl = document.getElementById('Main');
 mainEl?.appendChild(mainUI.el);
-const path = unescape(decodeURIComponent(window.location.pathname.replace(new URL(document.baseURI).pathname, '')));
+const path = decodeURIComponent(window.location.pathname.replace(new URL(document.baseURI).pathname, ''));
 const notebookBase = 'notebook/';
 if (path.startsWith(notebookBase)) {
   mainUI.loadNotebook(path.substring(notebookBase.length));


### PR DESCRIPTION
Thanks for your greate work on this excellent project!!!

I found a small bug:  when a notebook which contains UTF-8 characters such as Chinese is activated, refreshing the page will lead to garbled page title.

**Here shows how to reproduce the bug:**
![reproduce_problem](https://user-images.githubusercontent.com/52202080/91552919-229b7600-e95f-11ea-8053-e8d8e538df1f.gif)

**The result of manual test is as follows:**
![fix_problem](https://user-images.githubusercontent.com/52202080/91553216-9b023700-e95f-11ea-8d8a-e4f14da15f4b.gif)

looking forward to your review.
