### PR TITLE
Kernel status button and label are not in a straight line

### DIFF
--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -1526,7 +1526,7 @@ button.inspect.icon-button {
   .status {
     font-size: 200%;
     line-height: 0.5;
-    vertical-align: middle;
+    vertical-align: text-top;
     margin: 0 .125em;
   }
 


### PR DESCRIPTION
It's just a simple question of where the page components are displayed...😋😋😋
![kernel-icon-position-strange](https://user-images.githubusercontent.com/52202080/91718763-9c816880-ebc6-11ea-94dd-0d1161695737.png)

I try to fix this by change the css tyle and test it as belows:
![kernel-icon-position-fixed](https://user-images.githubusercontent.com/52202080/91718815-b753dd00-ebc6-11ea-823d-7941815e662d.png)
![validate](https://user-images.githubusercontent.com/52202080/91718816-b8850a00-ebc6-11ea-85cd-1832cb2cdd38.png)
