### PR TITLE
fix potential excpetion:java.nio.file.NoSuchFileException

### DIFF
--- a/polynote-server/src/main/scala/polynote/server/repository/fs/LocalFilesystem.scala
+++ b/polynote-server/src/main/scala/polynote/server/repository/fs/LocalFilesystem.scala
@@ -85,7 +85,10 @@ class LocalFilesystem(maxDepth: Int = 4) extends NotebookFilesystem {
   }
 
   override def list(path: Path): RIO[BaseEnv, List[Path]] =
-    effectBlocking(Files.walk(path, maxDepth, FileVisitOption.FOLLOW_LINKS).iterator().asScala.drop(1).toList)
+    effectBlocking(
+      if (Files.exists(path)) Files.walk(path, maxDepth, FileVisitOption.FOLLOW_LINKS).iterator().asScala.drop(1).toList
+      else List.empty[Path]
+    )
 
   override def validate(path: Path): RIO[BaseEnv, Unit] = {
     if (path.iterator().asScala.length > maxDepth) {


### PR DESCRIPTION
Thanks for your greate work on this excellent project😃!!!

Problem reproduction steps:
1. download latest polynote-dist.tar.gz from https://github.com/polynote/polynote/releases/tag/0.3.11
2. install polynote refer as the documentation: https://polynote.org/docs/01-installation.html and start it.
3. open home page in brower: `http://ip:8192` , after the page has been loaded, the server console shows exception stack trace:
**/data/polynote is the dir where I extract the tar file.**
```java
[ERROR]   (Logged from SocketSession.scala:77)
   |     java.nio.file.NoSuchFileException: /data/polynote/notebooks
   |     sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
   |     sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
   |     sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
   |     sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55)
   |     sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:144)
   |     sun.nio.fs.LinuxFileSystemProvider.readAttributes(LinuxFileSystemProvider.java:99)
   |     java.nio.file.Files.readAttributes(Files.java:1737)
   |     java.nio.file.FileTreeWalker.getAttributes(FileTreeWalker.java:225)
   |     java.nio.file.FileTreeWalker.visit(FileTreeWalker.java:276)
   |     java.nio.file.FileTreeWalker.walk(FileTreeWalker.java:322)
   |     java.nio.file.FileTreeIterator.<init>(FileTreeIterator.java:72)
   |     java.nio.file.Files.walk(Files.java:3574)
   |     polynote.server.repository.fs.LocalFilesystem$$anonfun$list$1.apply(LocalFilesystem.scala:88)
   |     polynote.server.repository.fs.LocalFilesystem$$anonfun$list$1.apply(LocalFilesystem.scala:88)
   |     zio.internal.FiberContext.evaluateNow(FiberContext.scala:458)
   |     zio.internal.FiberContext.zio$internal$FiberContext$$run$body$2(FiberContext.scala:687)
   |     zio.internal.FiberContext$$anonfun$12.run(FiberContext.scala:687)
   |     java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
   |     java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
   |     java.lang.Thread.run(Thread.java:748)
```
Running polynote for the first time, asthe directory noteboos does not exist, `FileBasedRepository.FileNotebookRef.listNotebooks` will throw exception.

**I try to fix this by check where the notebook dir exist, and test it ok in my env.**
**Please help me to review it, Thanks a lot😀**