### PR TITLE
fix repoen Preferences s cannot swith theme bug.

### DIFF
--- a/polynote-frontend/polynote/main.ts
+++ b/polynote-frontend/polynote/main.ts
@@ -62,8 +62,3 @@ export function setTheme(theme: string) {
 
 // set the initial theme based on preferences
 setTheme(preferences.get("Theme").value as string);
-
-// change the theme when the preference is changed
-preferences.addPreferenceListener("Theme", (oldValue, newValue) => {
-    setTheme(newValue.value as string);
-});

--- a/polynote-frontend/polynote/ui/component/about.ts
+++ b/polynote-frontend/polynote/ui/component/about.ts
@@ -170,6 +170,11 @@ export class About extends FullScreenModal {
         }
         storageInfoEl.appendChild(storageTable);
 
+        // bind theme switch listener
+        preferences.addPreferenceListener("Theme", (oldValue, newValue) => {
+            setTheme(newValue.value as string);
+        });
+        
         return el;
     }
 


### PR DESCRIPTION
reproduce:
Open polynote index html then click `view ui preferences `-> `Preferences` -> `Theme drop-box`， click switch between the light and dark themes, and then close the preferences window and reopen, repeat the switch Theme operation, and you will see that the switch does not take effect.
![problem](https://user-images.githubusercontent.com/52202080/92331561-2be8b900-f0aa-11ea-9446-ea63c79ffdcc.gif)

reason:
There is a global class instance in JS: `preference`. When the `ui preference page` is opened for the first time, this class is bound to the listener event for theme switching, but when the page is closed, the `clear()` method of the `Storage` class will be called , causing the preference listener to be cleared.  When the `ui preference page` is opened again, the listener event for theme switching is not re-bound.

fix:
The reason is clear, but I'm not sure there's a better way to handle it. Special treatment can be done in the clear method in the Storage class without clearing the preference for binding events, but this is not elegant and may introduce problems. I still think the perference class should be re-bound to the event when the page is opened. Do you have any good Suggestions?

Manual test result：
![after modified](https://user-images.githubusercontent.com/52202080/92331811-da412e00-f0ab-11ea-9e1d-e0f5b49cc322.gif)


