### PR TITLE
polynote 0.3.12,any Python script below Python3.7 can not execute

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/python/PythonInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/python/PythonInterpreter.scala
@@ -208,7 +208,7 @@ class PythonInterpreter private[python] (
   def init(state: State): RIO[InterpreterEnv, State] = for {
     globals <- getValue("globals().copy()")
     supportStatus <- isFutureAnnotationsSupported
-    _ <- exec(setup(supportStatus))
+    _       <- exec(setup(supportStatus))
     _       <- exec(matplotlib)
     scope   <- populateGlobals(state)
     _       <- jep { _ =>


### PR DESCRIPTION
browser:chrome
polynote: 0.3.12
python:3.6.8

polynote:0.3.11works fine.

![python error](https://user-images.githubusercontent.com/52202080/95484169-b599e800-09c2-11eb-8e28-0d394559d536.png)

pr #951 add new import `from __future__ import annotations` 
as shows in https://www.python.org/dev/peps/pep-0563/   This feature requires the Python version to be more than 3.7, and a direct error will be reported if using Python 3.6.X

as `from __future__ import annotations` must be at the begin of the py file, we canot check in the python script like below:
```python
import sys
if sys.version_info > (3,7):
    from __future__ import annotations
```
 I try to  check the python version in the scala code 
then in the setup metod use a bool variable to determine wheather the import sentence should be add or not.


