### PR TITLE
Add Java8 compile flag

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/ScalaCompiler.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/ScalaCompiler.scala
@@ -659,6 +659,7 @@ object ScalaCompiler {
     val cp = classPath ++ requiredPaths
 
     val settings = initial.copy()
+    settings.target.value = "jvm-1.8" // set Java8 by default
     settings.classpath.append(cp.map(_.getCanonicalPath).mkString(File.pathSeparator))
     settings.Yrangepos.value = true
     try {


### PR DESCRIPTION
Add default compile flag to allow Java8+ feature package imported for polynote.

Tested with build from source and `sbt dist` package. Looks good