### PR TITLE
Create py4j gateway on jep thread

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/python/PythonInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/python/PythonInterpreter.scala
@@ -53,7 +53,11 @@ class PythonInterpreter private[python] (
     }
 
     def hasAttribute(obj: PythonObject, name: String): Boolean = run {
-      hasAttr(obj.unwrap, name)
+      try {
+        hasAttr(obj.unwrap, name)
+      } catch  {
+        case _: JepException => false
+      }
     }
 
     def asScalaList(obj: PythonObject): List[PythonObject] = run {

--- a/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
@@ -134,7 +134,11 @@ class PySparkInterpreter(
     .readTimeout(GatewayServer.DEFAULT_READ_TIMEOUT)
     .customCommands(null)
 
-  private def startPySparkGateway(spark: SparkSession, doAuth: Boolean) = effectBlocking {
+  /**
+    * Start the py4j gateway, ensuring it's run on the Jep thread so it sees the proper classloader.
+    */
+  private def startPySparkGateway(spark: SparkSession, doAuth: Boolean) = jep {
+    _ =>
     val builder = if (doAuth) {
       // use try here just to be extra careful
       try gwBuilder.authToken(py4jToken) catch {


### PR DESCRIPTION
This ensures that py4j imports use the proper classloader, allowing py4j to see added jars (useful for some pyspark libraries that expect to be able to access dependencies through py4j)