### PR TITLE
Sandbox HTML output in an iframe

### DIFF
--- a/polynote-frontend/build_style
+++ b/polynote-frontend/build_style
@@ -8,3 +8,4 @@ build_less () {
 build_less "styles"
 build_less "colors-light"
 build_less "colors-dark"
+build_less "content"

--- a/polynote-frontend/polynote/ui/component/notebook/cell.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/cell.ts
@@ -1088,6 +1088,8 @@ class CodeCellOutput extends Disposable {
     }
 
     private clearResults() {
+        // notify iframes that they'll be removed
+        [...this.resultTabs.getElementsByTagName('iframe')].forEach(frame => frame.dispatchEvent(new CustomEvent('dispose')));
         this.resultTabs.innerHTML = '';
         this.cellResultMargin.innerHTML = '';
     }


### PR DESCRIPTION
Sandbox HTML output in an iframe.

This is to prevent malicious HTML from accessing the notebook or communicating with the server.

An attempt is made to keep the iframe sized to its content so that it looks like it's reasonably inline. But this is tricky and will probably need some refinement as issues are discovered.