### PR TITLE
Bring back addPyFile and attempt to set PYTHONPATH properly

### DIFF
--- a/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
@@ -242,12 +242,19 @@ class PySparkInterpreter(
            |if spark_py_libs:
            |    dependencies += [Path(x) for x in spark_py_libs]
            |
+           |# Unfortunately pyspark's `sc.addPyFile` modifies the sys.path, but we don't want that to happen in this case.
+           |# so, we'll just add the files ourselves.
+           |def addPyFile(path):
+           |    sc.addFile(path)
+           |    filename = os.path.basename(path)
+           |    sc._python_includes.append(filename)
+           |
            |for dep in dependencies:
            |    # we need to rename the wheels to zips because that's what spark wants... sigh
            |    as_zip = dep.with_suffix('.zip')
            |    if not as_zip.exists():
            |        shutil.copy(dep, as_zip)
-           |    sc.addPyFile(str(as_zip))
+           |    addPyFile(str(as_zip))
            |""".stripMargin)
   }
 

--- a/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
@@ -320,9 +320,7 @@ object PySparkInterpreter {
       val cfg = pysparkModules.fold(config) {
         files =>
           val pythonPath = files.map(f => s"./${f.getFileName}").mkString(":")
-          val augmentedPythonPath = config.get("spark.executorEnv.PYTHONPATH").map(env => s"$env:$pythonPath").getOrElse(pythonPath)
-
-          config ++ Map("spark.executorEnv.PYTHONPATH" -> augmentedPythonPath)
+          config ++ Map("spark.executorEnv.PYTHONPATH" -> pythonPath)
       }
       super.sparkConfig(cfg)
     }


### PR DESCRIPTION
Two changes in this PR. 

1. We used to add all the `pip` dependencies that users specified to the Spark context using `addPyFile` (see https://github.com/polynote/polynote/commit/17b084b0f15200fc29c2c3c03ebeccd069dc0648#diff-67c86e58452efd51d59583b6fe660dbc0aad32856b4cdff38261ce832db31cf2) but unfortunately this code was lost in a merge conflict a long time ago (and no one noticed 😓 )
2. We need to ensure that `spark.executorEnv.PYTHONPATH` is set properly under certain circumstances. This is not fully implemented in this PR though (just setting `PYTHONPATH`). 