### PR TITLE
Bumped coursier to 2.0.0-RC5-6.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val sparkVersion: SettingKey[String] = settingKey("Spark version")
 val versions = new {
   val fs2        = "1.0.5"
   val catsEffect = "2.0.0"
-  val coursier   = "2.0.0-RC2-6"
+  val coursier   = "2.0.0-RC5-6"
   val zio        = "1.0.2"
   val zioInterop = "2.0.0.0-RC12"
 }
@@ -19,8 +19,8 @@ val versions = new {
 def nativeLibraryPath = s"${sys.env.get("JAVA_LIBRARY_PATH") orElse sys.env.get("LD_LIBRARY_PATH") orElse sys.env.get("DYLD_LIBRARY_PATH") getOrElse "."}:."
 
 val commonSettings = Seq(
-  scalaVersion := "2.11.12",
-  crossScalaVersions := Seq("2.11.12", "2.12.10"),
+  scalaVersion := "2.12.12",
+  crossScalaVersions := Seq("2.11.12", "2.12.12"),
   organization := "org.polynote",
   publishMavenStyle := true,
   homepage := Some(url("https://polynote.org")),


### PR DESCRIPTION
Fixes #1003 and #998. Coursier `2.0.0-RC5-6` is the latest release still supporting Scala 2.11. Once polynote authors agree to drop 2.11, we can update to `coursier 2.0.7`.