### PR TITLE
update to new jedi version, make CI requirements.txt stricter

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/python/PythonInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/python/PythonInterpreter.scala
@@ -125,7 +125,8 @@ class PythonInterpreter private[python] (
   } yield resState
 
   private def extractParams(jep: Jep, jediDefinition: PyObject): List[(String, String)] = {
-    val getParams = jep.getValue("lambda jediDef: list(map(lambda p: [p.name, next(iter(map(lambda t: t.name, p.infer())), None)], jediDef.params))", classOf[PyCallable])
+    // TODO: this lambda is getting a bit unwieldy.
+    val getParams = jep.getValue("lambda jediDef: list(map(lambda p: [p.name, next(iter(map(lambda t: t.name, p.infer())), None)], sum([s.params for s in jediDef.get_signatures()], [])))", classOf[PyCallable])
     getParams.callAs(classOf[java.util.List[java.util.List[String]]], jediDefinition).asScala.map {
       tup =>
         val name = tup.get(0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 virtualenv
 ipython
 nbconvert
-jedi>=0.16.0
 numpy
 pandas
-jep==3.9.0
+jedi==0.18.*
+jep==3.9.*


### PR DESCRIPTION
Our requirements.txt wasn't strict enough when specifying jedi versions, so [the latest release](https://github.com/davidhalter/jedi/blob/master/CHANGELOG.rst#0180-2020-12-25) broke our CI build. 

This PR contains a fix for the jedi update as well as stricter versioning for that dependency. 

This stricter versioning is a tradeoff between CI stability and catching backwards-incompatible releases of our dependencies quickly. I think in this case we can err on the side of CI stability and be able to address dependency compatibility changes at our leisure. 