### PR TITLE
extracts zeppelin notebook name from json rather than using file path

### DIFF
--- a/polynote-server/src/main/scala/polynote/server/repository/format/ipynb/ZeppelinConverter.scala
+++ b/polynote-server/src/main/scala/polynote/server/repository/format/ipynb/ZeppelinConverter.scala
@@ -30,7 +30,8 @@ class ZeppelinToIpynbFormat extends NotebookFormat {
     } yield {
       val nbConfig = Option(NotebookConfig.empty.copy(sparkConfig = config.spark.map(SparkConfig.toMap)))
       val content = JupyterNotebook.toNotebook(zep.toJupyterNotebook).copy(config = nbConfig)
-      content.toNotebook(s"$noExtPath.ipynb") // Note the extension being overridden to ipynb here.
+      val nbName = if (zep.name == "") noExtPath else zep.name
+      content.toNotebook(s"$nbName.ipynb") // Note the extension being overridden to ipynb here.
     }
   }
 

--- a/polynote-server/src/test/scala/polynote/server/repository/format/ipynb/ZeppelinFormatSpec.scala
+++ b/polynote-server/src/test/scala/polynote/server/repository/format/ipynb/ZeppelinFormatSpec.scala
@@ -137,7 +137,7 @@ class ZeppelinFormatSpec extends FreeSpec with Matchers with ConfiguredZIOSpec {
 
       nb.cells.head.language shouldEqual "scala"
       nb.cells(1).language shouldEqual "scala"
-      nb shouldEqual Notebook("dummy.ipynb", List(
+      nb shouldEqual Notebook("My Zeppelin notebook.ipynb", List(
         NotebookCell(0, "scala", "some scala code", List(ResultValue("Out", "", List(StringRepr("some results")), 0, (), scala.reflect.runtime.universe.NoType, None))),
         NotebookCell(1, "scala", "more scala code", List(ResultValue("Out", "", List(StringRepr("more scala results")), 1, (), scala.reflect.runtime.universe.NoType, None))),
         NotebookCell(2, "scala", "", List.empty[ResultValue])


### PR DESCRIPTION
Resolves https://github.com/polynote/polynote/issues/975.

Extracts the notebook name from the Zeppelin JSON definition on import and uses this to name the generated `.ipynb` file. Preserves any directory structure from `/`'s in the name.

If the Zeppelin Notebook name has been left blank, this falls back to using the Zeppelin notebook path to name the new file (avoids creating notebooks named `.ipynb)`. 