### PR TITLE
Add JVM args config

### DIFF
--- a/polynote-frontend/polynote/data/data.ts
+++ b/polynote-frontend/polynote/data/data.ts
@@ -151,7 +151,7 @@ export class NotebookConfig {
         optional(SparkPropertySet.codec),
         optional(mapCodec(uint16, str as Codec<string>, str)),
         optional(str),
-        optional(str)
+        optional(arrayCodec(uint8, str))
     ).to(NotebookConfig);
     static unapply(inst: NotebookConfig): ConstructorParameters<typeof NotebookConfig> {
         return [inst.dependencies, inst.exclusions, inst.repositories, inst.sparkConfig, inst.sparkTemplate, inst.env, inst.scalaVersion, inst.jvmArgs];
@@ -161,7 +161,7 @@ export class NotebookConfig {
                 readonly repositories?: RepositoryConfig[], readonly sparkConfig?: Record<string, string>,
                 readonly sparkTemplate?: SparkPropertySet,
                 readonly env?: Record<string, string>,
-                readonly scalaVersion?: string, readonly jvmArgs?: string) {
+                readonly scalaVersion?: string, readonly jvmArgs?: string[]) {
         Object.freeze(this);
     }
 

--- a/polynote-frontend/polynote/data/data.ts
+++ b/polynote-frontend/polynote/data/data.ts
@@ -150,17 +150,18 @@ export class NotebookConfig {
         optional(mapCodec(uint16, str as Codec<string>, str)),
         optional(SparkPropertySet.codec),
         optional(mapCodec(uint16, str as Codec<string>, str)),
+        optional(str),
         optional(str)
     ).to(NotebookConfig);
     static unapply(inst: NotebookConfig): ConstructorParameters<typeof NotebookConfig> {
-        return [inst.dependencies, inst.exclusions, inst.repositories, inst.sparkConfig, inst.sparkTemplate, inst.env];
+        return [inst.dependencies, inst.exclusions, inst.repositories, inst.sparkConfig, inst.sparkTemplate, inst.env, inst.scalaVersion, inst.jvmArgs];
     }
 
     constructor(readonly dependencies?: Record<string, string[]>, readonly exclusions?: string[],
                 readonly repositories?: RepositoryConfig[], readonly sparkConfig?: Record<string, string>,
                 readonly sparkTemplate?: SparkPropertySet,
                 readonly env?: Record<string, string>,
-                readonly scalaVersion?: string) {
+                readonly scalaVersion?: string, readonly jvmArgs?: string) {
         Object.freeze(this);
     }
 

--- a/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
@@ -37,7 +37,7 @@ export class NotebookConfigEl extends Disposable {
         const dependencies = new Dependencies(configState.view("dependencies"));
         const exclusions = new Exclusions(configState.view("exclusions"));
         const resolvers = new Resolvers(configState.view("repositories"));
-        const serverTemplatesHandler = ServerStateHandler.view("sparkTemplates", configState);
+        const serverTemplatesHandler = ServerStateHandler.view("sparkTemplates").disposeWith(configState);
         const spark = new SparkConf(configState.view("sparkConfig"), configState.view("sparkTemplate"), serverTemplatesHandler);
         const kernel = new KernelConf(configState);
 

--- a/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
@@ -24,6 +24,7 @@ import {
 } from "../../../data/data";
 import {KernelStatusString} from "../../../data/messages";
 import {NBConfig} from "../../../state/notebook_state";
+import {joinQuotedArgs, parseQuotedArgs} from "../../../util/helpers";
 import {ServerStateHandler} from "../../../state/server_state";
 
 export class NotebookConfigEl extends Disposable {
@@ -436,7 +437,7 @@ class KernelConf extends Disposable {
             this.container = div(['env-list'], []),
             h4([], ['Additional JVM arguments:']),
             para([], ['Extra command-line arguments to the JVM, e.g. ', tag('code', [], {}, '"-Dmy.prop=a value" -Xmx200m')]),
-            this.jvmArgsInput = textbox(['jvm-args'], "JVM Arguments", jvmArgsHandler.state).attr("size", "64")
+            this.jvmArgsInput = textbox(['jvm-args'], "JVM Arguments", joinQuotedArgs(jvmArgsHandler.state)).attr("size", "64")
         ])
 
         const setEnv = (env: Record<string, string> | undefined) => {
@@ -452,7 +453,7 @@ class KernelConf extends Disposable {
         }
         setEnv(envHandler.state);
         envHandler.addObserver(env => setEnv(env));
-        jvmArgsHandler.addObserver(str => this.jvmArgsInput.value = str || "");
+        jvmArgsHandler.addObserver(strs => this.jvmArgsInput.value = joinQuotedArgs(strs) || "");
     }
 
     private addEnv(item?: {key: string, val: string}) {
@@ -488,8 +489,11 @@ class KernelConf extends Disposable {
         }, {})
     }
 
-    get jvmArgs(): string | undefined {
-        return this.jvmArgsInput.value || undefined;
+    get jvmArgs(): string[] | undefined {
+        if (this.jvmArgsInput.value) {
+            return parseQuotedArgs(this.jvmArgsInput.value);
+        }
+        return undefined;
     }
 
     get scalaVersion(): string | undefined {

--- a/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
@@ -8,7 +8,7 @@ import {
     h4,
     iconButton,
     para,
-    span,
+    span, tag,
     TagElement,
     textbox
 } from "../../tags";
@@ -434,7 +434,8 @@ class KernelConf extends Disposable {
             this.scalaVersionInput = dropdown(['scala-version'], {"": "Default", ...availableScalaVersions}, scalaVersionHandler.state || ""),
             h4([], 'Environment variables:'),
             this.container = div(['env-list'], []),
-            para([], ['Additional JVM arguments:']),
+            h4([], ['Additional JVM arguments:']),
+            para([], ['Extra command-line arguments to the JVM, e.g. ', tag('code', [], {}, '"-Dmy.prop=a value" -Xmx200m')]),
             this.jvmArgsInput = textbox(['jvm-args'], "JVM Arguments", jvmArgsHandler.state).attr("size", "64")
         ])
 

--- a/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
@@ -33,15 +33,15 @@ export class NotebookConfigEl extends Disposable {
         super()
 
         const configState = stateHandler.view("config");
-        const dependencies = new Dependencies(configState.view("dependencies"))
-        const exclusions = new Exclusions(configState.view("exclusions"))
-        const resolvers = new Resolvers(configState.view("repositories"))
-        const serverTemplatesHandler = ServerStateHandler.view("sparkTemplates");
-        const spark = new SparkConf(configState.view("sparkConfig"), configState.view("sparkTemplate"), serverTemplatesHandler)
-        const env = new EnvConf(configState.view("env"))
+        const dependencies = new Dependencies(configState.view("dependencies"));
+        const exclusions = new Exclusions(configState.view("exclusions"));
+        const resolvers = new Resolvers(configState.view("repositories"));
+        const serverTemplatesHandler = ServerStateHandler.view("sparkTemplates", configState);
+        const spark = new SparkConf(configState.view("sparkConfig"), configState.view("sparkTemplate"), serverTemplatesHandler);
+        const kernel = new KernelConf(configState);
 
         const saveButton = button(['save'], {}, ['Save & Restart']).click(evt => {
-            const conf = new NotebookConfig(dependencies.conf, exclusions.conf, resolvers.conf, spark.conf, spark.template, env.conf);
+            const conf = new NotebookConfig(dependencies.conf, exclusions.conf, resolvers.conf, spark.conf, spark.template, kernel.envVars, kernel.scalaVersion, kernel.jvmArgs);
             this.el.classList.remove("open");
             stateHandler.updateField("config", () => setValue(conf))
         })
@@ -53,7 +53,7 @@ export class NotebookConfigEl extends Disposable {
                 resolvers.el,
                 exclusions.el,
                 spark.el,
-                env.el,
+                kernel.el,
                 div(['controls'], [
                     saveButton,
                     button(['cancel'], {}, ['Cancel']).click(evt => {
@@ -332,7 +332,7 @@ class SparkConf extends Disposable {
         this.container = div(['spark-config-list'], []);
 
         this.el = div(['notebook-spark-config', 'notebook-config-section'], [
-            h3([], ['Spark Config']),
+            h3([], ['Spark configuration']),
             para([], ['Set Spark configuration for this notebook here. Please note that it is possible that your environment may override some of these settings at runtime :(']),
             div([], [h4([], ['Spark template:']), this.templateEl, h4([], ['Spark properties:']), this.container])
         ])
@@ -408,16 +408,34 @@ class SparkConf extends Disposable {
 
 }
 
-class EnvConf extends Disposable {
+class KernelConf extends Disposable {
     readonly el: TagElement<"div">;
     private container: TagElement<"div">;
+    private jvmArgsInput: TagElement<"input">;
+    private scalaVersionInput: DropdownElement;
 
-    constructor(envHandler: StateView<Record<string, string> | undefined>) {
-        super()
+    constructor(configState: StateView<NotebookConfig>) {
+        super();
+        const envHandler = configState.view("env");
+        const jvmArgsHandler = configState.view("jvmArgs");
+        const scalaVersionHandler = configState.view("scalaVersion");
+
+        // TODO: this could come from the server
+        const availableScalaVersions = {
+            "2.11": "2.11",
+            "2.12": "2.12"
+        }
+
         this.el = div(['notebook-env', 'notebook-config-section'], [
-            h3([], ['Environment Variables']),
-            para([], ['Set environment variables here. Please note this is only supported when kernels are launched as a subprocess (default).']),
-            this.container = div(['env-list'], [])
+            h3([], ['Kernel configuration']),
+            para([], ['Please note this is only supported when kernels are launched as a subprocess (default).']),
+            h4([], 'Scala version:'),
+            para([], `If using Spark, the Scala version must match that of your Spark installation. "Default" will use Polynote's configured Scala version, or auto-detect the appropriate version.`),
+            this.scalaVersionInput = dropdown(['scala-version'], {"": "Default", ...availableScalaVersions}, scalaVersionHandler.state || ""),
+            h4([], 'Environment variables:'),
+            this.container = div(['env-list'], []),
+            para([], ['Additional JVM arguments:']),
+            this.jvmArgsInput = textbox(['jvm-args'], "JVM Arguments", jvmArgsHandler.state).attr("size", "64")
         ])
 
         const setEnv = (env: Record<string, string> | undefined) => {
@@ -431,8 +449,9 @@ class EnvConf extends Disposable {
                 this.addEnv()
             }
         }
-        setEnv(envHandler.state)
-        envHandler.addObserver(env => setEnv(env)).disposeWith(this)
+        setEnv(envHandler.state);
+        envHandler.addObserver(env => setEnv(env));
+        jvmArgsHandler.addObserver(str => this.jvmArgsInput.value = str || "");
     }
 
     private addEnv(item?: {key: string, val: string}) {
@@ -461,10 +480,18 @@ class EnvConf extends Disposable {
         this.container.appendChild(row)
     }
 
-    get conf() {
+    get envVars() {
         return Array.from(this.container.children).reduce<Record<string, string>>((acc, row: HTMLDivElement & {data: {key: string, val: string}}) => {
             if (row.data.key) acc[row.data.key] = row.data.val
             return acc
         }, {})
+    }
+
+    get jvmArgs(): string | undefined {
+        return this.jvmArgsInput.value || undefined;
+    }
+
+    get scalaVersion(): string | undefined {
+        return this.scalaVersionInput.getSelectedValue() || undefined;
     }
 }

--- a/polynote-frontend/polynote/util/helpers.test.ts
+++ b/polynote-frontend/polynote/util/helpers.test.ts
@@ -13,9 +13,11 @@ import {
     diffArray,
     equalsByKey,
     isEmpty,
-    isObject, linePosAt,
+    isObject,
+    linePosAt,
     mapSome,
     mapValues,
+    parseQuotedArgs,
     partition,
     removeKeys,
     unzip,
@@ -469,6 +471,20 @@ describe("arrayStartsWith", () => {
                 expect(arrayStartsWith(arr, arrStart)).toBeTruthy()
             })
         )
+    })
+})
+
+describe("parseQuotedArgs", () => {
+    it ("parses simple space-separated arguments", () => {
+        expect(parseQuotedArgs(`first second third`)).toEqual(['first', 'second', 'third'])
+    })
+
+    it ("allows quoting things", () => {
+        expect(parseQuotedArgs(`first "two words" third`)).toEqual(['first', 'two words', 'third'])
+    })
+
+    it ("allows escaping things inside quotes", () => {
+        expect(parseQuotedArgs(`first "there is an \\" escaped quote" third`)).toEqual(['first', `there is an " escaped quote`, 'third'])
     })
 })
 

--- a/polynote-frontend/polynote/util/helpers.ts
+++ b/polynote-frontend/polynote/util/helpers.ts
@@ -331,6 +331,59 @@ export function positionIn(str: string, line: number, column: number): number {
 }
 
 //****************
+//* String Helpers
+//****************
+
+export function parseQuotedArgs(args: string): string[] {
+    function parseQuoted(rest: string): [string, string] {
+        const match = /^((?:[^"\\]|\\.)*)"/.exec(rest);
+        if (!match || !match[1])
+            return [rest, ""];
+        const arg = match[1];
+        return [arg.replace('\\"', '"'), rest.substr(arg.length + 1)]
+    }
+
+    function parseUnquoted(rest: string): [string, string] {
+        const nextSpace = rest.indexOf(' ');
+        if (nextSpace === -1)
+            return [rest, ""];
+        return [rest.substring(0, nextSpace), rest.substring(nextSpace + 1)];
+    }
+
+    function parseNext(rest: string): [string, string] {
+        rest = rest.trimLeft();
+        if (!rest)
+            return ["", ""];
+        if (rest.charAt(0) === '"')
+            return parseQuoted(rest.substring(1));
+        return parseUnquoted(rest);
+    }
+
+    const result = [];
+    let remaining = args;
+    while (remaining.length) {
+        const next = parseNext(remaining);
+        if (next[0])
+            result.push(next[0]);
+        remaining = next[1];
+    }
+    return result;
+}
+
+
+function quoted(str: string | undefined): string {
+    if (str && (str.indexOf('"') !== -1 || str.indexOf(' ') !== -1)) {
+        return ['"', str.replace('\\', '\\\\').replace('"', '\\"'), '"'].join('');
+    } else {
+        return str || "";
+    }
+}
+
+export function joinQuotedArgs(strs: string[] | undefined): string | undefined {
+    return strs?.map(quoted).join(' ')
+}
+
+//****************
 //* Other Helpers
 //****************
 

--- a/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
@@ -48,7 +48,8 @@ object Mount {
 final case class KernelConfig(
   listen: Option[String] = None,
   portRange: Option[Range] = None,
-  scalaVersion: Option[String] = None
+  scalaVersion: Option[String] = None,
+  jvmArgs: Option[String] = None
 )
 
 object KernelConfig {

--- a/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
@@ -43,13 +43,11 @@ object Mount {
   implicit val decoder: Decoder[Mount] = deriveConfigDecoder[Mount]
 }
 
-
-
 final case class KernelConfig(
   listen: Option[String] = None,
   portRange: Option[Range] = None,
   scalaVersion: Option[String] = None,
-  jvmArgs: Option[String] = None
+  jvmArgs: Option[Seq[String]] = None
 )
 
 object KernelConfig {

--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/DeploySparkSubmit.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/DeploySparkSubmit.scala
@@ -56,11 +56,13 @@ object DeploySparkSubmit extends DeployCommand {
       "java.library.path"   -> libraryPath
     )
 
-    val allDriverOptions =
+    val allDriverOptions = {
+      nbConfig.jvmArgs.toList ++
       sparkConfig.get("spark.driver.extraJavaOptions").toList ++
       javaOptions.toList.map {
         case (name, value) => s"-D$name=$value"
       } mkString " "
+    }
 
     val additionalJars = classPath.toList.filter(_.getFile.endsWith(".jar"))
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/transport.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/transport.scala
@@ -21,7 +21,6 @@ import zio.blocking.{Blocking, effectBlocking, effectBlockingCancelable, effectB
 import zio.{Cause, Promise, RIO, Schedule, Task, URIO, ZIO, system => ZSystem}
 import zio.duration.{DurationOps, durationInt, Duration => ZDuration}
 import zio.interop.catz._
-import zio.system.{env, property}
 
 import scala.concurrent.TimeoutException
 import scala.reflect.{ClassTag, classTag}
@@ -359,11 +358,11 @@ object SocketTransport {
 
     // For inheriting the classpath of the server process – this is mainly so that you can run from the IDE
     // without having built the distribution.
-    private def currentClasspath: URIO[zio.system.System, List[Path]] = zio.system.property("java.class.path").some
+    private def currentClasspath: URIO[zio.system.System, List[Path]] = ZSystem.property("java.class.path").some
       .map(_.split(File.pathSeparatorChar).toList.map(path => Paths.get(path)))
       .orElse(ZIO.succeed(Nil))
 
-    private def buildClassPath(scalaVersion: String): RIO[BaseEnv, Seq[Path]] = zio.system.env("POLYNOTE_INHERIT_CLASSPATH").flatMap {
+    private def buildClassPath(scalaVersion: String): RIO[BaseEnv, Seq[Path]] = ZSystem.env("POLYNOTE_INHERIT_CLASSPATH").flatMap {
       case None =>
         for {
           deps    <- listJarsForVersion("deps", scalaVersion).orElse(currentClasspath)
@@ -420,41 +419,10 @@ object SocketTransport {
       */
     class DeployJava[KernelFactory <: Kernel.Factory.Service : ClassTag] extends DeployCommand {
       private def findJava: URIO[BaseEnv, String] =
-        property("java.home").mapError(_.getMessage).someOrFail("No java.home property is set")
+        ZSystem.property("java.home").mapError(_.getMessage).someOrFail("No java.home property is set")
           .map(home => Paths.get(home, "bin", "java").toString)
           .tapError(err => Logging.warn("Couldn't find java executable; will just use 'java' ($err)"))
           .orElse(ZIO.succeed("java"))
-
-      // parse a JVM args string into a list of args
-      private def parseJVMArgs(str: String): List[String] = {
-        val searchQuoted = raw"""^((?:[^"\\]|\\.)*)"""".r
-
-        def parseQuoted(rest: String): (String, String) = searchQuoted.findFirstMatchIn(rest) match {
-          case None    => (rest, "")
-          case Some(m) => (m.group(1), rest.drop(m.end))
-        }
-
-        def parseUnquoted(rest: String): (String, String) = rest.indexOf(' ') match {
-          case -1 => (rest, "")
-          case n  => (rest.take(n), rest.drop(n + 1).dropWhile(_ == ' '))
-        }
-
-        def parseNext(rest: String): (String, String) = rest match {
-          case ""                     => ("", "")
-          case str if str.head == '"' => parseQuoted(str.tail)
-          case str                    => parseUnquoted(str)
-        }
-
-        @tailrec
-        def parse(rest: String, accum: List[String]): List[String] = rest match {
-          case ""   => accum.reverse
-          case rest =>
-            val (arg, remainder) = parseNext(rest)
-            parse(remainder, arg :: accum)
-        }
-
-        parse(str, Nil)
-      }
 
       override def apply(serverAddress: InetSocketAddress, classPath: Seq[Path]): RIO[BaseEnv with Config with CurrentNotebook, Seq[String]] = {
         for {
@@ -465,7 +433,7 @@ object SocketTransport {
             .filterNot(_.isEmpty)
             .mkString(File.pathSeparator)
 
-          val javaArgs = notebookConfig.jvmArgs.toList.flatMap(parseJVMArgs)
+          val javaArgs = notebookConfig.jvmArgs.toList.flatten
 
           java :: "-cp" :: fullClassPath :: javaArgs :::
             classOf[RemoteKernelClient].getName ::

--- a/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
+++ b/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
@@ -86,7 +86,8 @@ final case class NotebookConfig(
   sparkConfig: Option[ShortMap[String, String]],
   sparkTemplate: Option[SparkPropertySet],
   env: Option[ShortMap[String, String]],
-  scalaVersion: Option[String] = None
+  scalaVersion: Option[String] = None,
+  jvmArgs: Option[String] = None
 )
 
 object NotebookConfig {
@@ -112,7 +113,8 @@ object NotebookConfig {
         default     <- propSets.find(_.name == defaultName)
       } yield default,
       env = Option(config.env),
-      scalaVersion = config.kernel.scalaVersion
+      scalaVersion = config.kernel.scalaVersion,
+      jvmArgs = config.kernel.jvmArgs
     )
   }
 

--- a/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
+++ b/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
@@ -87,7 +87,7 @@ final case class NotebookConfig(
   sparkTemplate: Option[SparkPropertySet],
   env: Option[ShortMap[String, String]],
   scalaVersion: Option[String] = None,
-  jvmArgs: Option[String] = None
+  jvmArgs: Option[TinyList[String]] = None
 )
 
 object NotebookConfig {
@@ -114,7 +114,7 @@ object NotebookConfig {
       } yield default,
       env = Option(config.env),
       scalaVersion = config.kernel.scalaVersion,
-      jvmArgs = config.kernel.jvmArgs
+      jvmArgs = config.kernel.jvmArgs.map(_.toList)
     )
   }
 


### PR DESCRIPTION
(Includes #1015)

- Add config for JVM args (fixes #695)
- Add UI for Scala version and JVM args
- Don't inherit the whole classpath of server process (unless `POLYNOTE_INHERIT_CLASSPATH` env is set, or listing the required distribution JARs fails – to allow running from IDE)