### PR TITLE
Fix notebook load regression

### DIFF
--- a/polynote-frontend/polynote/data/messages.ts
+++ b/polynote-frontend/polynote/data/messages.ts
@@ -80,6 +80,7 @@ export class LoadNotebook extends Message {
 }
 
 
+// NOTE: maps to backend's `Notebook` message
 export class NotebookCells extends Message {
     static codec =
         combined(shortStr, arrayCodec(uint16, NotebookCell.codec), optional(NotebookConfig.codec)).to(NotebookCells);

--- a/polynote-frontend/polynote/messaging/comms.test.ts
+++ b/polynote-frontend/polynote/messaging/comms.test.ts
@@ -90,6 +90,27 @@ describe("SocketSession", () => {
         await expect(server).toReceiveMessage(encoded)
     })
 
+    test("can be opened after a previous client has closed", async () => {
+        const server = new WS('ws://localhost/socket');
+        const message = new LoadNotebook("test")
+        const encoded = Message.encode(message)
+
+        const client1 = createClient("socket")
+        await server.connected
+        expect(client1.queue.length).toEqual(0)
+
+        client1.send(message)
+        await expect(server).toReceiveMessage(encoded)
+        client1.close()
+
+        const client2 = createClient("socket")
+        await server.connected
+        expect(client2.queue.length).toEqual(0)
+
+        client2.send(message)
+        await expect(server).toReceiveMessage(encoded)
+    })
+
     test("enqueues messages sent while closed", async () => {
         const server = new WS('ws://localhost/socket');
         const client = createClient("socket")

--- a/polynote-frontend/polynote/messaging/comms.ts
+++ b/polynote-frontend/polynote/messaging/comms.ts
@@ -42,7 +42,7 @@ export class SocketSession extends EventTarget {
 
     static fromRelativeURL(relativeURL: string): SocketSession {
         const url = wsUrl(new URL(relativeURL, document.baseURI));
-        if (openSessions[url.href]) {
+        if (openSessions[url.href]?.socket) {
             return openSessions[url.href];
         }
         const session = new SocketSession(url)

--- a/polynote-frontend/polynote/messaging/dispatcher.ts
+++ b/polynote-frontend/polynote/messaging/dispatcher.ts
@@ -37,6 +37,9 @@ export abstract class MessageDispatcher<S, H extends StateHandler<S> = StateHand
         handler.onDispose.then(() => {
             this.socket.close()
         })
+        this.socket.onDispose.then(() => {
+            if (!this.isDisposed) this.dispose()
+        })
     }
 
     get state() {

--- a/polynote-frontend/polynote/messaging/receiver.ts
+++ b/polynote-frontend/polynote/messaging/receiver.ts
@@ -48,6 +48,13 @@ export class MessageReceiver<S> extends Disposable {
         super();
         this.socket = socket.fork(this);
         this.state = state.fork(this);
+
+        this.state.onDispose.then(() => {
+            this.socket.close()
+        })
+        this.socket.onDispose.then(() => {
+            if (!this.isDisposed) this.dispose()
+        })
     }
 
     protected receive<M extends messages.Message, C extends (new (...args: any[]) => M) & typeof messages.Message>(msgType: C, fn: (state: Readonly<S>,...args: ConstructorParameters<typeof msgType>) => UpdateOf<S>) {

--- a/polynote-frontend/polynote/state/socket_state.ts
+++ b/polynote-frontend/polynote/state/socket_state.ts
@@ -97,6 +97,7 @@ export class SocketStateHandler extends BaseHandler<SocketState> {
         socket.addEventListener('error', handleError);
 
         handler.onDispose.then(() => {
+            handler.close()
             socket.removeEventListener('open', setConnected);
             socket.removeEventListener('close', setDisconnected);
             socket.removeEventListener('error', handleError);

--- a/polynote-frontend/polynote/ui/component/tabs.ts
+++ b/polynote-frontend/polynote/ui/component/tabs.ts
@@ -33,7 +33,7 @@ export class Tabs extends Disposable {
                     }
                 })
             } else {
-                Object.keys(this.tabs).forEach(tab => this.remove(tab))
+                Object.keys(this.tabs).filter(t => t !== "home").forEach(tab => this.remove(tab))
             }
         }).disposeWith(this)
 


### PR DESCRIPTION
Fix a regression from #1016 where reopening a notebook didn't work. The problem was that closed SocketSessions weren't being cleaned up from the global state. 