### PR TITLE
Configurable Matplotlib output

### DIFF
--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -1221,16 +1221,6 @@ select {
         padding-left: 1em;
         padding-right: 1em;
       }
-
-      .htmltext {
-        max-width: 100%;
-        box-sizing: border-box;
-
-        img, svg {
-          width: 100%;
-        }
-      }
-
     }
   }
   &.viz {

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -1222,6 +1222,15 @@ select {
         padding-right: 1em;
       }
 
+      .htmltext {
+        max-width: 100%;
+        box-sizing: border-box;
+
+        img, svg {
+          width: 100%;
+        }
+      }
+
     }
   }
   &.viz {

--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/python/PythonInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/python/PythonInterpreter.scala
@@ -583,8 +583,7 @@ class PythonInterpreter private[python] (
       |            buf = io.BytesIO()
       |            self.canvas.figure.savefig(buf, format='png')
       |            buf.seek(0)
-      |            encoded = base64.b64encode(buf.getvalue()).decode('utf-8')
-      |            return f"<img class='matplotlib' src='data:image/png;base64,{encoded}'/>"
+      |            return base64.b64encode(buf.getvalue()).decode('utf-8')
       |
       |        def svg(self):
       |            # Save figure as SVG for display
@@ -592,22 +591,18 @@ class PythonInterpreter private[python] (
       |            buf = io.StringIO()
       |            self.canvas.figure.savefig(buf, format='svg')
       |            buf.seek(0)
-      |            return "<div class='matplotlib'>" + buf.getvalue() + "</div>"
+      |            return buf.getvalue()
       |
       |        def show(self):
-      |            html = None
       |            fmt = PolynoteBackend.output_format
       |            if fmt == 'svg':
-      |                html = self.svg()
+      |                kernel.display.content("image/svg", self.svg())
       |            elif fmt == 'png':
-      |                html = self.png()
+      |                kernel.display.content("image/png", self.png())
       |            else:
       |                print(f"PolynoteBackend: Unknown output format. Accepted values for PolynoteBackend.output_format are 'png' or 'svg' but got '{fmt}'. Defaulting to 'png'.",file=sys.stderr)
       |                sys.stderr.flush()
-      |                html = self.png()
-      |
-      |            # Display image as html
-      |            kernel.display.html(html)
+      |                kernel.display.content("image/png", self.png())
       |
       |
       |    @_Backend.export


### PR DESCRIPTION
* Matplotlib Output is now configurable. Users can choose between PNG
and SVG output (default is PNG).
* To set the default, execute `PolynoteBackend.output_format = 'png' # or 'svg'` in a
Python cell.
* Also fixes a bug where a duplicate figure would be plotted if a cell
was run twice.

Resolves #1037 