### PR TITLE
Bring back JVM args to non-Spark kernels.

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/DeploySparkSubmit.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/DeploySparkSubmit.scala
@@ -46,23 +46,12 @@ object DeploySparkSubmit extends DeployCommand {
       sparkConfig.get("sparkSubmitArgs").toList.flatMap(parseQuotedArgs)
 
     val isRemote = sparkConfig.get("spark.submit.deployMode") contains "cluster"
-    val libraryPath = List(sys.props.get("java.library.path"), sys.env.get("LD_LIBRARY_PATH"))
-      .flatten
-      .map(_.trim().stripPrefix(File.pathSeparator).stripSuffix(File.pathSeparator))
-      .mkString(File.pathSeparator)
-
-    val javaOptions = Map(
-      "log4j.configuration" -> "log4j.properties",
-      "java.library.path"   -> libraryPath
-    )
 
     val allDriverOptions = {
       nbConfig.jvmArgs.toList ++
       sparkConfig.get("spark.driver.extraJavaOptions").toList ++
-      javaOptions.toList.map {
-        case (name, value) => s"-D$name=$value"
-      } mkString " "
-    }
+      asPropString(javaOptions)
+    } mkString " "
 
     val additionalJars = classPath.toList.filter(_.getFile.endsWith(".jar"))
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/package.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/package.scala
@@ -3,8 +3,24 @@ package polynote.kernel
 import polynote.kernel.util.Publish
 import zio.{Has, Task}
 
+import java.io.File
+
 package object remote {
 
   type PublishRemoteResponse = Has[Publish[Task, RemoteResponse]]
 
+  lazy val javaOptions: Map[String, String] = {
+    val libraryPath = List(sys.props.get("java.library.path"), sys.env.get("LD_LIBRARY_PATH"))
+      .flatten
+      .mkString(File.pathSeparator)
+
+    Map(
+      "log4j.configuration" -> "log4j.properties",
+      "java.library.path"   -> libraryPath
+    )
+  }
+
+  def asPropString(m: Map[String, String]): List[String] = m.toList.map {
+    case (name, value) => s"-D$name=$value"
+  }
 }

--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/transport.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/transport.scala
@@ -433,7 +433,7 @@ object SocketTransport {
             .filterNot(_.isEmpty)
             .mkString(File.pathSeparator)
 
-          val javaArgs = notebookConfig.jvmArgs.toList.flatten
+          val javaArgs = notebookConfig.jvmArgs.toList.flatten ++ asPropString(javaOptions)
 
           java :: "-cp" :: fullClassPath :: javaArgs :::
             classOf[RemoteKernelClient].getName ::


### PR DESCRIPTION
Fix for a regression in https://github.com/polynote/polynote/pull/1020/files#diff-47293bc98d2e35ee033a5c7e31688c160993f9b1e5b92f6ab3ffa0fcbfd62b29