### PR TITLE
Stream scalar seqs as structs

### DIFF
--- a/polynote-frontend/polynote/data/data_type.ts
+++ b/polynote-frontend/polynote/data/data_type.ts
@@ -32,6 +32,7 @@ export abstract class DataType extends CodecContainer {
 
     abstract decodeBuffer(reader: DataReader): any // any way to type this better?
 
+
 }
 
 // Factory that creates DataTypes as Singleton classes that are instances of their own class constructor

--- a/polynote-frontend/polynote/data/value_repr.ts
+++ b/polynote-frontend/polynote/data/value_repr.ts
@@ -106,11 +106,13 @@ export class StreamingDataRepr extends ValueRepr {
         return [inst.handle, inst.dataType, inst.knownSize];
     }
 
-    constructor(readonly handle: number, readonly dataType: StructType, readonly knownSize?: number) {
+    constructor(readonly handle: number, readonly dataType: DataType, readonly knownSize?: number) {
         super();
         Object.freeze(this);
     }
 }
+
+export type StructStreamingDataRepr = StreamingDataRepr & { dataType: StructType }
 
 ValueRepr.codecs = [
     StringRepr,        // 0

--- a/polynote-frontend/polynote/interpreter/vega_interpreter.ts
+++ b/polynote-frontend/polynote/interpreter/vega_interpreter.ts
@@ -21,6 +21,7 @@ import {parseViz, Viz} from "../ui/input/viz_selector";
 import {DataRepr, MIMERepr, StreamingDataRepr, StringRepr} from "../data/value_repr";
 import {displayData, displaySchema} from "../ui/display/display_content";
 import {TableView} from "../ui/layout/table_view";
+import {StructType} from "../data/data_type";
 
 export const VegaInterpreter: IClientInterpreter = {
 
@@ -78,7 +79,7 @@ export function vizResult(id: number, viz: Viz, result: ResultValue, cellContext
 
     switch (viz.type) {
         case "plot":
-            if (!streamRepr) {
+            if (!streamRepr || !(streamRepr.dataType instanceof StructType)) {
                 return err(`Value ${viz.value} is not table-like`);
             }
 
@@ -106,7 +107,7 @@ export function vizResult(id: number, viz: Viz, result: ResultValue, cellContext
             return [new MIMEClientResult(mimeResult)];
 
         case "schema":
-            if (!streamRepr) {
+            if (!streamRepr || !(streamRepr.dataType instanceof StructType)) {
                 return err(`Value ${viz.value} is not table-like`);
             }
             const schemaEl = displaySchema(streamRepr.dataType);

--- a/polynote-frontend/polynote/ui/component/notebook/cell.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/cell.ts
@@ -1208,7 +1208,6 @@ class CodeCellOutput extends Disposable {
             const repr = result.reprs[index] as StreamingDataRepr;
             // surprisingly using monaco.editor.colorizeElement breaks the theme of the whole app! WAT?
             return monaco.editor.colorize(result.typeName, this.cellState.state.language, {}).then(typeHTML => {
-                const streamingRepr = result.reprs[index] as StreamingDataRepr;
                 const frag = document.createDocumentFragment();
                 const resultType = span(['result-type'], []).attr("data-lang" as any, "scala");
                 resultType.innerHTML = typeHTML;
@@ -1229,7 +1228,7 @@ class CodeCellOutput extends Disposable {
                                 })
                             : undefined
                     ]),
-                    repr.dataType instanceof StructType ? displaySchema(streamingRepr.dataType) : undefined
+                    repr.dataType instanceof StructType ? displaySchema(repr.dataType) : undefined
                 ]);
                 frag.appendChild(el);
                 return ["text/html", frag];

--- a/polynote-frontend/polynote/ui/component/plot_editor.ts
+++ b/polynote-frontend/polynote/ui/component/plot_editor.ts
@@ -15,7 +15,7 @@ import {
     OptionalType,
     ShortType,
     StringType,
-    StructField,
+    StructField, StructType,
     TimestampType
 } from "../../data/data_type";
 import {FakeSelect} from "../display/fake_select";
@@ -26,7 +26,7 @@ import {ClientResult, Output} from "../../data/result";
 import {NotebookMessageDispatcher} from "../../messaging/dispatcher";
 import {CellMetadata} from "../../data/data";
 import {DataStream} from "../../messaging/datastream";
-import {StreamingDataRepr} from "../../data/value_repr";
+import {StreamingDataRepr, StructStreamingDataRepr} from "../../data/value_repr";
 import {VegaClientResult} from "../../interpreter/vega_interpreter";
 import {deepEquals, mapValues} from "../../util/helpers";
 import {NotebookStateHandler} from "../../state/notebook_state";
@@ -131,9 +131,7 @@ export class PlotEditor {
     private spec: any;
     private plot: VegaResult;
 
-    constructor(private dispatcher: NotebookMessageDispatcher, private nbState: NotebookStateHandler, readonly repr: StreamingDataRepr, readonly name: string, readonly sourceCellId: number) {
-        this.fields = repr.dataType.fields;
-
+    constructor(private dispatcher: NotebookMessageDispatcher, private nbState: NotebookStateHandler, readonly repr: StructStreamingDataRepr, readonly name: string, readonly sourceCellId: number) {
         const connectionStatus = ServerStateHandler.state.connectionStatus;
         if (connectionStatus === "disconnected") {
             this.container = div(['plot-editor-container', 'disconnected'], [

--- a/polynote-frontend/polynote/ui/component/value_inspector.ts
+++ b/polynote-frontend/polynote/ui/component/value_inspector.ts
@@ -4,7 +4,14 @@ import {FullScreenModal} from "../layout/modal";
 import {div, TagElement} from "../tags";
 import {ResultValue} from "../../data/result";
 import match from "../../util/match";
-import {DataRepr, LazyDataRepr, MIMERepr, StreamingDataRepr, StringRepr} from "../../data/value_repr";
+import {
+    DataRepr,
+    LazyDataRepr,
+    MIMERepr,
+    StreamingDataRepr,
+    StringRepr,
+    StructStreamingDataRepr
+} from "../../data/value_repr";
 import {contentTypeName, displayContent, displayData, displaySchema} from "../display/display_content";
 import {DataReader} from "../../data/codec";
 import {StructType} from "../../data/data_type";
@@ -55,7 +62,7 @@ export class ValueInspector extends FullScreenModal {
                         try {
                             if (dataType instanceof StructType) {
                                 tabs['Schema'] = displaySchema(dataType);
-                                tabs['Plot data'] = new PlotEditor(dispatcher, nbState, repr, resultValue.name, resultValue.sourceCell).container;
+                                tabs['Plot data'] = new PlotEditor(dispatcher, nbState, repr as StructStreamingDataRepr, resultValue.name, resultValue.sourceCell).container;
                             }
                             tabs['View data'] = TableView.create(dispatcher, nbState, repr).el;
                         } catch(err) {

--- a/polynote-frontend/polynote/ui/input/viz_selector.ts
+++ b/polynote-frontend/polynote/ui/input/viz_selector.ts
@@ -132,16 +132,17 @@ export class VizSelector extends Disposable {
 
         reprs.forEach(repr => match(repr)
             .whenInstance(StreamingDataRepr, streamRepr => {
-                this.plotSelector = new PlotSelector(value, streamRepr.dataType, this.viz.type === 'plot' ?  this.viz.plotDefinition : undefined);
+                if (streamRepr.dataType instanceof StructType) {
+                    this.plotSelector = new PlotSelector(value, streamRepr.dataType, this.viz.type === 'plot' ? this.viz.plotDefinition : undefined);
+                    opts[PlotTitle] = this.plotSelector.el.listener(
+                        'TabDisplayed',
+                        () => this.update({ type: 'plot', value: value, plotDefinition: this.plotSelector!.currentPlot })
+                    );
+                }
                 this.tableView = TableView.create(dispatcher, state, streamRepr, true);
 
                 opts[SchemaTitle] = div([], []).listener('TabDisplayed',
                     () => this.update({ type: 'schema', value: value })
-                );
-
-                opts[PlotTitle] = this.plotSelector.el.listener(
-                    'TabDisplayed',
-                    () => this.update({ type: 'plot', value: value, plotDefinition: this.plotSelector!.currentPlot })
                 );
 
                 opts[TableTitle] = this.tableView!.el.listener(

--- a/polynote-frontend/polynote/ui/layout/table_view.ts
+++ b/polynote-frontend/polynote/ui/layout/table_view.ts
@@ -47,7 +47,7 @@ export class TableView {
 
     constructor(private stream: DataStream, private hideTable: boolean = false) {
         const dataType = stream.dataType;
-        this.fields = dataType.fields || [new StructField("entries", dataType)]; // if dataType is not a StructType, create a dummy entry for it.
+        this.fields = dataType instanceof StructType ? dataType.fields : [new StructField("entries", dataType)]; // if dataType is not a StructType, create a dummy entry for it.
         const fieldClasses = this.fields.map(field => field.name);
         const fieldNames = this.fields.map(field => `${field.name}: ${field.dataType.typeName()}`);
 


### PR DESCRIPTION
Stream e.g. `List[Double]` as structs, with index and value. This makes it more useful.

Also, fix some broken handling around StreamingDataRepr where the data type isn't a struct.