### PR TITLE
Switch favicon to use a regular observer

### DIFF
--- a/polynote-frontend/polynote/ui/component/notebook/cell.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/cell.ts
@@ -591,7 +591,7 @@ export class CodeCell extends Cell {
             }
         }
         updateQueued(this.state.queued)
-        cellState.view("queued").addPreObserver(prev => curr => updateQueued(curr, prev));
+        cellState.view("queued").addObserver((curr, update) => updateQueued(curr, update.oldValue));
 
         const updateHighlight = (h: { range: PosRange , className: string} | undefined) => {
             if (h) {


### PR DESCRIPTION
It doesn't _seem_ to be causing any problems as-is, but I think we'd rather not use PreObserver if we can help it. 