### PR TITLE
[WIP] Bring back the inspect modal (optionally) as "quick inspect"

### DIFF
--- a/polynote-frontend/polynote/messaging/dispatcher.ts
+++ b/polynote-frontend/polynote/messaging/dispatcher.ts
@@ -146,12 +146,7 @@ export class NotebookMessageDispatcher extends MessageDispatcher<NotebookState, 
      *******************************/
     // TODO: move this out of dispatcher
     showValueInspector(result: ResultValue, viewType?: string) {
-        this.handler.insertCell("below", {
-            id: result.sourceCell,
-            language: 'viz',
-            metadata: new CellMetadata(false, false, false),
-            content: JSON.stringify({type: viewType, value: result.name})
-        }).then(id => this.handler.selectCell(id))
+        this.handler.insertInspectionCell(result, viewType);
     }
 
     // TODO: this is pointless now, remove once ValueInspector goes away

--- a/polynote-frontend/polynote/state/notebook_state.ts
+++ b/polynote-frontend/polynote/state/notebook_state.ts
@@ -264,6 +264,20 @@ export class NotebookStateHandler extends BaseHandler<NotebookState> {
         )
     }
 
+    /**
+     * Helper for inserting an inspection cell
+     * @param result
+     * @param viewType
+     */
+    insertInspectionCell(result: ResultValue, viewType?: string) {
+        this.insertCell("below", {
+            id: result.sourceCell,
+            language: 'viz',
+            metadata: new CellMetadata(false, false, false),
+            content: JSON.stringify({type: viewType, value: result.name})
+        }).then(id => this.selectCell(id))
+    }
+
     deleteCell(id?: number, selectPrevCell: boolean = true): Promise<number | undefined> {
         if (id === undefined) {
             id = this.state.activeCellId;

--- a/polynote-frontend/polynote/ui/component/notebook/cell.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/cell.ts
@@ -538,7 +538,7 @@ export class CodeCell extends Cell {
 
         let copyCellOutputBtn = iconButton(['copy-output'], 'Copy Output to Clipboard', 'copy', 'Copy Output to Clipboard').click(() => this.copyOutput())
         copyCellOutputBtn.style.display = "none";
-        let cellOutput = new CodeCellOutput(dispatcher, cellState, this.cellId, compileErrorsState, runtimeErrorState, copyCellOutputBtn);
+        let cellOutput = new CodeCellOutput(this.notebookState, cellState, this.cellId, compileErrorsState, runtimeErrorState, copyCellOutputBtn);
 
         this.el = div(['cell-container', this.state.language, 'code-cell'], [
             div(['cell-input'], [
@@ -1126,7 +1126,7 @@ class CodeCellOutput extends Disposable {
     private cellErrorDisplay?: TagElement<"div">;
 
     constructor(
-        private dispatcher: NotebookMessageDispatcher,
+        private notebookState: NotebookStateHandler,
         private cellState: StateView<CellState>,
         private cellId: string,
         compileErrorsHandler: StateView<CompileErrors[]>,
@@ -1201,7 +1201,7 @@ class CodeCellOutput extends Disposable {
                     inspectIcon = [
                         iconButton(['inspect'], 'Inspect', 'search', 'Inspect').click(
                             evt => {
-                                this.dispatcher.showValueInspector(result)
+                                this.notebookState.insertInspectionCell(result)
                             }
                         )
                     ]
@@ -1275,11 +1275,11 @@ class CodeCellOutput extends Disposable {
                     h4(['result-name-and-type'], [
                         span(['result-name'], [result.name]), ': ', resultType,
                         iconButton(['view-data'], 'View data', 'table', '[View]')
-                            .click(_ => this.dispatcher.showValueInspector(result, 'table')),
+                            .click(_ => this.notebookState.insertInspectionCell(result, 'table')),
                         repr.dataType instanceof StructType
                             ? iconButton(['plot-data'], 'Plot data', 'chart-bar', '[Plot]')
                                 .click(_ => {
-                                    this.dispatcher.showValueInspector(result, 'plot')
+                                    this.notebookState.insertInspectionCell(result, 'plot')
                                 })
                             : undefined
                     ]),
@@ -1657,7 +1657,7 @@ export class VizCell extends Cell {
 
         const execInfoEl = div(["exec-info"], []);
 
-        this.cellOutput = new CodeCellOutput(dispatcher, cellState, this.cellId, cellState.view("compileErrors"), cellState.view("runtimeError"));
+        this.cellOutput = new CodeCellOutput(this.notebookState, cellState, this.cellId, cellState.view("compileErrors"), cellState.view("runtimeError"));
 
         // after the cell is run, cache the viz and result and hide input
         cellState.view('results').addObserver(results => {

--- a/polynote-frontend/polynote/ui/component/notebook/kernel.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/kernel.ts
@@ -27,7 +27,13 @@ import {ServerStateHandler} from "../../../state/server_state";
 import {KernelInfo, KernelState, KernelSymbols, KernelTasks, NotebookStateHandler} from "../../../state/notebook_state";
 import {ViewPreferences} from "../../../state/preferences";
 import {DisplayError, ErrorStateHandler} from "../../../state/error_state";
-import {changedKeys} from "../../../util/helpers";
+import {changedKeys, findInstance} from "../../../util/helpers";
+import {remove} from "vega-lite/build/src/compositemark";
+import * as monaco from "monaco-editor";
+import {displayData} from "../../display/display_content";
+import {DataReader} from "../../../data/codec";
+import {DataRepr, StreamingDataRepr} from "../../../data/value_repr";
+import {ValueInspector} from "../value_inspector";
 
 // TODO: this should probably handle collapse and expand of the pane, rather than the Kernel itself.
 export class KernelPane extends Disposable {
@@ -415,6 +421,200 @@ interface ResultRow extends TableRowElement {
     }
 }
 
+class KernelSymbolViewWidget {
+    static instance: KernelSymbolViewWidget = new KernelSymbolViewWidget();
+
+    readonly el: TagElement<'div'>;
+    private content: TagElement<'div'>;
+
+    private pointer: TagElement<'div'>;
+    private buttons: TagElement<'div'>;
+    private viewDataButton: TagElement<'button'>;
+    private plotButton: TagElement<'button'>;
+    private visualizeButton: TagElement<'button'>;
+    private inspectButton: TagElement<'button'>;
+
+    private currentElement?: HTMLElement;
+    private currentValue?: ResultValue;
+    private currentHandler?: NotebookStateHandler;
+
+    private hideTimeout: number = 0;
+    private readonly cancelHide: () => void = () => {
+        if (this.hideTimeout) {
+            window.clearTimeout(this.hideTimeout);
+            this.hideTimeout = 0;
+        }
+    }
+
+    private handleHide: () => void = () => {
+        this.cancelHide();
+        this.hideTimeout = window.setTimeout(() => this.hide(), 180);
+    }
+
+    private relayout: () => void = () => this.layout(false);
+
+    constructor() {
+        this.el = div(['kernel-symbol-widget'], [
+            this.pointer = div(['pointer'], [div(['arrow'], [])]),
+            div(['inner'], [
+                this.content = div(['content'], []),
+                this.buttons = div(['buttons'], [
+                    this.viewDataButton = iconButton(['view-data'], 'View data', 'table', '[View]').click(() => this.browse()),
+                    this.plotButton = iconButton(['plot-data'], 'Plot data', 'chart-bar', '[Plot]').click(() => this.plot()),
+                    this.visualizeButton = iconButton(['create-cell'], 'Visualize', 'plus-circle', '[Visualize]').click(() => this.visualize()),
+                    this.inspectButton = iconButton(['inspect-value'], 'Quick look', 'search', '[Quick Look]').click(() => this.inspect())
+                ])
+            ])
+        ]);
+        this.el.addEventListener('mouseout', this.handleHide);
+        this.el.addEventListener('mouseover', this.cancelHide);
+        this.content.addEventListener('toggle', this.relayout);
+        window.addEventListener('resize', this.relayout);
+        this.el.style.opacity = '0';
+    }
+
+    private static contentFor(value: ResultValue) {
+        return monaco.editor.colorize(value.typeName, "scala", {}).then(typeHTML => {
+            const dataRepr = findInstance(value.reprs, DataRepr);
+            const resultType = span(['result-type'], []).attr("data-lang" as any, "scala");
+            resultType.innerHTML = typeHTML;
+            // why do they put <br> elements in there?
+            [...resultType.getElementsByTagName('br')].forEach(br => br.parentNode?.removeChild(br));
+
+            if (dataRepr) {
+                return div(['data-content'], [
+                    span(['result-name-and-type'], [span(['result-name'], [value.name]), ': ', resultType, ' = ']),
+                    displayData(dataRepr.dataType.decodeBuffer(new DataReader(dataRepr.data)), undefined, 1)
+                ]);
+            }
+
+            return div(['string-content'], [
+                span(['result-name-and-type'], [span(['result-name'], [value.name]), ': ', resultType, ' = ']),
+                value.valueText
+            ]);
+        })
+    }
+
+    showFor(row: HTMLElement, value: ResultValue, handler: NotebookStateHandler) {
+        const rowDims = row.getBoundingClientRect();
+        this.cancelHide();
+
+        this.setFocus([row, value, handler]);
+
+        KernelSymbolViewWidget.contentFor(value).then(content => {
+            this.cancelHide();
+            this.content.innerHTML = '';
+            this.content.appendChild(content);
+
+            if (value.reprs.findIndex(repr => repr instanceof StreamingDataRepr) >= 0) {
+                this.plotButton.style.display = '';
+                this.viewDataButton.style.display = '';
+            } else {
+                this.plotButton.style.display = 'none';
+                this.viewDataButton.style.display = 'none';
+            }
+
+            this.layout();
+        }).then(() => window.requestAnimationFrame(() => this.el.style.opacity = '1.0'))
+
+    }
+
+    private layout(canMove: boolean = true) {
+        if (this.currentElement) {
+            const rowDims = this.currentElement.getBoundingClientRect();
+            const right = (document.body.clientWidth - rowDims.left);
+            this.el.style.right = right + 'px';
+            this.el.style.maxWidth = (document.body.clientWidth - right - 200) + 'px';
+
+            document.body.appendChild(this.el);
+
+            const widgetDims = this.el.getBoundingClientRect();
+
+            // center the widget vertically as much as possible
+            let top = (rowDims.y + (rowDims.height / 2) - (widgetDims.height / 2));
+            if (top >= 20 && (top + widgetDims.height + 20 < document.body.clientHeight) && canMove) {
+                this.el.classList.remove('floating');
+                this.buttons.style.marginTop = '0';
+                this.el.style.top = top + 'px';
+                this.pointer.style.top = '';
+            } else {
+                // the widget is too large to properly center it vertically (or we can't move it vertically) – instead,
+                // we'll center it as closely as possible (if we can vertically move it) and move the arrow and buttons
+                // to be in line with the element we're pointing to.
+                this.el.classList.add('floating');
+                if (canMove) {
+                    // position the thing in the center of the whole screen
+                    top = (document.body.clientHeight / 2) - (widgetDims.height / 2);
+                    this.el.style.top = top + 'px';
+                    this.el.style.maxHeight = '90vh';
+                } else {
+                    top = widgetDims.y;
+                    this.el.style.maxHeight = (document.body.clientHeight - 20 - top) + 'px';
+                }
+                const arrowY = (rowDims.y + (rowDims.height / 2) - top);
+                this.pointer.style.top = arrowY + 'px';
+                this.buttons.style.marginTop = (arrowY - (this.buttons.clientHeight / 2)) + 'px';
+            }
+        }
+    }
+
+    private plot() {
+        if (this.currentValue && this.currentHandler) {
+            this.currentHandler.insertInspectionCell(this.currentValue, 'plot');
+            this.hide();
+        }
+    }
+
+    private browse() {
+        if (this.currentValue && this.currentHandler) {
+            this.currentHandler.insertInspectionCell(this.currentValue, 'table');
+            this.hide();
+        }
+    }
+
+    private visualize() {
+        if (this.currentValue && this.currentHandler) {
+            this.currentHandler.insertInspectionCell(this.currentValue);
+            this.hide();
+        }
+    }
+
+    private inspect() {
+        if (this.currentValue && this.currentHandler) {
+            this.hide();
+            ValueInspector.get.inspect(this.currentHandler, this.currentValue);
+        }
+    }
+
+    private setFocus(focus?: [HTMLElement, ResultValue, NotebookStateHandler]) {
+        if (this.currentElement) {
+            this.currentElement?.removeEventListener('mouseout', this.handleHide);
+            this.currentElement?.removeEventListener('mouseover', this.cancelHide);
+        }
+        if (focus) {
+            const [targetEl, targetValue, targetHandler] = focus;
+            targetEl.addEventListener('mouseout', this.handleHide);
+            targetEl.addEventListener('mouseover', this.cancelHide);
+            this.currentElement = targetEl;
+            this.currentValue = targetValue;
+            this.currentHandler = targetHandler;
+        }
+    }
+
+    hide() {
+        this.setFocus(undefined);
+        this.el.style.maxHeight = '90vh';
+        this.el.style.maxWidth = 'none';
+        this.buttons.style.marginTop = '0';
+        this.el.classList.remove('floating');
+        this.el.parentNode?.removeChild(this.el);
+        this.el.style.opacity = '0';
+        this.buttons.style.marginTop = '0';
+        this.content.innerHTML = '';
+        this.currentElement = this.currentValue = this.currentHandler = undefined;
+    }
+}
+
 class KernelSymbolsEl extends Disposable {
     readonly el: TagElement<"div">;
     private tableEl: TableElement;
@@ -442,15 +642,27 @@ class KernelSymbolsEl extends Disposable {
 
         const handleSymbols = (symbols: KernelSymbols, updateResult?: UpdateResult<KernelSymbols>) => {
             const cells = Object.keys(symbols)
-            if (cells.length > 0) {
-                const changedCells = updateResult ? UpdateResult.addedOrChangedKeys(updateResult) : Object.keys(symbols);
-                changedCells.forEach(cell => {
-                    Object.values(symbols[cell]).forEach(s => this.addSymbol(s));
+            if (cells.length > 0 || updateResult) {
+                const addedCellIds = updateResult ? Object.keys(updateResult.addedValues ?? {}) : Object.keys(symbols);
+                addedCellIds.forEach(cellId => Object.values(symbols[cellId]).forEach(s => this.addSymbol(s)))
+
+                const changedCellIds = Object.keys(updateResult?.changedValues ?? {});
+                changedCellIds.forEach(cellIdStr => {
+                    const cellId: number = parseInt(cellIdStr, 10);
+                    const fieldUpdates: UpdateResult<Record<string, ResultValue>> | undefined = updateResult?.fieldUpdates?.[cellIdStr]
+                    const addedSymbols = fieldUpdates?.addedValues ?? {};
+                    const removedSymbols = fieldUpdates?.removedValues ?? {};
+                    const changedSymbols = fieldUpdates?.changedValues ?? {};
+
+                    Object.values(addedSymbols).forEach(value => value ? this.addSymbol(value) : {});
+                    Object.values(changedSymbols).forEach(value => value ? this.addSymbol(value) : {});
+                    Object.keys(removedSymbols).forEach(name => this.removeSymbol(cellId, name));
                 })
+
+                const removedCellIds = Object.keys(updateResult?.removedValues ?? {});
+                removedCellIds.forEach(cellId => this.removeAllSymbols(parseInt(cellId, 10)));
             } else if (Object.values(this.symbols).length > 0) {
-                Object.entries(this.symbols).forEach(([cellId, syms]) => {
-                    Object.keys(syms).forEach(s => this.removeSymbol(parseInt(cellId), s))
-                })
+                Object.keys(this.symbols).forEach(cellId => this.removeAllSymbols(parseInt(cellId, 10)));
             }
         }
         handleSymbols(notebookState.state.kernel.symbols)
@@ -481,13 +693,20 @@ class KernelSymbolsEl extends Disposable {
             type: span([], [resultValue.typeName]).attr('title', resultValue.typeName)
         }, whichBody) as ResultRow;
         tr.onmousedown = (evt) => {
+            if (evt.button !== 0)
+                return; // only for primary mouse button
             evt.preventDefault();
             evt.stopPropagation();
             this.dispatcher.showValueInspector(tr.resultValue)
         };
+        tr.onmouseover = () => this.showPopupFor(tr, resultValue);
         tr.data = {name: resultValue.name, type: resultValue.typeName};
         tr.resultValue = resultValue;
         return tr;
+    }
+
+    private showPopupFor(row: HTMLElement, resultValue: ResultValue) {
+        KernelSymbolViewWidget.instance.showFor(row, resultValue, this.notebookState);
     }
 
     private addScopeRow(resultValue: ResultValue) {
@@ -585,5 +804,10 @@ class KernelSymbolsEl extends Disposable {
         if (existing.length > 0) {
             existing.forEach(tr => tr.parentNode!.removeChild(tr));
         }
+    }
+
+    private removeAllSymbols(cellId: number) {
+        const names = Object.keys(this.symbols[cellId] ?? {});
+        names.forEach(name => this.removeSymbol(cellId, name));
     }
 }

--- a/polynote-frontend/polynote/ui/component/value_inspector.ts
+++ b/polynote-frontend/polynote/ui/component/value_inspector.ts
@@ -36,7 +36,7 @@ export class ValueInspector extends FullScreenModal {
         return ValueInspector.inst;
     }
 
-    inspect(dispatcher: NotebookMessageDispatcher, nbState: NotebookStateHandler, resultValue: ResultValue, whichTab?: string): Promise<void> {
+    inspect(nbState: NotebookStateHandler, resultValue: ResultValue, whichTab?: string): Promise<void> {
         this.content.innerHTML = "";
         let tabsPromise = Promise.resolve({} as Record<string, TagElement<any>>);
 
@@ -44,7 +44,11 @@ export class ValueInspector extends FullScreenModal {
             repr => tabsPromise = tabsPromise.then(tabs => {
                 match(repr)
                     .when(StringRepr, str => tabs['String'] = div(['plaintext'], [document.createTextNode(str)]))
-                    .when(MIMERepr, (mimeType, content) => displayContent(mimeType, content).then((el: TagElement<"div">) => tabs[contentTypeName(mimeType)] = el))
+                    .when(MIMERepr, (mimeType, content) => {
+                        const tabName = contentTypeName(mimeType);
+                        whichTab = whichTab || tabName
+                        return displayContent(mimeType, content).then((el: TagElement<"div">) => tabs[tabName] = el)
+                    })
                     .when(DataRepr, (dataType, data) => {
                         tabs[`Data(${resultValue.typeName})`] = displayData(dataType.decodeBuffer(new DataReader(data)))
                     })
@@ -62,9 +66,9 @@ export class ValueInspector extends FullScreenModal {
                         try {
                             if (dataType instanceof StructType) {
                                 tabs['Schema'] = displaySchema(dataType);
-                                tabs['Plot data'] = new PlotEditor(dispatcher, nbState, repr as StructStreamingDataRepr, resultValue.name, resultValue.sourceCell).container;
+                                //tabs['Plot data'] = new PlotEditor(dispatcher, nbState, repr as StructStreamingDataRepr, resultValue.name, resultValue.sourceCell).container;
                             }
-                            tabs['View data'] = TableView.create(dispatcher, nbState, repr).el;
+                            //tabs['View data'] = TableView.create(dispatcher, nbState, repr).el;
                         } catch(err) {
                             console.error(err);
                         }

--- a/polynote-frontend/polynote/ui/display/display_content.ts
+++ b/polynote-frontend/polynote/ui/display/display_content.ts
@@ -137,7 +137,7 @@ export function displayData(data: any, fieldName?: string, expandObjects: boolea
         }
         const elems = tag('ul', ['array-elements'], {}, []);
         const details = tag('details', ['array-display'], {}, [summary, elems]);
-
+        details.ontoggle = () => details.parentNode?.dispatchEvent(new CustomEvent('toggle', {bubbles: true}));  // the 'toggle' event doesn't bubble? Why?
         let count = 0;
         for (let elem of data) {
             if (count >= 99) {
@@ -158,7 +158,7 @@ export function displayData(data: any, fieldName?: string, expandObjects: boolea
 
         const fields = tag('ul', ['object-fields'], {}, []);
         const details = tag('details', ['object-display'], expandObjects ? { open: 'open' } : {}, [summary, fields]);
-
+        details.ontoggle = () => details.parentNode?.dispatchEvent(new CustomEvent('toggle', {bubbles: true}));  // the 'toggle' event doesn't bubble? Why?
         for (let [key, val] of data) {
             fields.appendChild(tag('li', [], {}, [displayData(val, key, expandNext)]));
         }
@@ -180,7 +180,7 @@ export function displayData(data: any, fieldName?: string, expandObjects: boolea
 
         const fields = tag('ul', ['object-fields'], {}, []);
         const details = tag('details', ['object-display'], expandObjects ? { open: 'open' } : {}, [summary, fields]);
-
+        details.ontoggle = () => details.parentNode?.dispatchEvent(new CustomEvent('toggle', {bubbles: true}));  // the 'toggle' event doesn't bubble? Why?
         for (let key of keys) {
             fields.appendChild(tag('li', [], {}, [displayData(data[key], key, expandNext)]));
         }
@@ -189,8 +189,8 @@ export function displayData(data: any, fieldName?: string, expandObjects: boolea
         let result;
         if (data !== null && data !== undefined) {
             switch (typeof data) {
-                case "number": result = span(['number'], [truncate(data.toString())]); break;
-                case "boolean": result = span(['boolean'], [data.toString()]); break;
+                case "number": result = span(['number', 'mtk6'], [truncate(data.toString())]); break;
+                case "boolean": result = span(['boolean', 'mtk6'], [data.toString()]); break;
                 default: result = span(['string'], [data.toString()]);
             }
         } else if (data == null) {

--- a/polynote-frontend/polynote/ui/input/viz_selector.ts
+++ b/polynote-frontend/polynote/ui/input/viz_selector.ts
@@ -188,7 +188,7 @@ export class VizSelector extends Disposable {
 
     set currentViz(viz: Viz) {
         this.viz = viz;
-        if (viz.type === 'plot' && this.plotSelector) {
+        if (viz.type === 'plot' && this.plotSelector && viz.plotDefinition) {
             this.plotSelector.setPlot(viz.plotDefinition);
         }
         this.tabNav.showItem(viewTitle(viz));

--- a/polynote-frontend/style/colors.less
+++ b/polynote-frontend/style/colors.less
@@ -453,6 +453,22 @@ button {
 
 }
 
+.kernel-symbol-widget {
+
+  .pointer .arrow {
+    background-color: @ui-panel-bg;
+    border-color: @ui-border-dark;
+    box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.2);
+  }
+
+  .inner {
+    background-color: @ui-panel-bg;
+    border-color: @ui-border-dark;
+    box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.2);
+
+  }
+}
+
 .result {
   table {
     border-color: @content-table-border;

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -28,6 +28,10 @@
 
 @import "common";
 
+html {
+  overflow: hidden;
+}
+
 body {
   font-family: 'Helvetica Neue', 'Segoe UI', sans-serif;
   font-size: 10pt;

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -1268,6 +1268,10 @@ button {
   &:disabled {
     pointer-events:none;
   }
+
+  .icon {
+    vertical-align: middle;
+  }
 }
 
 button.inspect.icon-button {
@@ -1577,6 +1581,66 @@ button.inspect.icon-button {
           width: 40%;
         }
       }
+    }
+  }
+}
+
+.kernel-symbol-widget {
+  position: fixed;
+  transition: opacity 0.25s;
+
+  z-index: 999;
+
+  padding-right: 16px;
+
+  .pointer {
+    position: absolute;
+    right: 1px;
+    top: 50%;
+    width: 16px;
+    height: 16px;
+    margin-top: -8px;
+    overflow: hidden;
+    .arrow {
+      position: absolute;
+      left: -8px;
+      top: 0;
+      width: 13px;
+      height: 13px;
+      border-width: 1px 1px 0 0;
+      border-style: solid;
+      transform: rotate(45deg);
+    }
+  }
+
+  .inner {
+    border-style: solid;
+    border-width: 1px;
+    border-radius: 4px;
+    max-width: 600px;
+    display: grid;
+    align-items: center;
+    grid-template-columns: 1fr min-content;
+
+    .content {
+      font-family: @code-fonts;
+      padding: 1em;
+      .result-name-and-type {
+        white-space: nowrap;
+      }
+      max-height: 90vh;
+      overflow-y: auto;
+      box-sizing: border-box;
+    }
+
+    .buttons {
+      white-space: nowrap;
+    }
+  }
+
+  &.floating {
+    .inner {
+      align-items: start;
     }
   }
 }


### PR DESCRIPTION
- Adds a hover popup UX for the symbol table, which shows you a quick view of the type & useful-est non-streaming presentation of that value in a popout on hover
  - Also includes buttons for quickly plotting, browsing, otherwise visualizing, and "quick-inspecting" the value.
- The "value inspector" modal returns as "quick inspect"
  - It no longer has the plot editor or data table browser (TODO: should we just embed the new versions of these things?)
  - This is mainly useful for "out-of-band" inspection of the value, when the aforementioned popup widget isn't enough (e.g. looking at MIME reprs out-of-band)