### PR TITLE
Remove `selected` field from CellState

### DIFF
--- a/polynote-frontend/polynote/messaging/receiver.ts
+++ b/polynote-frontend/polynote/messaging/receiver.ts
@@ -488,7 +488,6 @@ export class NotebookMessageReceiver extends MessageReceiver<NotebookState> {
             runtimeError: undefined,
             presence: {},
             editing: false,
-            selected: false,
             error: false,
             running: false,
             queued: false,

--- a/polynote-frontend/polynote/state/notebook_state.test.ts
+++ b/polynote-frontend/polynote/state/notebook_state.test.ts
@@ -124,10 +124,10 @@ describe('NotebookStateHandler', () => {
         await expect(init).resolves.toEqual(3)
 
         const waitForSelect = (cellId: number) => new Promise(resolve => {
-            const view = nbState.view("cells").view(cellId)
-            const obs = view.addObserver(state => {
+            const view = nbState.view("activeCellId")
+            const obs = view.addObserver(id => {
                 obs.dispose()
-                resolve([cellId, state.selected])
+                resolve([cellId, id === cellId])
             })
         })
 

--- a/polynote-frontend/polynote/state/notebook_state.ts
+++ b/polynote-frontend/polynote/state/notebook_state.ts
@@ -49,7 +49,6 @@ export interface CellState {
     // ephemeral states
     presence: Record<number, CellPresenceState>;
     editing: boolean,
-    selected: boolean,
     error: boolean,
     running: boolean
     queued: boolean,
@@ -216,10 +215,9 @@ export class NotebookStateHandler extends BaseHandler<NotebookState> {
                 activeCellId: id,
                 cells: id === undefined ? {} : {
                     [id]: {
-                        selected: true,
                         editing: options?.editing ?? false
                     },
-                    ...((prev === undefined && prev !== id) ? {} : {[prev]: {selected: false, editing: false}})
+                    ...((prev === undefined && prev !== id) ? {} : {[prev]: {editing: false}})
                 }
             };
             return update;

--- a/polynote-frontend/polynote/ui/component/toolbar.ts
+++ b/polynote-frontend/polynote/ui/component/toolbar.ts
@@ -186,11 +186,11 @@ class CellToolbar extends ToolbarElement {
             ], [
                 iconButton(["insert-cell-above"], "Insert cell above current", "arrow-up", "Insert above")
                     .click(() => {
-                        if(this.nbHandler) this.nbHandler.insertCell('above')
+                        if(this.nbHandler) this.nbHandler.insertCell('above').then(id => this.nbHandler?.selectCell(id))
                     }),
                 iconButton(["insert-cell-below"], "Insert cell below current", "arrow-down", "Insert below")
                     .click(() => {
-                        if (this.nbHandler) this.nbHandler.insertCell('below')
+                        if (this.nbHandler) this.nbHandler.insertCell('below').then(id => this.nbHandler?.selectCell(id))
                     }),
                 iconButton(["delete-cell"], "Delete current cell", "trash-alt", "Delete")
                     .click(() => {


### PR DESCRIPTION
`NotebookState#activeCellId` makes `CellState#selected` redundant, and
having to keep both in sync was causing problems.