### PR TITLE
Fix some result/output issues

### DIFF
--- a/polynote-frontend/polynote/data/result.ts
+++ b/polynote-frontend/polynote/data/result.ts
@@ -260,7 +260,7 @@ export class ResultValue extends Result {
     static codec = combined(tinyStr, tinyStr, arrayCodec(uint8, ValueRepr.codec), int16, optional(PosRange.codec), bool).to(ResultValue);
     static get msgTypeId() { return 4; }
 
-    static unapply(inst: ResultValue) {
+    static unapply(inst: ResultValue): ConstructorParameters<typeof ResultValue> {
         return [inst.name, inst.typeName, inst.reprs, inst.sourceCell, inst.pos, inst.live];
     }
 

--- a/polynote-frontend/polynote/ui/component/notebook/cell.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/cell.ts
@@ -1479,11 +1479,7 @@ class CodeCellOutput extends Disposable {
                 // clear results
                 this.resultTabs.innerHTML = '';
 
-                if (result.name !== "Out" && result.reprs.length > 1) {
-                    // TODO: hover for result text?
-                    //       Note: tried a "content widget" to bring up the value inspector. It just kinda got in the way.
-                    return Promise.resolve();
-                } else if (result.reprs.length > 0) {
+                if (result.name === 'Out' && result.reprs.length > 0) {
                     let inspectIcon: TagElement<"button">[] = [];
                     if (result.reprs.length > 1) {
                         inspectIcon = [
@@ -1660,6 +1656,8 @@ class CodeCellOutput extends Disposable {
 
     clearOutput() {
         this.clearErrors();
+        this.cellOutputDisplay.classList.remove('output');
+        this.cellOutputTools.classList.remove('output');
         [...this.cellOutputDisplay.children].forEach(child => this.cellOutputDisplay.removeChild(child));
         this.cellOutputDisplay.innerHTML = "";
         this.stdOutEl = null;
@@ -1672,6 +1670,7 @@ class CodeCellOutput extends Disposable {
     }
 
     private clearErrors() {
+        this.cellOutputDisplay.classList.remove('errors');
         if (this.cellErrorDisplay) {
             this.cellOutputDisplay.removeChild(this.cellErrorDisplay)
         }


### PR DESCRIPTION
- Don't display results which aren't `Out`
- Remove symbols from symbol table when results are cleared (otherwise, symbols never go away if the cell is edited to exclude them and re-run)
- Remove CSS classes when results/errors are cleared (otherwise the output/result area never fully goes away after re-running)