### PR TITLE
Tweaks to quick inspection widget

### DIFF
--- a/polynote-frontend/polynote/ui/component/notebook/kernel.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/kernel.ts
@@ -544,7 +544,8 @@ class KernelSymbolViewWidget {
             const rowDims = targetEl.getBoundingClientRect();
             const right = (document.body.clientWidth - rowDims.left);
             this.el.style.right = right + 'px';
-            this.el.style.maxWidth = (document.body.clientWidth - right - 200) + 'px';
+            this.el.style.maxWidth =
+                ((document.querySelector('.tab-view')?.clientWidth ?? document.body.clientWidth - right - 184) - 16) + 'px';
 
             document.body.appendChild(this.el);
 

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -1645,13 +1645,13 @@ button.inspect.icon-button {
 
   z-index: 999;
 
-  padding-right: 16px;
+  padding-right: 8px;
 
   .pointer {
     position: absolute;
     right: 1px;
     top: 50%;
-    width: 16px;
+    width: 8px;
     height: 16px;
     margin-top: -8px;
     overflow: hidden;
@@ -1671,20 +1671,24 @@ button.inspect.icon-button {
     border-style: solid;
     border-width: 1px;
     border-radius: 4px;
-    max-width: 600px;
     display: grid;
     align-items: center;
-    grid-template-columns: 1fr min-content;
+    grid-template-columns: auto min-content;
 
     .content {
       font-family: @code-fonts;
       padding: 1em;
-      .result-name-and-type {
-        white-space: nowrap;
-      }
       max-height: 90vh;
       overflow-y: auto;
       box-sizing: border-box;
+
+      > .string-content {
+        word-break: break-all;
+      }
+
+      .result-name-and-type {
+        white-space: nowrap;
+      }
     }
 
     .buttons {

--- a/polynote-kernel/src/main/scala/polynote/kernel/LocalKernel.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/LocalKernel.scala
@@ -14,7 +14,7 @@ import polynote.kernel.interpreter.{CellExecutor, Interpreter, InterpreterState,
 import polynote.kernel.logging.Logging
 import polynote.kernel.task.TaskManager
 import polynote.kernel.util.RefMap
-import polynote.messages.{ByteVector32, CellID, HandleType, Lazy, NotebookCell, Streaming, Updating, truncateTinyString}
+import polynote.messages.{ByteVector32, CellID, HandleType, Lazy, NotebookCell, Streaming, TinyString, Updating, truncateTinyString}
 import polynote.runtime._
 import scodec.bits.ByteVector
 import zio.blocking.{Blocking, effectBlocking}
@@ -234,7 +234,7 @@ class LocalKernel private[kernel] (
         }.toMap
 
         def updateValue(value: ResultValue): RIO[Blocking with Logging, ResultValue] = {
-          def stringRepr = StringRepr(truncateTinyString(Option(value.value).flatMap(v => Option(v.toString)).getOrElse("null")))
+          def stringRepr = StringRepr(TinyString.truncatePretty(Option(value.value).flatMap(v => Option(v.toString)).getOrElse("null")))
           if (value.value != null) {
             ZIO.effectTotal(instanceMap.get(value.name)).flatMap {
               case Some(instance) =>

--- a/polynote-kernel/src/main/scala/polynote/messages/package.scala
+++ b/polynote-kernel/src/main/scala/polynote/messages/package.scala
@@ -76,6 +76,10 @@ package object messages {
     else
       str.asInstanceOf[TinyString]
 
+    def truncatePretty(str: String): TinyString = if (str.length > 255) {
+      (str.substring(0, 254) + "…").asInstanceOf[TinyString]
+    } else str.asInstanceOf[TinyString]
+
     def unapply(str: TinyString): Option[String] = Option(str)
   }
 


### PR DESCRIPTION
- Allow it to take more screen width
- Move it a little closer to the symbol table
- Allow arbitrary line breaking in a StringRepr (like in a terminal) to prevent it from getting really ragged
- Truncate StringReprs in a nicer way (with an ellipsis at the end if it was truncated)