### PR TITLE
Reduce scroll listeners

### DIFF
--- a/polynote-frontend/polynote/ui/component/notebook/cell.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/cell.ts
@@ -1167,14 +1167,15 @@ export class CodeCell extends Cell {
     }
 
     private layoutWidgets() {
-        // update overflow widget node
-        const editorNode = this.editor.getDomNode()
-        if (editorNode) {
-            const r = editorNode.getBoundingClientRect()
-            this.overflowDomNode.style.top = r.top + "px";
-            this.overflowDomNode.style.left = r.left + "px";
-            this.overflowDomNode.style.height = r.height + "px"
-            this.overflowDomNode.style.width = r.width + "px"
+        if (this.overflowDomNode.parentNode) {
+            const editorNode = this.editor.getDomNode()
+            if (editorNode) {
+                const r = editorNode.getBoundingClientRect()
+                this.overflowDomNode.style.top = r.top + "px";
+                this.overflowDomNode.style.left = r.left + "px";
+                this.overflowDomNode.style.height = r.height + "px"
+                this.overflowDomNode.style.width = r.width + "px"
+            }
         }
     }
 


### PR DESCRIPTION
- Only focused cell has a scroll listener+widget DOM node
- Scrolling only does re-layout of the widget (not the whole editor)