### PR TITLE
Fix NotebookStateHandler loaded promise

### DIFF
--- a/polynote-frontend/polynote/main.ts
+++ b/polynote-frontend/polynote/main.ts
@@ -74,8 +74,10 @@ class Main {
             const notebookBase = 'notebook/';
             if (path.startsWith(notebookBase)) {
                 const nbPath = path.substring(notebookBase.length)
-                ServerStateHandler.loadNotebook(nbPath, true).then(() => {
-                    ServerStateHandler.selectNotebook(nbPath)
+                ServerStateHandler.loadNotebook(nbPath, true).then(nbInfo => {
+                    nbInfo.handler.loaded.then(() => {
+                        ServerStateHandler.selectNotebook(nbPath)
+                    })
                 })
             }
         })

--- a/polynote-frontend/polynote/state/notebook_state.ts
+++ b/polynote-frontend/polynote/state/notebook_state.ts
@@ -29,9 +29,9 @@ import {CellComment, CellMetadata, NotebookCell, NotebookConfig} from "../data/d
 import {ContentEdit, diffEdits} from "../data/content_edit";
 import {EditBuffer} from "../data/edit_buffer";
 import {deepEquals, diffArray, Deferred} from "../util/helpers";
-import {NotebookMessageDispatcher} from "../messaging/dispatcher";
 import {availableResultValues} from "../interpreter/client_interpreter";
 import {notReceiver} from "../messaging/receiver";
+import {ServerStateHandler} from "./server_state";
 
 
 export type CellPresenceState = {id: number, name: string, color: string, range: PosRange, avatar?: string};
@@ -330,7 +330,8 @@ export class NotebookStateHandler extends BaseHandler<NotebookState> {
     }
 
     get isLoading(): boolean {
-        return !!(this.state.kernel.tasks[this.state.path] ?? false)
+        const nbLoaded = ServerStateHandler.getNotebook(this.state.path)?.loaded
+        return nbLoaded === undefined || !nbLoaded || !!(this.state.kernel.tasks[this.state.path] ?? false)
     }
 
     fork(disposeContext?: IDisposable): NotebookStateHandler {

--- a/polynote-frontend/polynote/state/server_state.ts
+++ b/polynote-frontend/polynote/state/server_state.ts
@@ -144,7 +144,7 @@ export class ServerStateHandler extends BaseHandler<ServerState> {
     }
 
     /**
-     * Initialize a new NotebookState and create a NotebookMessageReceiver for that notebook.
+     * Initialize a new NotebookState for a notebook.
      */
     static getOrCreateNotebook(path: string): NotebookInfo {
         const maybeExists = ServerStateHandler.notebooks[path]


### PR DESCRIPTION
A `NotebookStateHandler` is created for every notebook, not only those
that have been loaded by the client.

Thus, the heuristic used by `NotebookStateHandler#isLoading` needs to
account for whether this notebook has been loaded by the client using
the `loaded` status for this notebook kept by the `ServerStateHandler`.

If we don't do this, it causes the `NotebookStateHandler#loaded` promise 
to automatically resolve when the `NotebookStateHandler` is being 
constructed, even for notebooks that are not loaded, which leads to 
ordering issues down the road. 

(We should revisit Notebook loading at a later date though. It would be 
better not to rely on a heuristic at all if possible). 