### PR TITLE
use cell index when undoing deletion

### DIFF
--- a/polynote-frontend/polynote/interpreter/client_interpreter.ts
+++ b/polynote-frontend/polynote/interpreter/client_interpreter.ts
@@ -64,7 +64,7 @@ export class ClientInterpreter {
         // we want to run the cell in order, so we need to find any cells above this one that are currently running/queued
         // and wait for them to complete
         const nbState = this.notebookState.state
-        const cellIdx = this.notebookState.getCellIndex(id)!
+        const cellIdx = this.notebookState.getCellIndex(id)
         const cell = nbState.cells[id]!;
 
         // first, queue up the cell, waiting for another cell to queue if necessary


### PR DESCRIPTION
Changed `insertCell` to support passing in the index instead of the cell id. The API could be a little more ergonomic...

Also fixed some incorrect typings on some of the cell index helper methods. 