### PR TITLE
Fix kernel layout

### DIFF
--- a/polynote-frontend/polynote/ui/component/notebook/kernel.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/kernel.ts
@@ -654,12 +654,14 @@ class KernelSymbolsEl extends Disposable {
         super()
         this.el = div(['kernel-symbols'], [
             h3([], ['Symbols']),
-            this.tableEl = table(['kernel-symbols-table'], {
-                header: ['Name', 'Type'],
-                classes: ['name', 'type'],
-                rowHeading: true,
-                addToTop: true
-            })
+            div(['table-scroller'], [
+                this.tableEl = table(['kernel-symbols-table'], {
+                    header: ['Name', 'Type'],
+                    classes: ['name', 'type'],
+                    rowHeading: true,
+                    addToTop: true
+                })
+            ])
         ]);
         this.resultSymbols = (this.tableEl.tBodies[0] as TagElement<"tbody">).addClass('results');
         this.scopeSymbols = this.tableEl.addBody().addClass('scope-symbols');

--- a/polynote-frontend/polynote/ui/layout/splitview.ts
+++ b/polynote-frontend/polynote/ui/layout/splitview.ts
@@ -107,12 +107,12 @@ export class SplitView extends Disposable {
         const left = div(['grid-shell'], [
             div(['ui-panel'], [
                 leftPane.header.click(() => this.togglePanel(leftView)),
-                div(['ui-panel-content'], [leftPane.el])])]);
+                div(['ui-panel-content', 'left'], [leftPane.el])])]);
 
         const right = div(['grid-shell'], [
             div(['ui-panel'], [
                 rightPane.header.click(() => this.togglePanel(rightView)),
-                div(['ui-panel-content'], [rightPane.el])])]);
+                div(['ui-panel-content', 'right'], [rightPane.el])])]);
 
         const initialPrefs = ViewPrefsHandler.state;
 

--- a/polynote-frontend/style/colors.less
+++ b/polynote-frontend/style/colors.less
@@ -734,8 +734,10 @@ button.dialog-button {
   }
 
   tbody {
-    &.results {
-      border-bottom-color: black;
+    &.results tr:last-child {
+      th, td {
+        border-bottom-color: black;
+      }
     }
 
     background: @ui-table-bg;

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -1452,9 +1452,8 @@ button.inspect.icon-button {
   width: 100%;
 
   .ui-panel-content {
-    display: inline-block;
     grid-area: body;
-    overflow-y: auto;
+    overflow: hidden;
     border-width: 1px;
     border-style: solid;
   }
@@ -1464,10 +1463,10 @@ button.inspect.icon-button {
   max-height: 100%;
   width: 100%;
   box-sizing: border-box;
-  > .ui-panel-content {
-    grid-template-areas: "info" "symbols" "tasks";
-    grid-template-rows:   auto   auto      1fr;
-  }
+  display: grid;
+  grid-template-areas: "info" "symbols"       "tasks";
+  grid-template-rows:   auto   minmax(0, 2fr) 1fr;
+
 
   h2 {
     position: relative;
@@ -1481,6 +1480,7 @@ button.inspect.icon-button {
 
   .kernel-tasks {
     grid-area: tasks;
+    overflow-y: auto;
     h3 button {
       font-size: inherit;
       padding: 0;
@@ -1601,6 +1601,7 @@ button.inspect.icon-button {
   .kernel-symbols {
     position: relative;
     grid-area: symbols;
+    overflow-y: auto;
   }
 
   .kernel-info {

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -1456,16 +1456,19 @@ button.inspect.icon-button {
     overflow: hidden;
     border-width: 1px;
     border-style: solid;
+    position: relative;
   }
 }
 
 .kernel-ui {
-  max-height: 100%;
-  width: 100%;
-  box-sizing: border-box;
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
   display: grid;
-  grid-template-areas: "info" "symbols"       "tasks";
-  grid-template-rows:   auto   minmax(0, 2fr) 1fr;
+  grid-template-areas: "info"       "symbols"   "tasks";
+  grid-template-rows:   min-content min-content 1fr;
 
 
   h2 {
@@ -1598,10 +1601,37 @@ button.inspect.icon-button {
     }*/
   }
 
+
+
   .kernel-symbols {
     position: relative;
     grid-area: symbols;
-    overflow-y: auto;
+
+    .table-scroller {
+      overflow-y: auto;
+      max-height: calc(60vh - 70px - 4em);
+    }
+
+    .kernel-symbols-table {
+      tbody {
+        position: relative;
+        z-index: 1;
+      }
+
+      tbody.results {
+        tr:last-child {
+          td, th {
+            border-bottom-width: 2pt;
+            border-bottom-style: solid;
+          }
+        }
+      }
+      thead th {
+        position: sticky;
+        top: 0;
+        z-index: 2;
+      }
+    }
   }
 
   .kernel-info {
@@ -2354,11 +2384,11 @@ button.dialog-button {
 .kernel-ui .kernel-symbols table,
 .table-view table {
   width: 100%;
-  border-collapse: collapse;
+  border-spacing: 0;
   border-width: 1px 0;
 
   th, td {
-    border-width: 1px;
+    border-width: 1px 1px 0 0;
     border-style: solid;
     padding: 0.25em;
     font-weight: normal;
@@ -2372,18 +2402,16 @@ button.dialog-button {
     border-right-width: 0;
   }
 
+  tr:last-child th, tr:last-child td {
+    border-bottom-width: 1px;
+  }
+
   thead {
     th {
       text-align: left;
     }
   }
   tbody {
-    &.results {
-      border-bottom-width: 2pt;
-      border-bottom-style: solid;
-    }
-
-    overflow-y: auto;
 
     tr {
       animation: highlight 2s;


### PR DESCRIPTION
At some point, symbols and tasks stopped nicely sharing the left panel. If you have too many symbols, it dominates the whole panel and tasks aren't visible.

Restores the original(-ish?) sharing of the panel; if symbols gets too large, they scroll (leaving room for tasks).