### PR TITLE
Fix cancelling client-side cells

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val versions = new {
   val fs2        = "1.0.5"
   val catsEffect = "2.0.0"
   val coursier   = "2.0.0-RC5-6"
-  val zio        = "1.0.2"
+  val zio        = "1.0.5"
   val zioInterop = "2.0.0.0-RC12"
 }
 

--- a/polynote-frontend/polynote/data/messages.ts
+++ b/polynote-frontend/polynote/data/messages.ts
@@ -711,6 +711,7 @@ export class CancelTasks extends Message {
 
     constructor(readonly path: string, readonly taskId?: string) {
         super();
+        this.taskId = taskId ?? undefined;
         Object.freeze(this);
     }
 }

--- a/polynote-frontend/polynote/interpreter/client_interpreter.ts
+++ b/polynote-frontend/polynote/interpreter/client_interpreter.ts
@@ -89,9 +89,11 @@ export class ClientInterpreter {
 
             if (waitCellId !== undefined) {
                 return new Promise<void>(resolve => {
-                    const disposable = this.notebookState.addObserver(state => {
-                        const maybeCellReady = state.cells[waitCellId!];
-                        if (maybeCellReady && !maybeCellReady.running && !maybeCellReady.queued) {
+                    const disposable = this.notebookState.view("cells").view(waitCellId!).addObserver(state => {
+                        if (id === 6) {
+                            console.log("Finished waiting for", waitCellId)
+                        }
+                        if (!(state?.running || state?.queued)) {
                             disposable.dispose();
                             resolve();
                         }

--- a/polynote-frontend/polynote/interpreter/client_interpreter.ts
+++ b/polynote-frontend/polynote/interpreter/client_interpreter.ts
@@ -66,6 +66,7 @@ export class ClientInterpreter {
         const nbState = this.notebookState.state
         const cellIdx = this.notebookState.getCellIndex(id)!
         const cell = nbState.cells[id]!;
+        const taskId = `Cell ${id}`;
 
         // first, queue up the cell, waiting for another cell to queue if necessary
         Promise.resolve().then(() => {
@@ -88,20 +89,23 @@ export class ClientInterpreter {
             }
 
             if (waitCellId !== undefined) {
-                return new Promise<void>(resolve => {
+                let wasRunning = false;
+                return new Promise<void>((resolve, reject) => {
                     const disposable = this.notebookState.view("cells").view(waitCellId!).addObserver(state => {
-                        if (id === 6) {
-                            console.log("Finished waiting for", waitCellId)
-                        }
-                        if (!(state?.running || state?.queued)) {
+                        if (state?.running) {
+                            wasRunning = true;
+                        }if (!state?.queued) {
                             disposable.dispose();
-                            resolve();
+                            if (!state?.error && wasRunning) {
+                                resolve();
+                            } else {
+                                reject();
+                            }
                         }
                     })
                 })
             } else return Promise.resolve()
         }).then(() => { // finally, interpret the cell
-            const taskId = `Cell ${id}`
             const start = Date.now()
             const updateStatus = (progress: number) => {
                 if (progress < 256) {
@@ -125,6 +129,9 @@ export class ClientInterpreter {
                     this.receiver.inject(new CellResult(id, res))
                 }
             })
+        }).catch(() => {}).finally(() => {
+            this.receiver.inject(new KernelStatus(new CellStatusUpdate(id, TaskStatus.Complete)))
+            this.receiver.inject(new KernelStatus(new UpdatedTasks([new TaskInfo(taskId, taskId, '', TaskStatus.Complete, 255)])))
         })
     }
 

--- a/polynote-frontend/polynote/ui/component/toolbar.ts
+++ b/polynote-frontend/polynote/ui/component/toolbar.ts
@@ -162,7 +162,7 @@ class NotebookToolbar extends ToolbarElement {
 
     enable(handler: NotebookStateHandler, dispatcher: NotebookMessageDispatcher) {
         if (this.handler && handler !== this.handler) {
-            // this.handler.dispose();
+            this.handler.dispose();
             this.handler = undefined;
         }
 
@@ -170,7 +170,7 @@ class NotebookToolbar extends ToolbarElement {
             this.handler = handler.fork();
             this.handler.view("kernel").view("tasks").addObserver((tasks, updateResult) => {
                 // only when there are newly added or removed tasks, not on any progress update
-                if (Object.keys(updateResult.addedValues ?? {}).length || Object.keys(updateResult.changedValues ?? {}).length) {
+                if (Object.keys(updateResult.addedValues ?? {}).length || Object.keys(updateResult.removedValues ?? {}).length) {
                     this.cancelButton.disabled = !Object.keys(tasks).find(taskId => taskId.startsWith("Cell"));
                 }
             });

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -1494,7 +1494,7 @@ button.inspect.icon-button {
       padding: 8px;
       margin: 4px 0;
       white-space: pre-line;
-
+      position: relative;
       h4 {
         margin-top: 0;
       }

--- a/polynote-kernel/src/main/scala/polynote/kernel/LocalKernel.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/LocalKernel.scala
@@ -86,9 +86,6 @@ class LocalKernel private[kernel] (
         inner <- queueTask
         _     <- publishStatus.publish1(CellStatusUpdate(id, Queued))
       } yield inner.onInterrupt(notifyCancelled)
-
-      PublishStatus(CellStatusUpdate(id, Queued)) *>
-        queueTask.map(_.onInterrupt(_ => notifyCancelled))
   }
 
   private def latestPredef(state: State) = state.rewindWhile(_.id >= 0) match {

--- a/polynote-server/src/main/scala/polynote/server/NotebookSession.scala
+++ b/polynote-server/src/main/scala/polynote/server/NotebookSession.scala
@@ -40,7 +40,7 @@ class NotebookSession(subscriber: KernelSubscriber, streamingHandles: StreamingH
       ZIO.unless(ids.isEmpty) {
         ZIO.foreachPar_(ids)(id => subscriber.checkPermission(Permission.ExecuteCell(_, id))) *>
           ZIO.foreach(ids.toList)(id => subscriber.publisher.queueCell(id)).flatMap {
-            tasks => ZIO.collectAll_(tasks).forkDaemon
+            tasks => ZIO.collectAll_(tasks.map(_.run.uninterruptible)).forkDaemon
           }
       }
 


### PR DESCRIPTION
Queued client-side cells (vega, viz) don't get properly aborted when the server-side cell they're waiting upon is aborted.

This fixes that, and also fixes an issue where `CellStatusUpdate` doesn't get issued for cells that are "unqueued" rather than interrupted.