### PR TITLE
Fix issue renaming notebooks

### DIFF
--- a/polynote-frontend/polynote/messaging/dispatcher.ts
+++ b/polynote-frontend/polynote/messaging/dispatcher.ts
@@ -3,18 +3,15 @@ import {HandleData, ModifyStream, NotebookUpdate, ReleaseHandle, TableOp} from "
 import {
     ClientResult,
     Output,
-    ResultValue,
     ServerErrorWithCause
 } from "../data/result";
 import {
-    Destroy,
     Disposable, setProperty,
     setValue,
     StateHandler,
     StateView, UpdateResult
 } from "../state";
 import {About} from "../ui/component/about";
-import {ValueInspector} from "../ui/component/value_inspector";
 import {collect, partition} from "../util/helpers";
 import {Either} from "../data/codec_types";
 import {DialogModal} from "../ui/layout/modal";
@@ -24,9 +21,6 @@ import {CellState, NotebookState, NotebookStateHandler} from "../state/notebook_
 import {ErrorStateHandler} from "../state/error_state";
 import {ClientBackup} from "../state/client_backup";
 import {ServerState, ServerStateHandler} from "../state/server_state";
-import {OpenNotebooksHandler} from "../state/preferences";
-import {ViewType} from "../ui/input/viz_selector";
-import {CellMetadata} from "../data/data";
 
 /**
  * The Dispatcher is used to handle actions initiated by the UI.
@@ -284,8 +278,6 @@ export class ServerMessageDispatcher extends MessageDispatcher<ServerState>{
                 ErrorStateHandler.addServerError(err.error)
             }
         }).disposeWith(this)
-
-        this.handler.observeKey("openNotebooks", nbs => OpenNotebooksHandler.update(() => setValue([...nbs])))
     }
 
     /*******************************

--- a/polynote-frontend/polynote/state/preferences.ts
+++ b/polynote-frontend/polynote/state/preferences.ts
@@ -1,5 +1,5 @@
 import {storage} from "./storage";
-import {BaseHandler, Disposable, IDisposable, ObjectStateHandler, setValue, StateHandler, StateView, UpdateOf} from ".";
+import {BaseHandler, IDisposable, ObjectStateHandler, setValue, StateHandler} from ".";
 import {deepEquals, diffArray} from "../util/helpers";
 
 export type RecentNotebooks = {name: string, path: string}[];


### PR DESCRIPTION
* Fix bug where the frontend didn't properly handle rename of a closed
  notebook that had previously been opened.
* Revamp recent/opened notebooks logic, putting all changes to those
  preferences in the same location.