### PR TITLE
don't break when cell context has invalid (for JS) variable names

### DIFF
--- a/polynote-frontend/polynote/interpreter/client_interpreter.ts
+++ b/polynote-frontend/polynote/interpreter/client_interpreter.ts
@@ -145,7 +145,7 @@ export function availableResultValues(symbols: KernelSymbols, cellOrder: number[
 
     return whichCells.reduce<Record<string, ResultValue>>((acc, next) => {
         Object.values(symbols[next] || {})
-            .forEach((result: ResultValue) => acc[result.name] = result);
+            .forEach((result: ResultValue) => acc[sanitizeJSVariable(result.name)] = result);
         return acc;
     }, {});
 }
@@ -169,4 +169,22 @@ function availableClientValues(resultValues: Record<string, ResultValue>, notebo
             }
         )
     )
+}
+
+/**
+ * Sanitize a string as a proper Javascript variable name. Variables in other languages can have characters that are
+ * not allowed in Javascript, such as `-`.
+ *
+ * @param variableName
+ */
+const substitutions = [
+    {
+        from: "-",
+        to: "$dash$"
+    }
+]
+function sanitizeJSVariable(variableName: string): string {
+    return substitutions.reduce((acc, {from, to}) => {
+        return acc.replaceAll(from, to)
+    }, variableName)
 }

--- a/polynote-frontend/polynote/interpreter/vega_interpreter.ts
+++ b/polynote-frontend/polynote/interpreter/vega_interpreter.ts
@@ -34,6 +34,7 @@ export const VegaInterpreter: IClientInterpreter = {
         try {
             ast = acorn.parse(code, {sourceType: 'script', ecmaVersion: 6, ranges: true })
         } catch (err) {
+            console.error(err)
             const pos = err.pos - 1;
             return [new CompileErrors([
                 new KernelReport(new Position(`Cell ${cellContext.id}`, pos, pos, pos), err.message, 2)
@@ -173,6 +174,7 @@ export const VizInterpreter: IClientInterpreter = {
             const result = cellContext.resultValues[viz.value];
             return vizResult(cellContext.id, viz, result, cellContext);
         } catch (err) {
+            console.error(err)
             const pos = err.lineNumber !== undefined && err.columnNumber !== undefined ?
                 positionIn(code, err.lineNumber, err.columnNumber) : 0;
             const message = err.message || "Cell does not contain a valid visualization description";


### PR DESCRIPTION
Fixes a bug where all plotting fails if you have a JS-invalid variable name, e.g., ```val `this-is-a-valid-scala-variable-name` = "foo"``` 