### PR TITLE
Allow Plot-less Viz Cell for non-numeric StructTypes

### DIFF
--- a/polynote-frontend/polynote/ui/input/plot_selector.ts
+++ b/polynote-frontend/polynote/ui/input/plot_selector.ts
@@ -148,6 +148,17 @@ export const PlotDefinition = {
     },
 }
 
+/**
+ * Check to see whether a Plot is supported for this Repr.
+ *
+ * Right now this is using the heuristic that we can't plot anything that doesn't have numeric measures, but perhaps
+ * there's better criteria?
+ */
+export function canPlot(schema: StructType): boolean {
+    const measureFields    = deepMeasureFields(schema.fields);
+    const numericMeasures  = measureFields.filter(field => field.dataType.isNumeric);
+    return numericMeasures.length > 0
+}
 
 /**
  * Validate the given plot definition, throwing a PlotValidationErrors error if it is not valid.

--- a/polynote-frontend/polynote/ui/input/viz_selector.ts
+++ b/polynote-frontend/polynote/ui/input/viz_selector.ts
@@ -1,4 +1,4 @@
-import {PlotDefinition, PlotSelector} from "./plot_selector";
+import {canPlot, PlotDefinition, PlotSelector} from "./plot_selector";
 import {DataType, StructType} from "../../data/data_type";
 import {div, span, TagElement} from "../tags";
 import {TabNav} from "../layout/tab_nav";
@@ -132,7 +132,7 @@ export class VizSelector extends Disposable {
 
         reprs.forEach(repr => match(repr)
             .whenInstance(StreamingDataRepr, streamRepr => {
-                if (streamRepr.dataType instanceof StructType) {
+                if (streamRepr.dataType instanceof StructType && canPlot(streamRepr.dataType)) {
                     this.plotSelector = new PlotSelector(value, streamRepr.dataType, this.viz.type === 'plot' ? this.viz.plotDefinition : undefined);
                     opts[PlotTitle] = this.plotSelector.el.listener(
                         'TabDisplayed',


### PR DESCRIPTION
Creating a Viz cell for a non-numeric data type such as 

```scala
Seq(("a", "1"), ("b", "2"), ("c", "3"))
```

would previously fail with 
```
state_handler.ts:192 TypeError: Cannot read property 'value' of undefined
    at HTMLSelectElement.getSelectedValue (tags.ts:406)
    at tags.ts:420
    at HTMLSelectElement.bind (tags.ts:169)
    at new kae (plot_selector.ts:1131)
    at viz_selector.ts:136
    at $e.whenInstance (match.ts:52)
    at viz_selector.ts:134
    at Array.forEach (<anonymous>)
    at new Gle (viz_selector.ts:133)
    at yle.setValue (cell.ts:2176)
```

This PR avoids attempting to create a Plot cell for Repr types without any numeric fields, allowing a Viz cell to be created for browsing the data or inspecting its schema. 