### PR TITLE
Set the vega plots default height to "container"

### DIFF
--- a/polynote-frontend/polynote/interpreter/vega_interpreter.ts
+++ b/polynote-frontend/polynote/interpreter/vega_interpreter.ts
@@ -198,7 +198,7 @@ export class VegaClientResult extends ClientResult {
     constructor(specObj: any) {
         super();
         const spec = {...specObj};
-        this.responsive = spec.width === 'container';
+        this.responsive = spec.width === 'container' || spec.height === 'container';
         this.runResult = this.outputEl.then(targetEl => {
             if (spec?.data?.values instanceof DataStream) {
                 const dataStream: DataStream = spec.data.values;

--- a/polynote-frontend/polynote/ui/display/display_content.ts
+++ b/polynote-frontend/polynote/ui/display/display_content.ts
@@ -39,7 +39,7 @@ export function displayContent(contentType: string, content: string | DocumentFr
         const wrapperEl = div(['vega-result'], [targetEl]);
         const spec = JSON.parse(content);
 
-        if (spec?.width === 'container') {
+        if (spec?.width === 'container' || spec?.height === 'container') {
             // must wait until the element is in the DOM before embedding, in case it's responsive sized.
             const onVisible = () => {
                 embed(targetEl, spec);

--- a/polynote-frontend/polynote/ui/input/plot_selector.ts
+++ b/polynote-frontend/polynote/ui/input/plot_selector.ts
@@ -320,6 +320,7 @@ function tableOps(plotDef: PlotDefinition): TableOp[] {
 export function plotToVega(plotDef: ValidPlotDefinition, schema: StructType): TopLevelSpec {
     const spec = plotToSpec(plotDef, schema) as any;
     spec.width = 'container';
+    spec.height = 'container';
     return spec as TopLevelSpec;
 }
 

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -3345,9 +3345,15 @@ img.icon, svg.icon {
   }
 }
 
+.vega-result {
+  height: 100%;
+}
+
 .vega-result .vega-embed {
   padding-right: 0;
   margin-right: 38px;
+  height: 100%;
+  min-height: 266px;
 }
 
 /*


### PR DESCRIPTION
This PR sets the Vega plots default height to "container" and changes some CSS rules so that the plots fill the whole div.

This allows the user to resize plots, which is particularly helpful when exploring line/bar charts.

This has some unfortunate limitations, since I don't think I can listen to an `onResize` event on the div to trigger the plot redraw (so the canvas needs to be manually rerun). I also saw some weird quirks in the code, so I'm not entirely sure if I'm doing "things the right way".

Nevertheless, this feels slightly better than the current behavior. Feel free to close this if you think otherwise, or if you would rather have a different solution.
