### PR TITLE
Set Python recursion limit to default

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/python/PythonInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/python/PythonInterpreter.scala
@@ -281,6 +281,10 @@ class PythonInterpreter private[python] (
       |    from importlib.util import spec_from_loader
       |    from collections import defaultdict, UserDict
       |
+      |    # Set the recursion limit to 1000 on Python 3.7 to avoid https://bugs.python.org/issue38593
+      |    if sys.version_info[:2] == (3,7):
+      |        sys.setrecursionlimit(1000)
+      |
       |    if not hasattr(sys, 'argv') or len(sys.argv) == 0:
       |        sys.argv  = ['']
       |

--- a/polynote-kernel/src/test/scala/polynote/kernel/interpreter/python/PythonInterpreterSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/interpreter/python/PythonInterpreterSpec.scala
@@ -343,6 +343,26 @@ class PythonInterpreterSpec extends FreeSpec with Matchers with InterpreterSpec 
         ParameterHints("delattr(o, name: str)", Option("Deletes the named attribute from the given object."),
           List(ParameterHint("o", "", None), ParameterHint("name", "str", None)))),0,0))
     }
+
+
+    "should get a RecursionError upon infinite recursion" in {
+      val code =
+        """
+          |def call_myself():
+          |    for r in call_myself():
+          |        pass
+          |
+          |call_myself()
+          |""".stripMargin
+      try {
+        assertOutput(code) { case _ => }
+      } catch {
+        case err: Throwable =>
+          err.getMessage shouldEqual "RecursionError: maximum recursion depth exceeded"
+      }
+    }
+
+
   }
 
   "PythonObject" - {


### PR DESCRIPTION
For some reason, the recursion limit is set to 3000 in Polynote (the
Python default seems to be 1000).

I have no idea why the limit is different in Polynote. The `jep` console
on my laptop has the limit set to 1000, as does my python installation.

Anyways, this is a problem with Python 3.7 apparently, because it seems
that we were running into https://bugs.python.org/issue38593 (which
caused the underlying issue with #1144).

Since that bug is limited to Python 3.7, we just set the recursion limit
to 1000 for Python 3.7.

Resolves #1144