### PR TITLE
This fix the issue of Docker build arguments being reset after FROM

### DIFF
--- a/docker/spark-2.4/Dockerfile
+++ b/docker/spark-2.4/Dockerfile
@@ -2,6 +2,8 @@ ARG POLYNOTE_VERSION
 ARG SCALA_VERSION="2.11"
 FROM polynote/polynote:${POLYNOTE_VERSION}-${SCALA_VERSION}
 
+ARG SCALA_VERSION="2.11" //Arguments after `FROM` are reset
+
 WORKDIR /opt
 
 USER root


### PR DESCRIPTION


After the image is built with this patch, you can see that spark is installed with the correct scala.

   docker exec -ti c22fa5f3f6d0 bash
polly@c22fa5f3f6d0:/opt$ spark-submit --version
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 2.4.5
      /_/

Using Scala version 2.12.10, OpenJDK 64-Bit Server VM, 1.8.0_282
Branch HEAD
Compiled by user centos on 2020-02-02T20:11:52Z
Revision cee4ecbb16917fa85f02c635925e2687400aa56b
Url https://gitbox.apache.org/repos/asf/spark.git
Type --help for more information.