### PR TITLE
Safer ReprsOf

### DIFF
--- a/polynote-runtime/src/main/scala/polynote/runtime/DataEncoder.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/DataEncoder.scala
@@ -51,7 +51,6 @@ trait DataEncoder[@specialized T] extends Serializable {
 }
 
 object DataEncoder extends DataEncoder0 {
-scala.collection.immutable.HashMap().toString()
   def truncateString(str: String): String = if (str.length > 255) str.substring(0, 254) + "…" else str
   def formatCollection[T](coll: GenTraversable[T], formatItem: T => String, prefix: Option[String]): String = {
     val innerStrs = if (coll.size > 10) {

--- a/polynote-runtime/src/main/scala/polynote/runtime/DataEncoder.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/DataEncoder.scala
@@ -14,10 +14,11 @@ trait DataEncoder[@specialized T] extends Serializable {
     encode(dataOutput, value)
     dataOutput
   }
+  def encodeDisplayString(value: T): String = DataEncoder.truncateString(value.toString)
   def dataType: DataType
   def sizeOf(t: T): Int
   def numeric: Option[Numeric[T]]
-  
+
   def bimap[U](from: U => T, to: T => U): DataEncoder[U] = new DataEncoder[U] {
     override def encode(dataOutput: DataOutput, value: U): Unit = DataEncoder.this.encode(dataOutput, from(value))
     override val dataType: DataType = DataEncoder.this.dataType
@@ -50,13 +51,42 @@ trait DataEncoder[@specialized T] extends Serializable {
 }
 
 object DataEncoder extends DataEncoder0 {
+scala.collection.immutable.HashMap().toString()
+  def truncateString(str: String): String = if (str.length > 255) str.substring(0, 254) + "…" else str
+  def formatCollection[T](coll: GenTraversable[T], formatItem: T => String, prefix: Option[String]): String = {
+    val innerStrs = if (coll.size > 10) {
+      coll.take(10).toSeq.map(formatItem).map(_.linesWithSeparators.map("  " + _).mkString) :+ s"  …(${coll.size - 10} more elements)"
+    } else coll.map(formatItem)
 
-  def sizedInstance[@specialized T](typ: DataType, size: T => Int, numericOpt: Option[Numeric[T]] = None)(fn: (DataOutput, T) => Unit): DataEncoder[T] = new DataEncoder[T] {
+    prefix.getOrElse(coll.stringPrefix) + "(\n" + innerStrs.mkString(",\n") + "\n)"
+  }
+
+  def formatCollection[T](coll: GenTraversable[T], formatItem: T => String, prefix: String): String =
+    formatCollection(coll, formatItem, Some(prefix))
+
+  def formatCollection[T](coll: GenTraversable[T], formatItem: T => String): String =
+    formatCollection(coll, formatItem, None)
+
+  def formatCollection[T](coll: GenTraversable[T], prefix: String)(implicit enc: DataEncoder[T]): String =
+    formatCollection(coll, t => enc.encodeDisplayString(t), Some(prefix))
+
+  def formatCollection[T](coll: GenTraversable[T])(implicit enc: DataEncoder[T]): String =
+    formatCollection(coll, t => enc.encodeDisplayString(t), None)
+
+  class SizedEncoder[@specialized T](
+    typ: DataType,
+    size: T => Int,
+    numericOpt: Option[Numeric[T]] = None)(
+    fn: (DataOutput, T) => Unit
+  ) extends DataEncoder[T] {
     def encode(dataOutput: DataOutput, value: T): Unit = fn(dataOutput, value)
     val dataType: DataType = typ
     override def sizeOf(t: T): Int = size(t)
     val numeric: Option[Numeric[T]] = numericOpt
   }
+
+  def sizedInstance[@specialized T](typ: DataType, size: T => Int, numericOpt: Option[Numeric[T]] = None)(fn: (DataOutput, T) => Unit): DataEncoder[T] =
+    new SizedEncoder[T](typ, size, numericOpt)(fn)
 
   def instance[@specialized T](typ: DataType)(fn: (DataOutput, T) => Unit): DataEncoder[T] = sizedInstance[T](typ, _ => typ.size)(fn)
 
@@ -127,7 +157,7 @@ object DataEncoder extends DataEncoder0 {
       case err: Throwable => -1
     }
 
-  implicit def array[A](implicit encodeA: DataEncoder[A]): DataEncoder[Array[A]] = sizedInstance[Array[A]](ArrayType(encodeA.dataType), arr => combineSize(seqSize(arr, encodeA), 4)) {
+  implicit def array[A](implicit encodeA: DataEncoder[A]): DataEncoder[Array[A]] = new SizedEncoder[Array[A]](ArrayType(encodeA.dataType), arr => combineSize(seqSize(arr, encodeA), 4))({
     (output, arr) =>
       output.writeInt(arr.length)
       var i = 0
@@ -135,14 +165,21 @@ object DataEncoder extends DataEncoder0 {
         encodeA.encode(output, arr(i))
         i += 1
       }
+  }) {
+    override def encodeDisplayString(value: Array[A]): String = formatCollection(value, "Array")
   }
 
-  implicit def optional[A](implicit encodeA: DataEncoder[A]): DataEncoder[Option[A]] = sizedInstance[Option[A]](OptionalType(encodeA.dataType), opt => opt.fold(1)(a => combineSize(encodeA.sizeOf(a), 1))) {
+  implicit def optional[A](implicit encodeA: DataEncoder[A]): DataEncoder[Option[A]] = new SizedEncoder[Option[A]](OptionalType(encodeA.dataType), opt => opt.fold(1)(a => combineSize(encodeA.sizeOf(a), 1)))({
     case (output, None) =>
       output.writeBoolean(false)
     case (output, Some(a)) =>
       output.writeBoolean(true)
       encodeA.encode(output, a)
+  }) {
+    override def encodeDisplayString(value: Option[A]): String = value match {
+      case Some(elem) => s"Some(${encodeA.encodeDisplayString(elem)})"
+      case None       => "None"
+    }
   }
 
   private[polynote] class BufferOutput(buf: ByteBuffer) extends DataOutput {
@@ -237,6 +274,12 @@ private[runtime] sealed trait DataEncoder0 extends DataEncoderDerivations { self
     }
 
     def numeric: Option[Numeric[F[K, V]]] = None
+
+    override def encodeDisplayString(value: F[K, V]): String = formatCollection[(K, V)](
+      value,
+      (tup: (K, V)) => s"${encodeK.encodeDisplayString(tup._1)} -> ${encodeV.encodeDisplayString(tup._2)}",
+      value.stringPrefix
+    )
   }
 
 
@@ -276,6 +319,8 @@ private[runtime] sealed trait DataEncoderDerivations { self: DataEncoder.type =>
       }
 
       override def sizeOf(t: (Int, A)): Int = encoder.sizeOf(t._2) + 4
+
+      override def encodeDisplayString(value: (Int, A)): String = s"(${value._1}, ${encoder.encodeDisplayString(value._2)})"
     }
   }
 
@@ -290,6 +335,8 @@ private[runtime] sealed trait DataEncoderDerivations { self: DataEncoder.type =>
     def dataType: DataType = ArrayType(encodeA.dataType)
     def sizeOf(t: F[A]): Int = if (encodeA.dataType.size >= 0) (encodeA.dataType.size * t.size + 4) else seqSize[A](t, encodeA) + 4
     def numeric: Option[Numeric[F[A]]] = None
+
+    override def encodeDisplayString(value: F[A]): String = formatCollection[A](value)(encodeA)
   }
 
   implicit def seq[A](implicit encodeA: DataEncoder[A]): DataEncoder[Seq[A]] = new SeqEncoder(encodeA)

--- a/polynote-runtime/src/main/scala/polynote/runtime/ReprsOf.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/ReprsOf.scala
@@ -58,10 +58,13 @@ object ReprsOf extends ExpandedScopeReprs {
 
     implicit def fromDataEncoder[T](implicit dataEncoder: DataEncoder[T]): DataReprsOf[T] = new DataReprsOf[T](dataEncoder.dataType) {
       val encode: T => ByteBuffer = t => DataEncoder.writeSized(t)
-      override def apply(value: T): Array[ValueRepr] = dataEncoder.sizeOf(value) match {
-        case s if s >= 0 && s <= EagerSizeThreshold => Array(DataRepr(dataType, DataEncoder.writeSized(value, s)))
-        case s if s >= 0 => Array(LazyDataRepr(dataType, DataEncoder.writeSized(value, s), Some(s))) // writeSized is suspended byname
-        case _ => Array(LazyDataRepr(dataType, DataEncoder.writeSized(value), None)) // writeSized is suspended byname
+      override def apply(value: T): Array[ValueRepr] = {
+        val stringRepr = StringRepr(dataEncoder.encodeDisplayString(value))
+        dataEncoder.sizeOf(value) match {
+          case s if s >= 0 && s <= EagerSizeThreshold => Array(stringRepr, DataRepr(dataType, DataEncoder.writeSized(value, s)))
+          case s if s >= 0 => Array(stringRepr, LazyDataRepr(dataType, DataEncoder.writeSized(value, s), Some(s))) // writeSized is suspended byname
+          case _ => Array(stringRepr, LazyDataRepr(dataType, DataEncoder.writeSized(value), None)) // writeSized is suspended byname
+        }
       }
     }
 
@@ -82,7 +85,7 @@ object ReprsOf extends ExpandedScopeReprs {
 
   val empty: ReprsOf[Any] = instance(_ => Array.empty)
 
-  implicit val sparkSession: ReprsOf[Runtime.type] = {
+  implicit val polynoteRuntime: ReprsOf[Runtime.type] = {
     instance {
       r =>
         val html =

--- a/polynote-runtime/src/test/scala/polynote/runtime/test/CollectionReprsSpec.scala
+++ b/polynote-runtime/src/test/scala/polynote/runtime/test/CollectionReprsSpec.scala
@@ -2,11 +2,12 @@ package polynote.runtime.test
 
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
+import scala.collection.JavaConverters._
 
 import org.scalatest.{FreeSpec, Matchers}
 import polynote.runtime.{DataEncoder, GroupAgg, ReprsOf, StreamingDataRepr}
 
-class  CollectionReprsSpec extends FreeSpec with Matchers {
+class CollectionReprsSpec extends FreeSpec with Matchers {
 
   "Streaming repr of structs" - {
     case class Example(label: String, i: Int, d: Double)
@@ -37,6 +38,16 @@ class  CollectionReprsSpec extends FreeSpec with Matchers {
         )
       }
 
+    }
+
+    "String representation truncates to 10 elements" in {
+      val de = implicitly[DataEncoder[Example]]
+      val all = (0 until 100).map(i => Example(i.toString, i, i.toDouble)).toVector
+      val expectedFirstTen = all.take(10).map {
+        example => de.encodeDisplayString(example).linesWithSeparators.map(str => s"  $str").mkString
+      }
+      implicitly[DataEncoder[Seq[Example]]].encodeDisplayString(all) shouldEqual
+        "Vector(\n" + expectedFirstTen.mkString(",\n") + ",\n  …(90 more elements)\n)"
     }
   }
 

--- a/polynote-runtime/src/test/scala/polynote/runtime/test/StructDataEncoderSpec.scala
+++ b/polynote-runtime/src/test/scala/polynote/runtime/test/StructDataEncoderSpec.scala
@@ -11,10 +11,10 @@ class StructDataEncoderSpec extends FreeSpec with Matchers {
 
   case class NestedMap(a: Map[String, Double], b: TestAllEncodable, c: Map[String, TestAllEncodable])
 
-  val e1 = implicitly[DataEncoder[NestedMap]]
+  private val inst = TestAllEncodable(22, 2.2, true, "hello")
 
   "can encode a case class" in {
-    val e1 = DataEncoder.StructDataEncoder
+    val e1 = DataEncoder.StructDataEncoder.caseClassMacro[TestAllEncodable]
     val encoder = implicitly[DataEncoder[TestAllEncodable]].asInstanceOf[DataEncoder.StructDataEncoder[TestAllEncodable]]
 
     encoder.dataType shouldEqual StructType(List(
@@ -24,12 +24,31 @@ class StructDataEncoderSpec extends FreeSpec with Matchers {
       StructField("fourth", StringType)
     ))
 
-    val inst = TestAllEncodable(22, 2.2, true, "hello")
 
     val Some((firstGetter, firstEncoder)) = encoder.field("first")
     firstGetter(inst) shouldEqual 22
     firstEncoder.dataType shouldEqual IntType
 
+    encoder.encodeDisplayString(inst) shouldEqual
+      s"""TestAllEncodable(
+        |  first = ${inst.first},
+        |  second = ${inst.second},
+        |  third = ${inst.third},
+        |  fourth = ${inst.fourth}
+        |)""".stripMargin
+
+  }
+
+  "formats nested things properly" in {
+    implicitly[DataEncoder[Nested]].encodeDisplayString(Nested(inst)) shouldEqual
+      s"""Nested(
+        |  a = TestAllEncodable(
+        |    first = ${inst.first},
+        |    second = ${inst.second},
+        |    third = ${inst.third},
+        |    fourth = ${inst.fourth}
+        |  )
+        |)""".stripMargin
   }
 
 }


### PR DESCRIPTION
- Catch when `.toString` fails, for badly behaved `.toString`s
- Use a new method of `DataEncoder` to encode `String` reprs, instead of just `.toString`
  - It truncates collections to 10 items
  - It formats things with nicer line breaks and indentation (case class implementations are macro-generated)

Hopefully this will solve e.g. giant `List`s or `Map`s causing OOMs on `.toString`, in a couple of different ways.