### PR TITLE
Fix package cell detection

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/ScalaCompiler.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/ScalaCompiler.scala
@@ -121,7 +121,7 @@ class ScalaCompiler private (
   ): Task[CellCode] = for {
     sourceFile  <- ZIO(newSourceFile(code, name))
     compileUnit <- ZIO(new global.RichCompilationUnit(sourceFile))
-    parsed      <- parse(compileUnit, strictParse, code.trim().startsWith("package"))
+    parsed      <- parse(compileUnit, strictParse, code.trim().startsWith("package "))
   } yield {
     val definedTerms = parsed.collect {
       case tree: DefTree if tree.name.isTermName => tree.name.decoded


### PR DESCRIPTION
Prevent package cell detection from kicking in if the cell starts with `package` but isn't actually declaring a package. 

Without this change, a variable called `packages_in_dir` on the first line of a cell would result in ```Error: expected class or object definition (Line 0,0)```.