### PR TITLE
Make PySpark dependency distribution configurable

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
@@ -176,12 +176,23 @@ object SparkPropertySet {
   implicit val codec: Codec[SparkPropertySet] = cachedImplicit[Codec[SparkPropertySet]]
 }
 
+final case class PySparkConfig(
+  distributeDependencies: Option[Boolean] = None,
+  distributionExcludes: List[String] = Nil
+)
+
+object PySparkConfig {
+  implicit val encoder: ObjectEncoder[PySparkConfig] = deriveEncoder
+  implicit val decoder: Decoder[PySparkConfig] = deriveDecoder
+}
+
 final case class SparkConfig(
   properties: Map[String, String],
   sparkSubmitArgs: Option[String] = None,
   distClasspathFilter: Option[Pattern] = None,
   propertySets: Option[List[SparkPropertySet]] = None,
-  defaultPropertySet: Option[String] = None
+  defaultPropertySet: Option[String] = None,
+  pyspark: Option[PySparkConfig] = None
 )
 
 object SparkConfig {

--- a/polynote-kernel/src/test/scala/polynote/config/PolynoteConfigSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/config/PolynoteConfigSpec.scala
@@ -115,6 +115,11 @@ class PolynoteConfigSpec extends FlatSpec with Matchers with EitherValues {
         |    foo:   bar
         |  spark_submit_args: these are the args
         |  dist_classpath_filter: .jar$
+        |  pyspark:
+        |    distribute_dependencies: true
+        |    distribution_excludes:
+        |     - foo
+        |     - bar
         |  property_sets:
         |    - name: Test
         |      properties:
@@ -136,6 +141,8 @@ class PolynoteConfigSpec extends FlatSpec with Matchers with EitherValues {
       SparkPropertySet(name = "Test", properties = Map("something" -> "thing", "another" -> "one"), sparkSubmitArgs = Some("some more args"), None),
       SparkPropertySet(name = "Test 2", properties = Map("something" -> "thing2"))
     )
+    parsed.pyspark.get.distributionExcludes shouldEqual List("foo", "bar")
+    parsed.pyspark.get.distributeDependencies shouldEqual Option(true)
   }
 
   it should "fail on invalid configuration" in {

--- a/polynote-spark/src/test/scala/polynote/kernel/interpreter/python/PySparkInterpreterSpec.scala
+++ b/polynote-spark/src/test/scala/polynote/kernel/interpreter/python/PySparkInterpreterSpec.scala
@@ -1,19 +1,15 @@
 package polynote.kernel.interpreter.python
 
-import java.io.IOException
-import java.util.concurrent.atomic.AtomicReference
-
 import org.apache.spark.sql.{AnalysisException, SparkSession}
-import org.scalatest.{BeforeAndAfterEach, FreeSpec, Matchers}
-import polynote.kernel.ScalaCompiler
-import polynote.kernel.environment.Env
+import org.scalatest.{FreeSpec, Matchers}
+import polynote.config.PolynoteConfig
 import polynote.kernel.interpreter.{Interpreter, State}
-import polynote.runtime.python.PythonObject
 import polynote.testing.InterpreterSpec
 import polynote.testing.kernel.MockEnv
 import zio.ZLayer
 import zio.blocking.Blocking
 
+import java.util.concurrent.atomic.AtomicReference
 import scala.reflect.io.PlainDirectory
 import scala.tools.nsc.io.{AbstractFile, Directory}
 
@@ -41,7 +37,7 @@ class PySparkInterpreterSpec extends FreeSpec with InterpreterSpec with Matchers
     if (interpreterRef.get() != null) {
       interpreter.shutdown().runIO()
     }
-    interpreterRef.set(PySparkInterpreter(None).provideSomeLayer[Blocking](ZLayer.succeed(compiler)).runIO())
+    interpreterRef.set(PySparkInterpreter(None).provideSomeLayer[Blocking](ZLayer.succeed(compiler) ++ ZLayer.succeed(PolynoteConfig())).runIO())
 
     f
 
@@ -200,20 +196,20 @@ class PySparkInterpreterSpec extends FreeSpec with InterpreterSpec with Matchers
             "py" -> "four"))
         }
       }
+    }
 
-      "should capture py4j exceptions" in {
-        initialize()
-        try {
-          assertOutput("spark.read.text(\"doesnotexist\")"){ case _ => }
-        } catch {
-          case err: Throwable =>
-            err shouldBe a[RuntimeException]
-            err.getMessage should include ("AnalysisException: 'Path does not exist:")
-            err.getCause shouldBe a[RuntimeException]
-            err.getCause.getMessage should include ("Py4JJavaError: An error occurred while calling")
-            err.getCause.getCause shouldBe a[AnalysisException]
-            err.getCause.getCause.getMessage should include ("Path does not exist:")
-        }
+    "should capture py4j exceptions" in {
+      initialize()
+      try {
+        assertOutput("spark.read.text(\"doesnotexist\")"){ case _ => }
+      } catch {
+        case err: Throwable =>
+          err shouldBe a[RuntimeException]
+          err.getMessage should include ("AnalysisException: 'Path does not exist:")
+          err.getCause shouldBe a[RuntimeException]
+          err.getCause.getMessage should include ("Py4JJavaError: An error occurred while calling")
+          err.getCause.getCause shouldBe a[AnalysisException]
+          err.getCause.getCause.getMessage should include ("Path does not exist:")
       }
     }
   }


### PR DESCRIPTION
Some python modules should not be distributed via PySpark for various
reasons. For example, Boto doesn't work when distributed as a zip file
(which is how the PySpark distribution works), see
https://github.com/boto/boto3/issues/1770 for details.

This PR adds a set of modules excluded by default, as well as
configurability of this feature. It can be turned off entirely, or a
different list of exclusions can be provided.