### PR TITLE
Customize template notebook cell in Polynote config

### DIFF
--- a/config-template.yml
+++ b/config-template.yml
@@ -57,6 +57,8 @@
 #  kernel_isolation: always
 #  shared_packages:
 #    - com.esoteric.kryo
+#  default_notebook: examples/template.ipynb
+
 
 ########## Notebook Creation Configuration #######################################################
 ###

--- a/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
@@ -110,7 +110,8 @@ object KernelIsolation {
 final case class Behavior(
   dependencyIsolation: Boolean = true,
   kernelIsolation: KernelIsolation = KernelIsolation.Always,  // TODO: Should move this to KernelConfig now?
-  sharedPackages: List[String] = Nil
+  sharedPackages: List[String] = Nil,
+  defaultNotebook: String = ""
 ) {
   private final val defaultShares = "scala|javax?|jdk|sun|com.sun|com.oracle|polynote|org.w3c|org.xml|org.omg|org.ietf|org.jcp|org.apache.spark|org.spark_project|org.glassfish.jersey|org.jvnet.hk2|org.apache.hadoop|org.codehaus|org.slf4j|org.log4j|org.apache.log4j"
 

--- a/polynote-kernel/src/test/scala/polynote/config/PolynoteConfigSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/config/PolynoteConfigSpec.scala
@@ -211,4 +211,15 @@ class PolynoteConfigSpec extends FlatSpec with Matchers with EitherValues {
     val parsed = PolynoteConfig.parse(yamlStr)
     parsed.right.value.spark.get.properties("spark.some.decimal") shouldEqual "1.523432422343"
   }
+
+  it should "parse default notebook properly" in {
+    val yamlStr =
+      """
+        |behavior:
+        |  default_notebook: notebooks/template.ipynb
+        |""".stripMargin
+    val parsed = PolynoteConfig.parse(yamlStr)
+    parsed.right.value.behavior.defaultNotebook shouldEqual "notebooks/template.ipynb"
+  }
 }
+

--- a/polynote-server/src/main/scala/polynote/server/repository/FileBasedRepository.scala
+++ b/polynote-server/src/main/scala/polynote/server/repository/FileBasedRepository.scala
@@ -353,6 +353,15 @@ class FileBasedRepository(
       nb      <- maybeContent.map(content => fmt.decodeNotebook(noExtPath, content)).getOrElse {
         val defaultTitle = noExtPath.split('/').last.replaceAll("[\\s\\-_]+", " ").trim()
         emptyNotebook(path, defaultTitle)
+        Config.access.map {
+          config => {
+            config.behavior.defaultNotebook.isEmpty match {
+              case true => emptyNotebook(path, defaultTitle)
+              case false => loadNotebook(config.behavior.defaultNotebook)
+            }
+          }
+        }
+        loadNotebook(path)
       }
       name    <- findUniqueName(nb.path)
       _       <- saveNotebook(nb.copy(path = name))


### PR DESCRIPTION
This PR contains implementation for https://github.com/polynote/polynote/issues/1190

We'd like to make the first cell of new notebooks customizable so that users can inject their code templates for new notebooks. This requires two additional settings under `behavior:default_notebook ` category: `notebook_language` and `notebook_content`. `notebook_language` supports text, python, scala, sql, and vega while `notebook_content` is a string containing the desired template to use.

Tested locally on MacOS JVM 8

<img width="515" alt="Screen Shot 2021-08-17 at 3 54 19 PM" src="https://user-images.githubusercontent.com/75392384/129811165-358a0f2f-b050-4fbe-a602-b1ff621af5c7.png">


![Screen Shot 2021-08-17 at 3 51 30 PM](https://user-images.githubusercontent.com/75392384/129811065-2dc2e298-c3da-46a8-8aeb-1c2bcca6db6d.png)


