### PR TITLE
Fix frontend rebasing

### DIFF
--- a/polynote-frontend/package.json
+++ b/polynote-frontend/package.json
@@ -30,7 +30,6 @@
     "@types/jest": "26.0.19",
     "@types/node": "14.14.20",
     "babel-jest": "26.6.3",
-    "canvas": "2.6.1",
     "copy-webpack-plugin": "7.0.0",
     "css-loader": "3.4.2",
     "fake-indexeddb": "3.1.2",

--- a/polynote-frontend/polynote/data/content_edit.ts
+++ b/polynote-frontend/polynote/data/content_edit.ts
@@ -83,7 +83,11 @@ export abstract class ContentEdit extends CodecContainer {
     }
 
     // port of ContentEdits#rebase, since there's no ContentEdits class here
-    static rebaseEdits(edits1: ContentEdit[], edits2: ContentEdit[]) {
+    static rebaseEdits(edits1: ContentEdit[], edits2: ContentEdit[]): ContentEdit[] {
+        return ContentEdit.rebaseBoth(edits1, edits2)[0];
+    }
+
+    static rebaseBoth(edits1: ContentEdit[], edits2: ContentEdit[]): [ContentEdit[], ContentEdit[]] {
         const result: ContentEdit[] = [];
         let otherEdits = edits2;
         edits1.forEach((edit) => {
@@ -91,7 +95,7 @@ export abstract class ContentEdit extends CodecContainer {
             result.push(...rebased[0]);
             otherEdits = rebased[1];
         });
-        return result;
+        return [result, otherEdits];
     }
 
     isEmpty() {

--- a/polynote-frontend/polynote/data/edit_buffer.test.ts
+++ b/polynote-frontend/polynote/data/edit_buffer.test.ts
@@ -3,22 +3,22 @@ import {DeleteCell} from "./messages";
 
 describe("EditBuffer", () => {
     const firstUpdate = new DeleteCell(0, 0, 0)
-    const secondUpdate = [new DeleteCell(1, 1, 1), new DeleteCell(2, 2, 2)]
+    const secondUpdate = new DeleteCell(2, 2, 2)
     const edits = new EditBuffer()
         .push(0, firstUpdate)
         .push(1, secondUpdate);
-    const expectedVersions = [{version: 0, edits: [firstUpdate]}, {version: 1, edits: secondUpdate}]
+    const expectedVersions = [{version: 0, edit: firstUpdate}, {version: 1, edit: secondUpdate}]
 
     test("stores updates in order", () => {
         expect(edits.versions).toEqual(expectedVersions)
     })
 
     test("properly discards versions", () => {
-        expect(edits.discard(-1).versions).toEqual(expectedVersions)
-        expect(edits.discard(0).versions).toEqual(expectedVersions)
-        expect(edits.discard(1).versions).toEqual([{version: 1, edits: secondUpdate}])
-        expect(edits.discard(2).versions).toEqual([])
-        expect(edits.discard(3).versions).toEqual([])
+        expect(edits.duplicate.discard(-1).versions).toEqual(expectedVersions)
+        expect(edits.duplicate.discard(0).versions).toEqual(expectedVersions)
+        expect(edits.duplicate.discard(1).versions).toEqual([{version: 1, edit: secondUpdate}])
+        expect(edits.duplicate.discard(2).versions).toEqual([])
+        expect(edits.duplicate.discard(3).versions).toEqual([])
     })
 
     test("retrieves a range of versions", () => {
@@ -30,9 +30,9 @@ describe("EditBuffer", () => {
         expect(edits.range(-2, -1)).toEqual([])
         expect(edits.range(1, 2)).toEqual([])
         expect(edits.range(-1, 0)).toEqual([firstUpdate])
-        expect(edits.range(-1, 1)).toEqual([firstUpdate, ...secondUpdate])
-        expect(edits.range(-1, 2)).toEqual([firstUpdate, ...secondUpdate])
-        expect(edits.range(-2, 1)).toEqual([firstUpdate, ...secondUpdate])
-        expect(edits.range(-2, 2)).toEqual([firstUpdate, ...secondUpdate])
+        expect(edits.range(-1, 1)).toEqual([firstUpdate, secondUpdate])
+        expect(edits.range(-1, 2)).toEqual([firstUpdate, secondUpdate])
+        expect(edits.range(-2, 1)).toEqual([firstUpdate, secondUpdate])
+        expect(edits.range(-2, 2)).toEqual([firstUpdate, secondUpdate])
     })
 })

--- a/polynote-frontend/polynote/state/notebook_state.ts
+++ b/polynote-frontend/polynote/state/notebook_state.ts
@@ -499,12 +499,10 @@ export class NotebookUpdateHandler extends Disposable { // extends ObjectStateHa
     rebaseUpdate(update: NotebookUpdate) {
         this.globalVersion = update.globalVersion
         if (update.localVersion < this.localVersion) {
-            const prevUpdates = this.edits.range(update.localVersion, this.localVersion);
+            update = this.edits.rebaseThrough(update, this.localVersion);
 
             // discard edits before the local version from server – it will handle rebasing at least until that point
             this.edits = this.edits.discard(update.localVersion)
-
-            update = messages.NotebookUpdate.rebase(update, prevUpdates)
         }
 
         return update


### PR DESCRIPTION
(Based on #1201)

When getting the concurrent editing test to fully pass, I realized that the key was that the client side needs to do a similar thing to its edit buffer when rebasing as what the server does. It has to rebase each edit through its buffer, while also correcting the buffered edit for future rebasing.

So I added that functionality to `EditBuffer` on the client side. It would be great to add a test for this, but simulating the server from the client would be a lot harder! Maybe at some point we can set up real integration tests (where a server will be started, and we can run a test with two clients from the frontend tests).  However, I tested this change locally (by opening two browser windows to the same notebook, and scripting each of them to "keyboard mash", and checking whether they both ended up with the same state).

I also made `EditBuffer` mutable at the same time, because I don't see any reason for it to be immutable. Being mutable will avoid a lot of array copying.