### PR TITLE
Some small steps towards better stderr support

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/CellExecutor.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/CellExecutor.scala
@@ -25,14 +25,18 @@ class CellExecutor(publishSync: Result => Unit, classLoader: ClassLoader, blocki
     blockingExecutor.submit {
       new Runnable {
         def run(): Unit = {
-          val console = new ResultPrintStream(publishSync)()
+          val stdout = new ResultPrintStream(publishSync)()
+          val stderr = new ResultPrintStream(publishSync, rel = "stderr")()
           withContextClassLoader(classLoader) {
             try {
-              Console.withOut(console) {
-                runnable.run()
+              Console.withOut(stdout) {
+                Console.withErr(stderr) {
+                  runnable.run()
+                }
               }
             } finally {
-              console.close()
+              stdout.close()
+              stderr.close()
             }
           }
         }

--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/python/PythonInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/python/PythonInterpreter.scala
@@ -529,7 +529,8 @@ class PythonInterpreter private[python] (
       |        had some serious performance degradations.
       |        '''
       |        try:
-      |            sys.stdout = kernel.display
+      |            sys.stdout = kernel.stdout
+      |            sys.stderr = kernel.stderr
       |
       |            # These names already exist in globals, so we keep track of them in case they might be reassignments
       |            # This is needed for proper attribution of declarations to cells, otherwise a shadowed variable could

--- a/polynote-kernel/src/test/scala/polynote/kernel/interpreter/python/PythonInterpreterSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/interpreter/python/PythonInterpreterSpec.scala
@@ -417,7 +417,7 @@ class PythonInterpreterSpec extends FreeSpec with Matchers with InterpreterSpec 
 
     "completions" in {
       val completions = interpreter.completionsAt("dela", 4, State.id(1)).runIO()
-      completions shouldEqual List(Completion("delattr", Nil, TinyList(List(TinyList(List(("o", ""), ("name", "str"))))), "", CompletionType.Method))
+      completions shouldEqual List(Completion("delattr", Nil, TinyList(List(TinyList(List(("obj", ""), ("name", "str"))))), "", CompletionType.Method))
       val keywordCompletion = interpreter.completionsAt("d={'foo': 'bar'}; d['']", 21, State.id(1)).runIO()
       keywordCompletion shouldEqual List(Completion("'foo", Nil, Nil, "", CompletionType.Unknown, None))
     }
@@ -425,8 +425,8 @@ class PythonInterpreterSpec extends FreeSpec with Matchers with InterpreterSpec 
     "parameters" in {
       val params = interpreter.parametersAt("delattr(", 8, State.id(1)).runIO()
       params shouldEqual Option(Signatures(List(
-        ParameterHints("delattr(o, name: str)", Option("Deletes the named attribute from the given object."),
-          List(ParameterHint("o", "", None), ParameterHint("name", "str", None)))),0,0))
+        ParameterHints("delattr(obj, name: str)", Option("Deletes the named attribute from the given object."),
+          List(ParameterHint("obj", "", None), ParameterHint("name", "str", None)))),0,0))
     }
 
 

--- a/polynote-kernel/src/test/scala/polynote/kernel/interpreter/scal/ScalaInterpreterSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/interpreter/scal/ScalaInterpreterSpec.scala
@@ -347,6 +347,20 @@ class ScalaInterpreterSpec extends FreeSpec with Matchers with InterpreterSpec {
       }
     }
 
+    "capture printing to stderr too" in {
+      val code =
+        """
+          |Console.out.println("stdout")
+          |Console.err.println("stderr")
+      """.stripMargin
+      assertOutput(code) {
+        (vars, output) =>
+          vars shouldBe empty
+          stdOut(output) shouldEqual "stdout\n"
+          stdErr(output) shouldEqual "stderr\n"
+      }
+    }
+
     "support destructured assignment" in {
       val code =
         """

--- a/polynote-kernel/src/test/scala/polynote/testing/InterpreterSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/testing/InterpreterSpec.scala
@@ -81,4 +81,9 @@ trait InterpreterSpec extends ZIOSpec {
     case (accum, _) => accum
   }
 
+  def stdErr(results: Seq[Result]): String = results.foldLeft("") {
+    case (accum, Output("text/plain; rel=stderr", next)) => accum + next.mkString
+    case (accum, _) => accum
+  }
+
 }

--- a/polynote-runtime/src/main/java/polynote/runtime/KernelRuntime.java
+++ b/polynote-runtime/src/main/java/polynote/runtime/KernelRuntime.java
@@ -6,14 +6,29 @@ public class KernelRuntime implements Serializable {
     public interface Display extends Serializable {
         void content(String contentType, String content);
 
+        // TODO(jindig): I removed write() and a few other methods from here. Should we keep them for backwards-compatibility?
         default void html(String content) { content("text/html", content); }
-        default void write(String str) { content("text/plain; rel=stdout", str); }
-        default void flush() {} // So python doesn't error on sys.stdout.flush().
         default void text(String str) { content("text/plain", str); }
-        default Boolean isatty() { return false; } // so python doesn't error when checking isatty(), as some libs seem to do.
+    }
+
+    // Implement a File-like object (https://docs.python.org/3/glossary.html#term-file-object) for writing plaintext output
+    public static class Output implements Serializable {
+        transient private final Display display;
+        transient private final String type;
+
+        public Output(Display display, String type) {
+            this.display = display;
+            this.type = type;
+        }
+
+        public void write(String str) { display.content(type, str); }
+        public void flush() {} // So python doesn't error on sys.stdout.flush().
+        public Boolean isatty() { return false; } // so python doesn't error when checking isatty(), as some libs seem to do.
     }
 
     transient public final Display display;
+    transient public final Output stdout;
+    transient public final Output stderr;
     transient private final scala.Function2<Double, String, scala.Unit> progressSetter;
     transient private final scala.Function1<scala.Option<scala.Tuple2<Integer, Integer>>, scala.Unit> executionStatusSetter;
 
@@ -22,6 +37,8 @@ public class KernelRuntime implements Serializable {
             scala.Function2<Double, String, scala.Unit> progressSetter,
             scala.Function1<scala.Option<scala.Tuple2<Integer, Integer>>, scala.Unit> executionStatusSetter) {
         this.display = display;
+        this.stdout = new Output(display, "text/plain; rel=stdout");
+        this.stderr = new Output(display, "text/plain; rel=stderr");
         this.progressSetter = progressSetter;
         this.executionStatusSetter = executionStatusSetter;
     }

--- a/polynote-server/src/main/scala/polynote/server/repository/format/ipynb/ast.scala
+++ b/polynote-server/src/main/scala/polynote/server/repository/format/ipynb/ast.scala
@@ -129,6 +129,7 @@ object JupyterOutput {
       List {
         args.get("rel") match {
           case Some(name) if mime == "text/plain" && name == "stdout" => Stream(name, content.toList)
+          case Some(name) if mime == "text/plain" && name == "stderr" => Stream(name, content.toList)
           case _ => DisplayData(Map(mime -> Json.arr(content.map(_.asJson): _*)), args.get("lang").map(l => Map("lang" -> l).asJsonObject))
         }
       }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ ipython
 nbconvert
 numpy
 pandas==1.2.5
-jedi==0.18.*
+jedi>=0.18.1
 jep==3.9.*


### PR DESCRIPTION
Added some support for stderr cell Output.

Does **NOT** capture stderr output from kernel processes! This means it
doesn't do anything to Spark logging; in fact, there are no changes to
System.err at all.

However, this does effectively support stderr output in Python, since
sys.stderr can be easily remapped.

The UI already supported Output with "text/plain; rel=stderr"
contentType, so nothing needs to be changed there.

This is the first step towards more robust support for handling stderr.

![stderr](https://user-images.githubusercontent.com/5430417/142712231-7377fce0-97cb-4902-a2ff-2cfcc76fbcf4.png)

