### PR TITLE
Fix JVM argument handling in Spark kernels #1220

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/DeploySparkSubmit.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/DeploySparkSubmit.scala
@@ -48,10 +48,11 @@ object DeploySparkSubmit extends DeployCommand {
     val isRemote = sparkConfig.get("spark.submit.deployMode") contains "cluster"
 
     val allDriverOptions = {
-      nbConfig.jvmArgs.toList ++
-      sparkConfig.get("spark.driver.extraJavaOptions").toList ++
-      asPropString(javaOptions)
-    } mkString " "
+      val all: List[String] = jvmArgs(nbConfig) ++
+        sparkConfig.get("spark.driver.extraJavaOptions").toList ++
+        asPropString(javaOptions)
+      all mkString " "
+    }
 
     val additionalJars = classPath.toList.filter(_.getFile.endsWith(".jar"))
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/package.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/package.scala
@@ -1,6 +1,7 @@
 package polynote.kernel
 
 import polynote.kernel.util.RPublish
+import polynote.messages.NotebookConfig
 import zio.Has
 
 import java.io.File
@@ -24,4 +25,5 @@ package object remote {
     case (name, value) => s"-D$name=$value"
   }
 
+  def jvmArgs(nbConfig: NotebookConfig) = nbConfig.jvmArgs.toList.flatten
 }

--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/transport.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/transport.scala
@@ -425,7 +425,7 @@ object SocketTransport {
             .filterNot(_.isEmpty)
             .mkString(File.pathSeparator)
 
-          val javaArgs = notebookConfig.jvmArgs.toList.flatten ++ asPropString(javaOptions)
+          val javaArgs = jvmArgs(notebookConfig) ++ asPropString(javaOptions)
 
           java :: "-cp" :: fullClassPath :: javaArgs :::
             classOf[RemoteKernelClient].getName ::

--- a/polynote-kernel/src/test/scala/polynote/kernel/remote/DeploySparkSubmitSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/remote/DeploySparkSubmitSpec.scala
@@ -1,14 +1,44 @@
 package polynote.kernel.remote
 
 import org.scalatest.{FreeSpec, Matchers}
+import polynote.config.PolynoteConfig
+import polynote.buildinfo.BuildInfo
+import polynote.messages.{NotebookConfig, TinyList}
 import polynote.testing.ZIOSpec
 import polynote.testing.MockSystem
 import zio.ZIO
 
 import java.io.File
+import java.net.{URI, URL}
 import java.nio.file.{Files, Paths}
 
 class DeploySparkSubmitSpec extends FreeSpec with Matchers with ZIOSpec {
+
+  "Generates a proper command string" in {
+    val conf = PolynoteConfig()
+    val jvmProps: Option[TinyList[String]] = Option(List("-Dprop=value"))
+    val nbConf = NotebookConfig(None, None, None, None, None, None, jvmArgs = jvmProps)
+    val nbPath = "foo"
+    val assemblyJar = "/path/to/polynote/polynote-spark-assembly.jar"
+    val cp = Seq(
+      URI.create("file:///path/to/my.jar").toURL,
+      URI.create("file:///path/to/not-a-jar/").toURL,
+      URI.create(s"file://${assemblyJar}").toURL)
+    val serverArgs = List("--address", "blah", "--port", "12345")
+
+    val expected =
+      "spark-submit" ::
+        "--class" :: "polynote.kernel.remote.RemoteKernelClient" ::
+        "--name" :: s"Polynote ${BuildInfo.version}: $nbPath" ::
+        "--driver-java-options" :: (jvmArgs(nbConf) ++ asPropString(javaOptions)).mkString(" ") ::
+        "--driver-class-path" :: cp.map(_.getPath).mkString(File.pathSeparator) ::
+        assemblyJar ::
+        serverArgs
+
+    val command = DeploySparkSubmit.build(conf, nbConf, nbPath, cp, serverArgs = serverArgs)
+
+    command should contain theSameElementsInOrderAs expected
+  }
 
   "Detect scala version" - {
 


### PR DESCRIPTION
A `.flatten` was missing in `DeploySparkSubmit`. This fix adds a test and also contains minor refactoring to share a bit more code between `DeployJava` and `DeploySparkSubmit`. 

Resolves #1220 