### PR TITLE
Fix a failure in the notebook runner when the notebook has a 'viz' cell #1236

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 * Fix bug preventing addition of new cells in empty notebooks #1229
+* Fix a failure in the notebook runner when the notebook has a 'viz' cell #1236
 
 # 0.4.4 (Dec 10, 2021)
 * Upgrade Jep to 4.0.0


### PR DESCRIPTION
Note: I reverted the logic to allow the listed cells types instead of filtering out those that are not able to run in the notebook runner mode. The latter looks more clear and failure-proof in case new not-runnable cell types are introduced.