### PR TITLE
Fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Fix for a bug handling JVM arguments in Spark kernels #1221
 * Fix a bug displaying the Cause of exceptions #1226
 
-# O.4.3 (Nov 24, 2021)
+# 0.4.3 (Nov 24, 2021)
 * Preliminary alpha support for Scala 2.13 (with Spark 3) (not yet ready for release)
 * Fix an issue which sometimes caused Polynote to reject all updates, "freezing" the notebook in an old state.
 * Safety and performance improvements to `ReprsOf` solving OOMs when handling huge collections.


### PR DESCRIPTION
Strangely, v0.4.3 was vO.4.3