### PR TITLE
Custom keybindings implementation

### DIFF
--- a/polynote-frontend/polynote/state/notebook_state.ts
+++ b/polynote-frontend/polynote/state/notebook_state.ts
@@ -36,6 +36,7 @@ import {deepEquals, Deferred} from "../util/helpers";
 import {notReceiver} from "../messaging/receiver";
 import {ConstView, ProxyStateView} from "./state_handler";
 import {ServerStateHandler} from "./server_state";
+import { moveArrayValue } from "./state_updates";
 
 
 export type CellPresenceState = {id: number, name: string, color: string, range: PosRange, avatar?: string};
@@ -294,6 +295,33 @@ export class NotebookStateHandler extends BaseHandler<NotebookState> {
         return this.updateHandler.insertCell(maxId + 1, anchor.language, anchor.content ?? '', anchor.metadata, maybePrevId).then(
             insert => insert.cell.id
         )
+    }
+
+    /**
+     * Helper for moving current cell.
+     *
+     * @param direction  Whether to insert below of above the anchor
+     * @return           A Promise that resolves with the inserted cell's id.
+     */
+    moveCell(direction: 'above' | 'below'): Promise<number|undefined> {
+        const state = this.state;
+        let currentCellId = state.activeCellId;
+        if (currentCellId) {
+            const anchorIdx = this.getCellIndex(currentCellId)!;
+            const afterIdx = direction === 'above' ? anchorIdx - 1 : anchorIdx + 1;
+            // trigger the move
+            if (afterIdx >= 0 && afterIdx < state.cellOrder.length) {
+                //TODO: why does moveCell not work?
+                //this.updateHandler.moveCell(currentCellId, maybeAfterId);
+                return this.updateAsync(state => {
+                    return {
+                        cellOrder: moveArrayValue(anchorIdx, afterIdx)
+                    }
+                }, this, 'cellOrder')
+                .then(_ => currentCellId);
+            }
+        }
+        return Promise.resolve(undefined);
     }
 
     /**

--- a/polynote-frontend/polynote/state/server_state.ts
+++ b/polynote-frontend/polynote/state/server_state.ts
@@ -12,7 +12,7 @@ import {
     StateView,
     updateProperty
 } from ".";
-import {Identity} from "../data/messages";
+import {HotkeyInfo, Identity} from "../data/messages";
 import {SocketSession} from "../messaging/comms";
 import {NotebookMessageReceiver} from "../messaging/receiver";
 import {NotebookMessageDispatcher,} from "../messaging/dispatcher";
@@ -38,7 +38,8 @@ export interface ServerState {
     serverVersion: string,
     serverCommit: string,
     identity: Identity,
-    sparkTemplates: SparkPropertySet[]
+    sparkTemplates: SparkPropertySet[],
+    customKeybindings: Record<number, HotkeyInfo>,
     // ephemeral states
     currentNotebook?: string,
     openNotebooks: string[],
@@ -63,6 +64,7 @@ export class ServerStateHandler extends BaseHandler<ServerState> {
                 serverCommit: "unknown",
                 identity: new Identity("Unknown User", null),
                 sparkTemplates: [],
+                customKeybindings: {},
                 currentNotebook: undefined,
                 openNotebooks: [],
                 serverOpenNotebooks: []
@@ -105,6 +107,7 @@ export class ServerStateHandler extends BaseHandler<ServerState> {
                 serverCommit: "unknown",
                 identity: new Identity("Unknown User", null),
                 sparkTemplates: [],
+                customKeybindings: {},
                 currentNotebook: undefined,
                 openNotebooks: [],
                 serverOpenNotebooks: []

--- a/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
@@ -139,8 +139,21 @@ object Security {
   implicit val decoder: Decoder[Security] = deriveConfigDecoder
 }
 
+final case class HotkeyInfo(
+  key: String,
+  description: String,
+  hide: Boolean = false,
+  vimOnly: Boolean = false
+)
+
+object HotkeyInfo {
+  implicit val encoder: Encoder.AsObject[HotkeyInfo] = deriveEncoder
+  implicit val decoder: Decoder[HotkeyInfo] = deriveDecoder
+}
+
 final case class UI(
-  baseUri: String = "/"
+  baseUri: String = "/",
+  customKeybindings: Map[String, HotkeyInfo] = Map()
 )
 
 object UI {

--- a/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
+++ b/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
@@ -8,7 +8,7 @@ import scodec.bits.{BitVector, ByteVector}
 import scodec.codecs._
 import scodec.codecs.implicits._
 import io.circe.generic.semiauto._
-import polynote.config.{DependencyConfigs, PolynoteConfig, RepositoryConfig, SparkConfig, SparkPropertySet}
+import polynote.config.{DependencyConfigs, PolynoteConfig, RepositoryConfig, SparkConfig, SparkPropertySet, HotkeyInfo}
 import polynote.data.Rope
 import polynote.runtime.{CellRange, StreamingDataRepr, TableOp}
 import shapeless.cachedImplicit
@@ -419,7 +419,8 @@ final case class ServerHandshake(
   serverVersion: TinyString,
   serverCommit: TinyString,
   identity: Option[Identity],
-  sparkTemplates: List[SparkPropertySet]
+  sparkTemplates: List[SparkPropertySet],
+  customKeybindings: TinyMap[TinyString,HotkeyInfo]
 ) extends Message
 object ServerHandshake extends MessageCompanion[ServerHandshake](16)
 

--- a/polynote-server/src/main/scala/polynote/server/SocketSession.scala
+++ b/polynote-server/src/main/scala/polynote/server/SocketSession.scala
@@ -11,6 +11,7 @@ import polynote.kernel.logging.Logging
 import polynote.messages._
 import polynote.server.auth.IdentityProvider.checkPermission
 import polynote.server.auth.{IdentityProvider, Permission, UserIdentity}
+import polynote.config.HotkeyInfo
 import uzhttp.websocket.Frame
 import zio.stream.{Stream, Take, UStream, ZStream}
 import zio.Queue
@@ -85,7 +86,8 @@ object SocketSession {
       serverVersion = BuildInfo.version,
       serverCommit = BuildInfo.commit,
       identity = identity.map(i => Identity(i.name, i.avatar.map(ShortString))),
-      sparkTemplates = config.spark.flatMap(_.propertySets).getOrElse(Nil)
+      sparkTemplates = config.spark.flatMap(_.propertySets).getOrElse(Nil),
+      customKeybindings = config.ui.customKeybindings.asInstanceOf[TinyMap[TinyString, HotkeyInfo]],
     )
 
   def getRunningKernels: RIO[SessionEnv with PublishMessage with NotebookManager, RunningKernels] = for {


### PR DESCRIPTION
Hi @jeremyrsmith,

I tried to implement custom keybindings in config.yml as follow up for https://github.com/polynote/polynote/issues/1252.
I must say that i really like Polynotes code and found it easy to add functionality. Amazing how you built your own server protocol...

The draft implementation of this PR works, but i would like to have you opinion on some design decisions before finalizing it:

1) I found current cellHotkeys definition in cell.ts. It seems to me that they have the scope "cell", e.g. only being active when focus is on a notebook cell. Do you have plans for other scopes, e.g. hotkeys in the list of notebooks?
Should we then add a scope to the configuration entries in the configuration?

2) I dont like this static definitions like cellHotkeys too much in code - would you mind moving all these entries into the configuration file as default entries? It would allow to fully customize the hotkey experience...

3) More hotkey actions - in my project we used Spark-Notebook before. It had hotkeys for moving cells up/down and split/merge cells. There are other issues in Polynotes backlog about additional hotkeys (#437,#263). Would it be supported by you to extend Polynote in this way?

4) The current implementation looks a little bit confusing regarding the meaning of keybindings - is it a string, number or Object implementing Keybinding interface, or even Monacos SimpleKeybinding? Also the name hotkey / keybinding is used similar.
Would you agree that this might be a point to cleanup and maybe even have a target solution and naming in mind?

Some technical questions i was struggling with we might discuss directly in the code if ok for you.

I hope this suggestion finds you well - otherwise let me know if your process or format requirements are different.