### PR TITLE
Add documentation for running with IntelliJ

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -9,7 +9,7 @@ outlined under [Dependencies](#dependencies) prior to attempting to build from
 
 ## Dependencies
 
-- JDK 8+
+- JDK 8
 - SBT
 - Node.js 13+
 - Python 3.7
@@ -37,3 +37,11 @@ cd target/dist/polynote
 ./polynote.py
 ```
 
+# Running with IntelliJ
+To run your app using IntelliJ, navigate to `Run -> Edit Configuration` and perform the following steps:
+
+- Select `Modify Options` -> Select `Add VM Options` and `Add depdendencies with provided scope to classpath`
+- Select `Build and Run` -> Select `cp-spark`
+- Under `VM Options`, enter `-Djava.library.path=<path-to-jep>`
+  - Ex: `-Djava.library.path=/opt/homebrew/lib/python3.9/site-packages/jep`
+- Under `Program Arguments`, enter `--watch`

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -3,8 +3,7 @@
 Polynote is written in a combination of Python and Scala (for the backend) 
 and Typescript (for the frontend ui). You will need the development tools
 outlined under [Dependencies](#dependencies) prior to attempting to build from
- source. Alternatively, you can use the 
- [development docker image](https://github.com/polynote/polynote/tree/master/docker#dev-image).
+ source. 
  
 
 ## Dependencies

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -3,7 +3,8 @@
 Polynote is written in a combination of Python and Scala (for the backend) 
 and Typescript (for the frontend ui). You will need the development tools
 outlined under [Dependencies](#dependencies) prior to attempting to build from
- source. 
+ source. Alternatively, you can use the 
+ [development docker image](https://github.com/polynote/polynote/tree/master/docker#dev-image).
  
 
 ## Dependencies

--- a/docs-site/docs/docs/development.md
+++ b/docs-site/docs/docs/development.md
@@ -1,1 +1,1 @@
-`sbt dist`
+See [Developing Polynote on GitHub](https://github.com/polynote/polynote/blob/master/DEVELOPING.md)

--- a/docs-site/docs/docs/docker.md
+++ b/docs-site/docs/docs/docker.md
@@ -1,0 +1,1 @@
+See [Official Docker Images on GitHub](https://github.com/polynote/polynote/tree/master/docker#dev-image)


### PR DESCRIPTION
- Added section to configure the `run` button in IntelliJ 
- Clarified JDK version (JDK 11 currently fails to build) 
- Added link to GitHub doc on web docs 