### PR TITLE
add sticky new cell button on last cell, enlarge sizing

### DIFF
--- a/polynote-frontend/style/colors.less
+++ b/polynote-frontend/style/colors.less
@@ -76,7 +76,7 @@ select {
 }
 
 .new-cell-divider {
-  &:hover {
+  &:hover, .cell-and-divider:last-child & {
     background-color: @new-cell-divider-hover-bg;
   }
 }

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -276,15 +276,16 @@ select {
 }
 
 .new-cell-divider {
-  height: 0.5em;
+  height: 0.75em;
   text-align: center;
   line-height: 0.5em;
   padding-top: 1px; // correct '+' location
   white-space: pre;
   font-family: @code-fonts;
+  font-size: 16px;
   margin-left: @cell-left-border-width;
 
-  &:hover:after {
+  &:hover:after, .cell-and-divider:last-child &:after {
     content: '+';
   }
 }


### PR DESCRIPTION
Addressing #1262, two changes make the new cell button more obvious: 
- Enlarge the spacing between each cell (and thus, the button size) for better visibility 
- Add a sticky button to the bottom of the last cell 

Another possible enhancement was to make the button right below the currently selected cell visible, however I chose to ignore it. I think this issue is primarily pointed at new users, whose first notebook would only have a few cells, and thus they could see the button now anyways (and it has been made larger). Open for any discussions though on how it could still be made better! 