### PR TITLE
Add markdown cells (#755)

### DIFF
--- a/docs-site/docs/docs/examples/Writing Markdown.ipynb
+++ b/docs-site/docs/docs/examples/Writing Markdown.ipynb
@@ -1,0 +1,144 @@
+{
+  "metadata" : {
+    "config" : {
+      "dependencies" : {
+        
+      },
+      "exclusions" : [
+      ],
+      "repositories" : [
+      ],
+      "env" : {
+        
+      }
+    },
+    "language_info" : {
+      "name" : "scala"
+    }
+  },
+  "nbformat" : 4,
+  "nbformat_minor" : 0,
+  "cells" : [
+    {
+      "cell_type" : "markdown",
+      "execution_count" : 0,
+      "metadata" : {
+        "language" : "text"
+      },
+      "language" : "text",
+      "source" : [
+        "# Writing Markdown\n",
+        "\n",
+        "\n",
+        "This is a rich text cell. Polynote also supports markdown cells, an example of which is below. To edit it, click on the cell to view the raw markdown, and click anywhere else on the page to see it rendered into HTML. \n",
+        "\n",
+        "\n"
+      ],
+      "outputs" : [
+      ]
+    },
+    {
+      "cell_type" : "markdown",
+      "execution_count" : 1,
+      "metadata" : {
+        "language" : "markdown"
+      },
+      "language" : "markdown",
+      "source" : [
+        "# h1 Heading \n",
+        "## h2 Heading\n",
+        "### h3 Heading\n",
+        "#### h4 Heading\n",
+        "##### h5 Heading\n",
+        "###### h6 Heading\n",
+        "\n",
+        "\n",
+        "## Horizontal Rules\n",
+        "\n",
+        "---\n",
+        "\n",
+        "## Emphasis\n",
+        "\n",
+        "**This is bold text**\n",
+        "\n",
+        "__This is bold text__\n",
+        "\n",
+        "*This is italic text*\n",
+        "\n",
+        "_This is italic text_\n",
+        "\n",
+        "~~Strikethrough~~\n",
+        "\n",
+        "\n",
+        "## Blockquotes\n",
+        "\n",
+        "> Blockquotes can also be nested...\n",
+        ">> ...by using additional greater-than signs right next to each other...\n",
+        "> > > ...or with spaces between arrows.\n",
+        "\n",
+        "\n",
+        "## Lists\n",
+        "\n",
+        "Unordered\n",
+        "\n",
+        "+ Create a list by starting a line with `+`, `-`, or `*`\n",
+        "+ Sub-lists are made by indenting 2 spaces:\n",
+        "  - Marker character change forces new list start:\n",
+        "    * Ac tristique libero volutpat at\n",
+        "    + Facilisis in pretium nisl aliquet\n",
+        "    - Nulla volutpat aliquam velit\n",
+        "+ Very easy!\n",
+        "\n",
+        "Ordered\n",
+        "\n",
+        "1. Lorem ipsum dolor sit amet\n",
+        "2. Consectetur adipiscing elit\n",
+        "3. Integer molestie lorem at massa\n",
+        "\n",
+        "Start numbering with offset:\n",
+        "\n",
+        "57. foo\n",
+        "1. bar\n",
+        "\n",
+        "\n",
+        "## Code\n",
+        "\n",
+        "Inline `code`\n",
+        "\n",
+        "Block code \"fences\"\n",
+        "\n",
+        "```\n",
+        "var foo = function (bar) {\n",
+        "  return bar++;\n",
+        "};\n",
+        "\n",
+        "console.log(foo(5));\n",
+        "```\n",
+        "\n",
+        "## Tables\n",
+        "\n",
+        "| Option | Description |\n",
+        "| ------ | ----------- |\n",
+        "| data   | path to data files to supply the data that will be passed into templates. |\n",
+        "| engine | engine to be used for processing templates. Handlebars is the default. |\n",
+        "| ext    | extension to be used for dest files. |\n",
+        "\n",
+        "Right aligned columns\n",
+        "\n",
+        "| Option | Description |\n",
+        "| ------:| -----------:|\n",
+        "| data   | path to data files to supply the data that will be passed into templates. |\n",
+        "| engine | engine to be used for processing templates. Handlebars is the default. |\n",
+        "| ext    | extension to be used for dest files. |\n",
+        "\n",
+        "\n",
+        "## Images\n",
+        "\n",
+        "![Minion](https://octodex.github.com/images/minion.png)\n",
+        "![Stormtroopocat](https://octodex.github.com/images/stormtroopocat.jpg \"The Stormtroopocat\")\n"
+      ],
+      "outputs" : [
+      ]
+    }
+  ]
+}

--- a/polynote-frontend/polynote/messaging/dispatcher.ts
+++ b/polynote-frontend/polynote/messaging/dispatcher.ts
@@ -214,7 +214,7 @@ export class NotebookMessageDispatcher extends MessageDispatcher<NotebookState, 
             cellIds = this.state.cellOrder
         }
 
-        cellIds = collect(cellIds, id => this.state.cells[id]?.language !== "text" ? id : undefined);
+        cellIds = collect(cellIds, id => this.state.cells[id]?.language !== "text" && this.state.cells[id]?.language !== "markdown" ? id : undefined);
 
         const [clientCells, serverCells] = partition(cellIds, id => {
             const cell = this.state.cells[id]

--- a/polynote-frontend/polynote/messaging/receiver.ts
+++ b/polynote-frontend/polynote/messaging/receiver.ts
@@ -591,8 +591,9 @@ export class ServerMessageReceiver extends MessageReceiver<ServerState> {
                     interpreters[key] = ClientInterpreters[key].languageTitle;
             });
 
+
             return {
-                interpreters: setValue(interpreters),
+                interpreters: setValue({'markdown': 'Markdown', ...interpreters}), // inject the client markdown interpreter here
                 serverVersion: setValue(serverVersion),
                 serverCommit: setValue(serverCommit),
                 identity: setValue(identity ?? new Identity("Unknown User", null)),

--- a/polynote-frontend/polynote/state/notebook_state.ts
+++ b/polynote-frontend/polynote/state/notebook_state.ts
@@ -341,12 +341,12 @@ export class NotebookStateHandler extends BaseHandler<NotebookState> {
         const cell = this.cellsHandler.state[id];
         this.cellsHandler.updateField(id, () => ({
             language,
-            // clear a bunch of stuff if we're changing to text... hm, maybe we need to do something else when it's a a text cell...
-            output: language === "text" ? clearArray() : NoUpdate,
-            results: language === "text" ? clearArray() : NoUpdate,
-            error: language === "text" ? false : NoUpdate,
-            compileErrors: language === "text" ? clearArray() : NoUpdate,
-            runtimeError: language === "text" ? setValue(undefined) : NoUpdate,
+            // clear a bunch of stuff if we're changing to text... hm, maybe we need to do something else when it's a text cell...
+            output: language === "text" || language === "markdown" ? clearArray() : NoUpdate,
+            results: language === "text" || language === "markdown" ? clearArray() : NoUpdate,
+            error: language === "text" || language === "markdown" ? false : NoUpdate,
+            compileErrors: language === "text" || language === "markdown" ? clearArray() : NoUpdate,
+            runtimeError: language === "text" || language === "markdown" ? setValue(undefined) : NoUpdate,
         }), source)
     }
 

--- a/polynote-frontend/polynote/ui/component/notebook/notebook.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/notebook.ts
@@ -238,7 +238,7 @@ export class Notebook extends Disposable {
                 return acc;
             }, undefined);
 
-            const lang = prevCell?.language && prevCell.language !== "text" && prevCell.language !== "viz" ? prevCell.language : "scala"; // TODO: make this configurable
+            const lang = prevCell?.language && prevCell.language !== "text" && prevCell.language !== "markdown" && prevCell.language !== "viz" ? prevCell.language : "scala"; // TODO: make this configurable
 
             this.insertCell(prevCell?.id ?? -1, lang, '');
         });

--- a/polynote-frontend/polynote/ui/component/toolbar.ts
+++ b/polynote-frontend/polynote/ui/component/toolbar.ts
@@ -42,6 +42,9 @@ export class Toolbar extends Disposable {
                             if (lang === "text") {
                                 this.el.classList.remove('editing-code');
                                 this.el.classList.add('editing-text');
+                            } else if (lang === "markdown") {
+                                this.el.classList.remove('editing-code');
+                                this.el.classList.remove('editing-text');
                             } else {
                                 this.el.classList.remove('editing-text');
                                 this.el.classList.add('editing-code');
@@ -198,7 +201,7 @@ class CellToolbar extends ToolbarElement {
         super(connectionStatus);
 
         const selectEl = fakeSelectElem(["cell-language"], [
-            button(["selected"], {value: "text"}, ["Text"])
+            button(["selected"], {value: "text"}, ["Rich Text"])
         ]);
         const disabledSelectEl = fakeSelectElem(["cell-language"], [
             button(["selected"], {}, "")


### PR DESCRIPTION
Addresses #755 by adding a new "Markdown" cell type. Note that this included a large refactor of the `CodeCell` class to a `MonacoCell` abstract superclass - if we think that's too much for this PR, I'm happy to try and refactor accordingly. 


https://user-images.githubusercontent.com/11023620/184995646-a65e816b-7f38-4d97-83fd-f1e4687dadb9.mov

