### PR TITLE
Add notifications for new updates

### DIFF
--- a/config-template.yml
+++ b/config-template.yml
@@ -164,6 +164,14 @@
 #    path: ~/.config/coursier/credentials.properties
 
 #############################################################################################################
+###
+### Notifications. This gives a small pop-up in the UI whenever a new release is available.
+###
+#############################################################################################################
+
+#notifications: release_notifications 
+
+#############################################################################################################
 # Environment variables. This map gets merged with the notebook config's environment variable map at runtime.
 #############################################################################################################
 

--- a/polynote-frontend/polynote/data/messages.ts
+++ b/polynote-frontend/polynote/data/messages.ts
@@ -676,13 +676,13 @@ export class Identity {
 }
 
 export class ServerHandshake extends Message {
-    static codec = combined(mapCodec(uint8, tinyStr, tinyStr), tinyStr, tinyStr, optional(Identity.codec), arrayCodec(int32, SparkPropertySet.codec), arrayCodec(int32, shortStr)).to(ServerHandshake);
+    static codec = combined(mapCodec(uint8, tinyStr, tinyStr), tinyStr, tinyStr, optional(Identity.codec), arrayCodec(int32, SparkPropertySet.codec), arrayCodec(int32, shortStr), bool).to(ServerHandshake);
     static get msgTypeId() { return 16; }
     static unapply(inst: ServerHandshake): ConstructorParameters<typeof ServerHandshake> {
-        return [inst.interpreters, inst.serverVersion, inst.serverCommit, inst.identity, inst.sparkTemplates, inst.notebookTemplates];
+        return [inst.interpreters, inst.serverVersion, inst.serverCommit, inst.identity, inst.sparkTemplates, inst.notebookTemplates, inst.notifications];
     }
 
-    constructor(readonly interpreters: Record<string, string>, readonly serverVersion: string, readonly serverCommit: string, readonly identity: Identity | null, readonly sparkTemplates: SparkPropertySet[], readonly notebookTemplates: string[]) {
+    constructor(readonly interpreters: Record<string, string>, readonly serverVersion: string, readonly serverCommit: string, readonly identity: Identity | null, readonly sparkTemplates: SparkPropertySet[], readonly notebookTemplates: string[], readonly notifications: boolean) {
         super();
         Object.freeze(this);
     }

--- a/polynote-frontend/polynote/messaging/receiver.ts
+++ b/polynote-frontend/polynote/messaging/receiver.ts
@@ -578,7 +578,7 @@ export class ServerMessageReceiver extends MessageReceiver<ServerState> {
             })
             return { notebooks: setValue(notebooks) }
         });
-        this.receive(messages.ServerHandshake, (s, interpreters, serverVersion, serverCommit, identity, sparkTemplates, notebookTemplates) => {
+        this.receive(messages.ServerHandshake, (s, interpreters, serverVersion, serverCommit, identity, sparkTemplates, notebookTemplates, notifications) => {
             // First, we need to check to see if versions match. If they don't, we need to reload to clear out any
             // messed up state!
             if (s.serverVersion !== "unknown" && serverVersion !== s.serverVersion) {
@@ -598,7 +598,8 @@ export class ServerMessageReceiver extends MessageReceiver<ServerState> {
                 serverCommit: setValue(serverCommit),
                 identity: setValue(identity ?? new Identity("Unknown User", null)),
                 sparkTemplates: setValue(sparkTemplates),
-                notebookTemplates: setValue(notebookTemplates)
+                notebookTemplates: setValue(notebookTemplates),
+                notifications: setValue(notifications)
             }
         });
         this.receive(messages.RunningKernels, (s, kernelStatuses) => {

--- a/polynote-frontend/polynote/state/preferences.ts
+++ b/polynote-frontend/polynote/state/preferences.ts
@@ -5,6 +5,7 @@ import {deepEquals, diffArray} from "../util/helpers";
 export type RecentNotebooks = {name: string, path: string}[];
 export type OpenNotebooks = string[]; // paths
 export type NotebookScrollLocations = Record<string, number>; // path -> scrollTop
+export type DismissedNotifications = string[];
 export interface ViewPreferences {
     leftPane: {
         size: string,
@@ -60,6 +61,7 @@ export function clearStorage() {
 export const RecentNotebooksHandler = new LocalStorageHandler<RecentNotebooks>("RecentNotebooks", storage.get("recentNotebooks") ?? []);
 export const OpenNotebooksHandler = new LocalStorageHandler<OpenNotebooks>("OpenNotebooks", []);
 export const NotebookScrollLocationsHandler = new LocalStorageHandler<NotebookScrollLocations>("NotebookScrollLocations", {});
+export const DismissedNotificationsHandler = new LocalStorageHandler<DismissedNotifications>("DismissedNotifications", []);
 export const ViewPrefsHandler = new LocalStorageHandler<ViewPreferences>("ViewPreferences", {
     leftPane: {
         size: '300px',

--- a/polynote-frontend/polynote/state/server_state.ts
+++ b/polynote-frontend/polynote/state/server_state.ts
@@ -40,6 +40,7 @@ export interface ServerState {
     identity: Identity,
     sparkTemplates: SparkPropertySet[],
     notebookTemplates: string[],
+    notifications: boolean,
     // ephemeral states
     currentNotebook?: string,
     openNotebooks: string[],
@@ -66,6 +67,7 @@ export class ServerStateHandler extends BaseHandler<ServerState> {
                 identity: new Identity("Unknown User", null),
                 sparkTemplates: [],
                 notebookTemplates: [],
+                notifications: false,
                 currentNotebook: undefined,
                 openNotebooks: [],
                 serverOpenNotebooks: [],
@@ -110,6 +112,7 @@ export class ServerStateHandler extends BaseHandler<ServerState> {
                 identity: new Identity("Unknown User", null),
                 sparkTemplates: [],
                 notebookTemplates: [],
+                notifications: false,
                 currentNotebook: undefined,
                 openNotebooks: [],
                 serverOpenNotebooks: [],

--- a/polynote-frontend/polynote/ui/component/about.ts
+++ b/polynote-frontend/polynote/ui/component/about.ts
@@ -11,7 +11,7 @@ import {TabNav} from "../layout/tab_nav";
 import {getHotkeys} from "../input/hotkeys";
 import {ServerStateHandler} from "../../state/server_state";
 import {
-    clearStorage,
+    clearStorage, DismissedNotificationsHandler,
     LocalStorageHandler, NotebookScrollLocationsHandler, OpenNotebooksHandler,
     RecentNotebooksHandler,
     UserPreferencesHandler, ViewPrefsHandler
@@ -180,6 +180,7 @@ export class About extends FullScreenModal implements IDisposable {
         addStorageEl(NotebookScrollLocationsHandler)
         addStorageEl(OpenNotebooksHandler)
         addStorageEl(ViewPrefsHandler)
+        addStorageEl(DismissedNotificationsHandler)
 
         storageInfoEl.appendChild(storageTable);
 

--- a/polynote-frontend/polynote/ui/component/notification.ts
+++ b/polynote-frontend/polynote/ui/component/notification.ts
@@ -1,0 +1,21 @@
+import {a, div, iconButton, para} from "../tags";
+import {DismissedNotificationsHandler} from "../../state/preferences";
+
+export class Notification {
+    readonly el: HTMLElement;
+
+    constructor(version: string, releaseNotes: string) {
+        this.el = div(['snackbar'], [
+            iconButton(['notification-close'], 'Close', 'times-circle', 'Close').click(evt => {
+                DismissedNotificationsHandler.update((ignoredReleases) => {
+                    const newIgnoredReleases: string[] = Object.assign([], ignoredReleases);
+                    newIgnoredReleases.push(version);
+                    return newIgnoredReleases;
+                });
+                this.el.remove();
+            }),
+            para([], [`Great news! Version ${version} of Polynote is now available.`]),
+            a([], releaseNotes, ["View the release notes here."], { target: "_blank" })
+        ])
+    }
+}

--- a/polynote-frontend/style/colors.less
+++ b/polynote-frontend/style/colors.less
@@ -977,6 +977,11 @@ button.dialog-button {
   }
 }
 
+.snackbar {
+  background-color: @ui-background;
+  border-left: 2px solid @ui-selected;
+}
+
 .link-component {
   background: @ui-border-light;
   box-shadow: 0px 0px 5px @ui-border-dark;

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -3284,6 +3284,23 @@ img.icon, svg.icon {
   }
 }
 
+.snackbar {
+  width: 25em;
+  margin-left: -12.5em;
+  border-radius: 8px;
+  padding: 16px 32px 24px 16px;
+  position: fixed;
+  z-index: 999;
+  right: 2.5%;
+  bottom: 2em;
+
+  .notification-close {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+  }
+}
+
 .polynote-logo {
   background-repeat: no-repeat;
   background-position: center center;

--- a/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
@@ -239,6 +239,7 @@ final case class PolynoteConfig(
   security: Security = Security(),
   ui: UI = UI(),
   credentials: Credentials = Credentials(),
+  notifications: String = "",
   env: Map[String, String] = Map.empty,
   static: StaticConfig = StaticConfig()
 )

--- a/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
+++ b/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
@@ -422,7 +422,8 @@ final case class ServerHandshake(
   serverCommit: TinyString,
   identity: Option[Identity],
   sparkTemplates: List[SparkPropertySet],
-  notebookTemplates: List[ShortString]
+  notebookTemplates: List[ShortString],
+  notifications: Boolean
 ) extends Message
 object ServerHandshake extends MessageCompanion[ServerHandshake](16)
 

--- a/polynote-kernel/src/test/scala/polynote/config/PolynoteConfigSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/config/PolynoteConfigSpec.scala
@@ -223,4 +223,13 @@ class PolynoteConfigSpec extends FlatSpec with Matchers with EitherValues {
     val parsed = PolynoteConfig.parse(yamlStr)
     parsed.right.value.spark.get.properties("spark.some.decimal") shouldEqual "1.523432422343"
   }
+
+  it should "parse notification config values properly" in {
+    val yamlStr =
+      """
+        |notifications: release_notifications
+        |""".stripMargin
+    val parsed = PolynoteConfig.parse(yamlStr)
+    parsed.right.value.notifications shouldEqual "release_notifications"
+  }
 }

--- a/polynote-server/src/main/scala/polynote/server/SocketSession.scala
+++ b/polynote-server/src/main/scala/polynote/server/SocketSession.scala
@@ -90,7 +90,8 @@ object SocketSession {
       serverCommit = BuildInfo.commit,
       identity = identity.map(i => Identity(i.name, i.avatar.map(ShortString))),
       sparkTemplates = config.spark.flatMap(_.propertySets).getOrElse(Nil),
-      notebookTemplates = config.behavior.notebookTemplates
+      notebookTemplates = config.behavior.notebookTemplates,
+      notifications = config.notifications == "release_notifications"
     )
 
   def getRunningKernels: RIO[SessionEnv with PublishMessage with NotebookManager, RunningKernels] = for {


### PR DESCRIPTION
Creates an "announcement system" to address the need of wanting to notify users whenever a new update comes out in the app by using the GitHub API to check for new Polynote releases. In the interest of privacy and being non-intrusive to users (as we don't want to be spamming API requests from their browsers), a few checks are in place before we check the GitHub API and notify users in the UI: 

- A user must set that they want notifications in their config.yml file (by default they will _not_ be signed up for notifications, unless configured here) 
- A user must have an internet connection 
- If both of the above are true, then we make a request to GitHub's API. However, we only display a notification if the user's version is out of date and they have _not_ previously dismissed a notification for this version (pressing the `X` button will silence notifications for this version forever, unless the user's local browser memory is cleared). 
  - This request will appear on every page refresh until closed. GitHub allows 60 reqs/sec from an IP, so users shouldn't ever get rate limited. 

Video Demo: 
https://user-images.githubusercontent.com/11023620/194441345-10222799-d71c-4d46-b5dc-c89527292604.mov 