### PR TITLE
Fix comment creation

### DIFF
--- a/polynote-frontend/polynote/ui/component/notebook/cell.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/cell.ts
@@ -1663,13 +1663,15 @@ export class CodeCell extends MonacoCell {
     }
 
     protected onDeselected() {
-        super.onDeselected();
-        // TODO (overflow widgets)
-        // this.overflowDomNode.parentNode?.removeChild(this.overflowDomNode)
-        // this.editorEl.closest('.notebook-cells')?.removeEventListener('scroll', this.scrollListener);
-        this.commentHandler.hide()
-        // hide parameter hints on blur
-        this.editor.trigger('keyboard', 'closeParameterHints', null);
+        if (this.cellState.state.currentSelection === undefined) {
+            super.onDeselected();
+            // TODO (overflow widgets)
+            // this.overflowDomNode.parentNode?.removeChild(this.overflowDomNode)
+            // this.editorEl.closest('.notebook-cells')?.removeEventListener('scroll', this.scrollListener);
+            this.commentHandler.hide()
+            // hide parameter hints on blur
+            this.editor.trigger('keyboard', 'closeParameterHints', null);
+        }
     }
 
     delete() {

--- a/polynote-frontend/polynote/ui/component/notebook/cell.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/cell.ts
@@ -1663,14 +1663,16 @@ export class CodeCell extends MonacoCell {
     }
 
     protected onDeselected() {
+        super.onDeselected();
+        // hide parameter hints on blur
+        this.editor.trigger('keyboard', 'closeParameterHints', null);
+        // TODO (overflow widgets)
+        // this.overflowDomNode.parentNode?.removeChild(this.overflowDomNode)
+        // this.editorEl.closest('.notebook-cells')?.removeEventListener('scroll', this.scrollListener);
+
+        // If no line of text was previously selected, then the user wasn't creating a comment, so hide all comments.
         if (this.cellState.state.currentSelection === undefined) {
-            super.onDeselected();
-            // TODO (overflow widgets)
-            // this.overflowDomNode.parentNode?.removeChild(this.overflowDomNode)
-            // this.editorEl.closest('.notebook-cells')?.removeEventListener('scroll', this.scrollListener);
-            this.commentHandler.hide()
-            // hide parameter hints on blur
-            this.editor.trigger('keyboard', 'closeParameterHints', null);
+           this.commentHandler.hide()
         }
     }
 


### PR DESCRIPTION
Addresses a regression where commenting was no longer possible because clicking the `+` icon would open and then immediately close the commend modal. The issue was that the cell would be deselected because the comment modal's textarea would be focused, unfocusing the cell, which was programmed to hide all comments for that cell. This now only happens if a line of text is not selected anymore when a cell deselection occurs, symbolizing that a comment is not trying to be created since no line of text is currently selected. 