### PR TITLE
Support txt dependency lists

### DIFF
--- a/docs-site/docs/docs/notebook-configuration.md
+++ b/docs-site/docs/docs/notebook-configuration.md
@@ -28,6 +28,9 @@ both Maven and Ivy resolvers (the type of resolver can be selected in the dropdo
 Additionally, Polynote supports specifying a URL directly to a jar file - such as `file:///home/jars/myCoolLibrary.jar`. 
 Supported schemas include `http` and `s3` (if Spark is enabled). 
 
+You can place your JVM dependencies in a newline-separated `.txt` file and include that file's URL in your dependencies.
+This will unpack the `.txt` and download each dependency individually. Note that this method will cache all of the JARs included. 
+
 !!!warning
     Note that if you specify a jar directly, Polynote will not resolve any transitive dependencies for this jar. In 
     general, we recommend using GAV coordinates if you can.

--- a/polynote-kernel/src/main/scala/polynote/kernel/dependency/CoursierFetcher.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/dependency/CoursierFetcher.scala
@@ -45,6 +45,7 @@ object CoursierFetcher {
       config         <- CurrentNotebook.config
       configDeps      = config.dependencies.flatMap(_.toMap.get(language)).map(_.distinct.toList).getOrElse(Nil)
       txtUris        <- downloadUris(configDeps.filter(_.endsWith(".txt")).map(d => new URI(d)))
+      _ <- ZIO(println(txtUris))
       downloadTxtUris = parseTxtUris(txtUris)
       splitRes       <- splitDependencies(configDeps.filter(!_.endsWith(".txt")) ++ downloadTxtUris)
       (deps, uris)    = splitRes
@@ -64,12 +65,12 @@ object CoursierFetcher {
 
   private def parseTxtUris(deps: List[(Boolean, String, File)]): List[String] = {
     deps.map(dep => {
-      parseTxtFile(dep._2)
+      parseTxtFile(dep._3.toURI)
     }).flatten
   }
 
-  private def parseTxtFile(filename: String): List[String] = {
-    val bufferedSource = Source.fromFile(URI.create(filename))
+  private def parseTxtFile(filename: URI): List[String] = {
+    val bufferedSource = Source.fromFile(filename)
     val lines = (for {
       line <- bufferedSource.getLines()
     } yield line).toList

--- a/polynote-kernel/src/test/scala/polynote/kernel/dependency/CoursierFetcherTest.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/dependency/CoursierFetcherTest.scala
@@ -1,0 +1,49 @@
+package polynote.kernel.dependency
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{FreeSpec, Matchers, PrivateMethodTester}
+import polynote.kernel.dependency.CoursierFetcher.parseTxtDeps
+import polynote.testing.ConfiguredZIOSpec
+
+import java.io.{File, FileWriter}
+import java.net.URI
+import java.nio.file.Paths
+
+class CoursierFetcherTest extends FreeSpec with Matchers with MockFactory with ConfiguredZIOSpec with PrivateMethodTester {
+  def fileManager(fileName: String, content: String): URI = {
+    // Create fake directory
+    val dir = Paths.get("someDir").toFile
+    dir.mkdirs()
+    dir.deleteOnExit()
+
+    // Create fake file
+    val file = new File(dir, fileName)
+    file.createNewFile()
+    file.deleteOnExit()
+
+    // Write to fake file
+    val fw = new FileWriter(file)
+    fw.write(content)
+    fw.close()
+
+    file.toURI()
+  }
+
+  "CoursierFetcher" - {
+    "parseTxtFile" - {
+      "correctly parses a list of jars in a .txt file" - {
+        val uri = fileManager("someFileName", "ex1.jar\nex2.jar")
+        parseTxtDeps(uri).runIO() shouldBe List("ex1.jar", "ex2.jar")
+      }
+
+      "correctly parses extraneous whitespace in a list of jars in a .txt file" - {
+        val uri = fileManager("someFileName", "ex1.jar\n\n\n\n    ex2.jar")
+        parseTxtDeps(uri).runIO() shouldBe List("ex1.jar", "ex2.jar")
+      }
+
+      "throws on a bad .txt file path" - {
+        parseTxtDeps(new URI("badPath")).isFailure
+      }
+    }
+  }
+}


### PR DESCRIPTION
Addresses #1349 - currently only supports JVM dependencies, but I can make a follow-up issue for using this logic with Python dependencies as well. 