### PR TITLE
Remove extra dropdown button on advanced options label

### DIFF
--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -2007,18 +2007,14 @@ button.inspect.icon-button {
       padding: 5px;
       margin-left: 5px;
 
-      h3 {
-        margin: 4px 0 4px 0;
+      h3:before {
+        content: none;
       }
     }
 
     &.show-advanced {
       .advanced {
         display: block;
-      }
-
-      .expand svg {
-        transform: rotate(90deg);
       }
     }
 


### PR DESCRIPTION
Fixes a regression I had created when putting dropdowns on the config settings. The `Advanced Options` setting shouldn't have a dropdown next to it since it's controlled by the three dots. This dropdown also didn't do anything either, making it extra confusing for users. 

Bug: 
<img width="541" alt="Screenshot 2022-11-06 at 7 32 21 AM" src="https://user-images.githubusercontent.com/11023620/200180163-eb478b62-6900-4cc5-a0b5-dd87a3ddc9d6.png">


Fix: 
<img width="714" alt="image" src="https://user-images.githubusercontent.com/11023620/200180128-b23f8a98-1670-4ec3-916f-9e2b66582a92.png">