### PR TITLE
Make Polynote compatible with Spark 3.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,12 +16,14 @@ val circeYamlVersion: SettingKey[String] = settingKey("circe-yaml version")
 val sparkInstallLocation: SettingKey[String] = settingKey("Location of Spark installation(s)")
 val sparkHome: SettingKey[String] = settingKey("Location of specific Spark installation to use for SPARK_HOME during tests")
 
+val scala_211 = "2.11.12"
+val scala_212 = "2.12.15"
+val scala_213 = "2.13.8"
 
 val versions = new {
   val coursier   = "2.0.0-RC5-6"
   val zio        = "1.0.11"
 }
-
 
 lazy val nativeLibraryPath = {
   val jepPath = sys.env.get("JEP_DIR") orElse Try {
@@ -32,21 +34,21 @@ lazy val nativeLibraryPath = {
       .filterNot(_.isEmpty)
       .map(_ + "/jep")
   }.toOption.flatten orElse
-    sys.env.get("JAVA_LIBRARY_PATH") orElse
-    sys.env.get("LD_LIBRARY_PATH") orElse
-    sys.env.get("DYLD_LIBRARY_PATH") getOrElse "."
+  sys.env.get("JAVA_LIBRARY_PATH") orElse
+  sys.env.get("LD_LIBRARY_PATH") orElse
+  sys.env.get("DYLD_LIBRARY_PATH") getOrElse "."
 
   Seq(jepPath, ".").mkString(File.pathSeparator)
 }
 
 val distBuildDir = file(".") / "target" / "dist" / "polynote"
-val scalaVersions = Seq("2.11.12", "2.12.12", "2.13.6")
+val scalaVersions = Seq(scala_211, scala_212, scala_213)
 lazy val scalaBinaryVersions = scalaVersions.map {
   ver => ver.split('.').take(2).mkString(".")
 }.distinct
 
 val commonSettings = Seq(
-  scalaVersion := "2.11.12",
+  scalaVersion := scala_212,
   crossScalaVersions := scalaVersions,
   organization := "org.polynote",
   publishMavenStyle := true,

--- a/polynote-kernel/src/main/scala-2.12/polynote
+++ b/polynote-kernel/src/main/scala-2.12/polynote
@@ -1,1 +1,0 @@
-../scala-2.11/polynote

--- a/polynote-kernel/src/main/scala-2.12/polynote/kernel/util/KernelReporter.scala
+++ b/polynote-kernel/src/main/scala-2.12/polynote/kernel/util/KernelReporter.scala
@@ -1,0 +1,84 @@
+package polynote.kernel.util
+
+import cats.data.Ior
+import polynote.kernel.{CompileErrors, KernelReport, Pos}
+
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+import scala.reflect.internal.util.Position
+import scala.tools.nsc.Settings
+import scala.tools.nsc.reporters.FilteringReporter
+
+/**
+  * This separate source file is necessary, because the interface for Reporter changed in Scala 2.13
+  */
+case class KernelReporter(settings: Settings) extends FilteringReporter {
+
+  private val _reports = new ListBuffer[KernelReport]()
+
+  def display(pos: Position, msg: String, severity: Severity): Unit = _reports.synchronized {
+    _reports += KernelReport(new Pos(pos), msg, severity.id)
+  }
+
+  override def doReport(pos: Position, msg: String, severity: Severity): Unit =  _reports.synchronized {
+    _reports += KernelReport(new Pos(pos), msg, severity.id)
+  }
+
+  def displayPrompt(): Unit = ()
+
+  override def reset(): Unit = {
+    super.reset()
+    _reports.clear()
+  }
+
+  def reports: List[KernelReport] = _reports.synchronized(_reports.toList)
+
+  private def captureState = State(reports, 0, warningCount, errorCount)
+  private def restoreState(state: State): Unit = {
+    reset()
+    _reports ++= state.reports
+    (0 until state.warns).foreach(_ => increment(WARNING))
+    (0 until state.errs).foreach(_ => increment(ERROR))
+  }
+
+  def attempt[T](fn: => T): Either[Throwable, T] = _reports.synchronized {
+    val state = captureState
+    reset()
+
+    try {
+      val result = Right(fn)
+
+      if (hasErrors)
+        throw CompileErrors(_reports.filter(_.severity == ERROR.id).toList)
+
+      result
+    } catch {
+      case err: Throwable =>
+        Left(err)
+    } finally {
+      restoreState(state)
+    }
+  }
+
+  def attemptIor[T](fn: => T): Ior[Throwable, T] = _reports.synchronized {
+    val state = captureState
+    reset()
+
+    try {
+      val result = Ior.right(fn)
+
+      if (hasErrors)
+        result.putLeft(CompileErrors(_reports.filter(_.severity == ERROR.id).toList))
+      else
+        result
+
+    } catch {
+      case err: Throwable =>
+        Ior.Left(err)
+    } finally {
+      restoreState(state)
+    }
+  }
+
+  private case class State(reports: List[KernelReport], infos: Int, warns: Int, errs: Int)
+}

--- a/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
@@ -218,11 +218,14 @@ class PySparkInterpreter(
            |java_import(gateway.jvm, "org.apache.spark.mllib.api.python.*")
            |java_import(gateway.jvm, "org.apache.spark.sql.*")
            |java_import(gateway.jvm, "org.apache.spark.sql.hive.*")
+           |java_import(gateway.jvm, "org.apache.spark.sql.api.python.*")
+           |
+           |from pyspark.sql import SQLContext
            |
            |__sparkConf = SparkConf(_jvm = gateway.jvm, _jconf = gateway.entry_point.sparkContext().getConf())
            |sc = SparkContext(jsc = gateway.jvm.org.apache.spark.api.java.JavaSparkContext(gateway.entry_point.sparkContext()), gateway = gateway, conf = __sparkConf)
            |spark = SparkSession(sc, gateway.entry_point)
-           |sqlContext = spark._wrapped
+           |sqlContext = SQLContext(spark._sc, spark, spark._jsparkSession.sqlContext())
            |from pyspark.sql import DataFrame
            |
            |


### PR DESCRIPTION
These are some small fixes to be compatible with Spark 3.3.

Spark 3.3 is built against Scala 2.12.15 and 2.13.8. Especially for the Scala 2.12 version, this is a breaking change because some `serialVersionUid`s changed.

The `SparkSession` in Python does not have the `SQLContext` stored in `spark._wrapped`, so it is now explicitly created. Also, there is an additional import required for some PySpark functionality to work correctly.