### PR TITLE
Add stylesheet versions to bust CSS cache

### DIFF
--- a/polynote-frontend/index.html
+++ b/polynote-frontend/index.html
@@ -5,9 +5,9 @@
     <meta charset="utf-8" />
     <base href="$BASE_URI" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" type="text/css" href="static/style/styles.css" />
-    <link rel="stylesheet" type="text/css" href="static/style/colors-light.css" id="polynote-color-theme" />
-    <link rel="stylesheet" href="static/vendor/katex/katex.min.css">
+    <link rel="stylesheet" type="text/css" href="static/style/styles.css?v=0.5.0" />
+    <link rel="stylesheet" type="text/css" href="static/style/colors-light.css?v=0.5.0" id="polynote-color-theme" />
+    <link rel="stylesheet" href="static/vendor/katex/katex.min.css?v=0.5.0">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <link rel="alternate icon" href="/favicon.ico">
     <script defer src="static/vendor/katex/katex.min.js"></script>


### PR DESCRIPTION
Fixes #1136 - Webpack doesn't seem to support this out of the box. 

Several online resources like [this](https://css-tricks.com/strategies-for-cache-busting-css/#aa-query-strings) indicate versioning CSS files is the best way to do this without losing performance gains. Downside is that this will have to be changed on each version release, but seems like the most reliable method. 