### PR TITLE
Add error message on config paste failure

### DIFF
--- a/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
@@ -32,6 +32,7 @@ import {copyToClipboard} from "./cell";
 export class NotebookConfigEl extends Disposable {
     readonly el: TagElement<"div">;
     private readonly stateHandler: StateHandler<NBConfig>;
+    private pasteErrorMessage: TagElement<"p">
 
     constructor(dispatcher: NotebookMessageDispatcher, stateHandler: StateHandler<NBConfig>, kernelStateHandler: StateView<KernelStatusString>) {
         super()
@@ -71,7 +72,8 @@ export class NotebookConfigEl extends Disposable {
                             const conf = new NotebookConfig(dependencies.conf, exclusions.conf, resolvers.conf, spark.conf, spark.template, kernel.envVars, kernel.scalaVersion, kernel.jvmArgs);
                             this.copyConfig(conf);
                         }),
-                        button([], {}, ['Paste & Save Configuration']).click(() => this.pasteConfig())
+                        button([], {}, ['Paste & Save Configuration']).click(() => this.pasteConfig()),
+                        this.pasteErrorMessage = para(['hide', 'error-message'], ['Paste failed - your clipboard does not contain valid JSON'])
                     ])
                 ])
             ])
@@ -94,6 +96,7 @@ export class NotebookConfigEl extends Disposable {
             if (open) {
                 this.el.classList.add("open")
             } else {
+                this.pasteErrorMessage.classList.add('hide');
                 this.el.classList.remove("open")
             }
         }).disposeWith(this)
@@ -119,6 +122,7 @@ export class NotebookConfigEl extends Disposable {
                 conf = new NotebookConfig(paste.dependencies, paste.exclusions, paste.repositories, paste.sparkConfig, paste.sparkTemplate, paste.env, paste.scalaVersion, paste.jvmArgs);
                 this.saveConfig(conf)
             } catch (e) {
+                this.pasteErrorMessage.classList.remove('hide');
                 console.error("Paste failed - the following clipboard value is not valid JSON:", paste!);
                 console.error(e);
             }

--- a/polynote-frontend/style/colors-dark.less
+++ b/polynote-frontend/style/colors-dark.less
@@ -23,6 +23,7 @@
 @md-text-color:                #BBBBBB;
 @icon-fg:                      #BBBBBB;
 @icon-green:                   #66CC33;
+@text-red:                     #DD3311;
 @icon-red:                     #DD3311;
 
 @input-shadow:                 none;

--- a/polynote-frontend/style/colors-light.less
+++ b/polynote-frontend/style/colors-light.less
@@ -23,6 +23,7 @@
 @md-text-color:                #24292e;
 @icon-fg:                      black;
 @icon-green:                   green;
+@text-red:                     #AA0000;
 @icon-red:                     #AA0000;
 
 @input-shadow:                 inset 1px 1px 2px rgba(0,0,0,0.05);

--- a/polynote-frontend/style/colors.less
+++ b/polynote-frontend/style/colors.less
@@ -574,6 +574,10 @@ button {
       }
     }
   }
+
+  .error-message {
+    color: @text-red;
+  }
 }
 
 .notebook-config.open {

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -1957,6 +1957,10 @@ button.inspect.icon-button {
     display: none;
     font-size: 86%;
     margin: 0 1.75em;
+
+    .error-message {
+      text-align: right;
+    }
   }
 
   &.open .content {


### PR DESCRIPTION
Addresses a smaller issue a user had where they couldn't tell why a notebook config paste had failed - it should ideally be surfaced in the UI. 