### PR TITLE
Searchbox to filter notebook list

### DIFF
--- a/polynote-frontend/polynote/ui/component/notebook/kernel.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/kernel.ts
@@ -118,6 +118,7 @@ export class Kernel extends Disposable {
             span(['left-buttons'], [
                 helpIconButton([], "https://polynote.org/latest/docs/kernel-pane/"),
             ]),
+            span(['middle-area'], ""),
             span(['right-buttons'], [
                 iconButton(['connect'], 'Connect to server', 'plug', 'Connect').click(evt => this.connect(evt)),
                 iconButton(['start'], 'Start kernel', 'power-off', 'Start').click(evt => this.startKernel(evt)),

--- a/polynote-frontend/polynote/ui/component/notebooklist.ts
+++ b/polynote-frontend/polynote/ui/component/notebooklist.ts
@@ -10,7 +10,8 @@ import {
     para,
     span,
     tag,
-    TagElement
+    TagElement,
+    textbox
 } from "../tags";
 import {ServerMessageDispatcher} from "../../messaging/dispatcher";
 import {deepCopy, diffArray, getHumanishDate} from "../../util/helpers";
@@ -219,6 +220,7 @@ class SortHeader {
 export class NotebookList extends Disposable {
     readonly el: TagElement<"div">;
     readonly header: TagElement<"h2">;
+    readonly searchbox: TagElement<"input">;
 
     private dragEnter: EventTarget | null;
     private tree: BranchEl;
@@ -231,11 +233,15 @@ export class NotebookList extends Disposable {
         searchModal.show();
         searchModal.hide();
 
+        this.searchbox = textbox(['notebook-searchbox'], 'search');
+        //this.el = div(['notebooks-list'], [div(['tree-view'], [this.tree.el])])
+        //    .listener("contextmenu", evt => NotebookListContextMenu.get(dispatcher).showFor(evt));
         this.header = h2(['ui-panel-header', 'notebooks-list-header'], [
             'Notebooks',
             span(['left-buttons'], [
                 helpIconButton([], "https://polynote.org/latest/docs/notebooks-list/"),
             ]),
+            span(['middle-area'], [this.searchbox]),
             span(['right-buttons'], [
                 iconButton(['create-notebook'], 'Create new notebook', 'plus-circle', 'New').click(evt => {
                     evt.stopPropagation();
@@ -324,6 +330,9 @@ export class NotebookList extends Disposable {
                 removed.forEach(path => treeState.removePath(path));
             }
         });
+
+        // setup searchbox
+        this.searchbox.addEventListener("input", evt => this.tree.filter(this.searchbox.value.toLowerCase()));
 
         // we're ready to request the notebooks list now!
         dispatcher.requestNotebookList()
@@ -511,6 +520,12 @@ export class BranchEl extends Disposable {
 
     focus() {
         this.branchEl.focus()
+    }
+
+    filter(searchStr: string): boolean {
+        const childrenFound = this.children.map(child => child.filter(searchStr)).find(v => v) || false;
+        this.el.hidden = !childrenFound;
+        return childrenFound;
     }
 
     private addChild(node: Branch | Leaf) {
@@ -723,6 +738,12 @@ export class LeafEl extends Disposable {
 
     focus() {
         this.leafEl.focus()
+    }
+
+    filter(searchStr: string): boolean {
+        const isMatch = this.path.toLowerCase().includes(searchStr);
+        this.el.hidden = !isMatch;
+        return isMatch;
     }
 
     private getEl(leaf: Leaf) {

--- a/polynote-frontend/style/styles.less
+++ b/polynote-frontend/style/styles.less
@@ -1495,17 +1495,25 @@ button.inspect.icon-button {
     grid-area: head;
     position: relative;
     user-select: none;
+    display: flex; 
+    align-items: center; 
+    min-width: 0; 
+    overflow: hidden;
+    height: 1em;
+
     .left-buttons, .right-buttons {
-      position: absolute;
-      top: .1em;
-      bottom: .1em;
       line-height: 1.8em;
     }
 
     .right-buttons {
-      right: 0;
       text-align: right;
-      padding-right: .25em;
+    }
+
+    .middle-area {
+      flex-grow: 1;
+      input.notebook-searchbox {
+        width: 100%;
+      }
     }
 
     button.icon-button {


### PR DESCRIPTION
Hello,
I have a implemented a small practical improvement in the frontend to filter the notebook list by a search box. It helps finding notebooks by name in large repositories.
It implements a case-insensitive filter on the path of the entries of the tree view.
It needed some CSS adaptions to make the searchbox in the ui-panel-header adapting its size.
Hope this fits with your idea and coding practices for Polynote, otherwise let me know.
Best, zzeekk