### PR TITLE
[DATAPLT-2469] Butler build script for forked Polynote

### DIFF
--- a/butler.yml
+++ b/butler.yml
@@ -1,0 +1,6 @@
+default:
+  tasks:
+    pre:
+      - ./scripts/pre.sh
+    build:
+      - ./scripts/build.sh

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -23,7 +23,7 @@ RUN pip3 install -r /tmp/requirements.txt
 # Then build this from the project root using `-f docker/dev/Dockerfile` to select this file.
 # for example (don't forget the dot at the end!):
 # for frontend dev
-#   cd polynote-frontend; npm install; npm run dist; cd..
+#   cd polynote-frontend; npm install; npm run dist; cd ..
 # for image creation
 #   sbt dist
 #   docker build -t strava/polynote:dev -f docker/dev/Dockerfile .

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,15 +1,14 @@
 # Set this to match your JDK version compiled with.
-FROM openjdk:8-slim-buster
+FROM --platform=linux/x86_64 openjdk:11-slim-buster
 
 WORKDIR /opt
 
 RUN apt update -y && \
-    apt install -y wget python3 python3-dev python3-pip build-essential
+    apt install -y wget python3 python3-dev python3-pip build-essential git curl nano vim sudo
 
 COPY docker/spark/install_spark.sh .
 RUN ./install_spark.sh
 ENV SPARK_HOME="/opt/spark"
-ENV HADOOP_HOME="/opt/hadoop-2.7.7"
 ENV PATH="$PATH:$SPARK_HOME/bin:$SPARK_HOME/sbin"
 
 # Copy over the requirements early so that we can cache this layer seperate from polynote-dist
@@ -23,9 +22,11 @@ RUN pip3 install -r /tmp/requirements.txt
 # Package everything together by making the distribution with `sbt dist`
 # Then build this from the project root using `-f docker/dev/Dockerfile` to select this file.
 # for example (don't forget the dot at the end!):
-#   cd polynote-static; npm install; npm run dist; cd..
+# for frontend dev
+#   cd polynote-frontend; npm install; npm run dist; cd..
+# for image creation
 #   sbt dist
-#   docker build -t polynote:dev -f docker/dev/Dockerfile .
+#   docker build -t strava/polynote:dev -f docker/dev/Dockerfile .
 COPY target/polynote-dist.tar.gz .
 RUN tar xfzp polynote-dist.tar.gz && \
     rm polynote-dist.tar.gz

--- a/docker/spark/install_spark.sh
+++ b/docker/spark/install_spark.sh
@@ -3,7 +3,7 @@
 
 set -e -x
 
-SPARK_VERSION=${SPARK_VERSION:-"2.4.5"}
+SPARK_VERSION=${SPARK_VERSION:-"3.3.1"}
 SPARK_VERSION_DIR="spark-${SPARK_VERSION}"
 
 if test "${SPARK_VERSION}" \> "3" -a "${SCALA_VERSION}" = "2.11"
@@ -24,7 +24,7 @@ then
   SPARK_DIST_CLASSPATH=$($HADOOP_HOME/bin/hadoop classpath)
   popd
 else
-  SPARK_NAME="spark-${SPARK_VERSION}-bin-hadoop2.7"
+  SPARK_NAME="spark-${SPARK_VERSION}-bin-hadoop3"
 fi
 
 pushd /opt

--- a/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/interpreter/python/PySparkInterpreter.scala
@@ -222,7 +222,7 @@ class PySparkInterpreter(
            |__sparkConf = SparkConf(_jvm = gateway.jvm, _jconf = gateway.entry_point.sparkContext().getConf())
            |sc = SparkContext(jsc = gateway.jvm.org.apache.spark.api.java.JavaSparkContext(gateway.entry_point.sparkContext()), gateway = gateway, conf = __sparkConf)
            |spark = SparkSession(sc, gateway.entry_point)
-           |sqlContext = spark._wrapped
+           |sqlContext = spark._wrapped if hasattr(spark, '_wrapped') else SQLContext._get_or_create(sc)
            |from pyspark.sql import DataFrame
            |
            |

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Build and push Docker images for Polynote.
+# TODO DATAPLT-2330: Call from butler
+# TODO DATAPLT-2332: Better support local building needs
+
+# Build and push Docker image with a commit and branch tag
+set -e
+
+if [ -z "$GIT_SHA" ]; then
+    echo "Environment variable \$GIT_SHA expected to be set (by Butler)"
+    exit 1
+fi
+
+if [ -z "$GIT_BRANCH" ]; then
+    echo "Environment variable \$GIT_BRANCH expected to be set (by Butler)"
+    exit 1
+fi
+
+REPO="docker.strava.com/strava/polynote"
+COMMIT_TAG="$REPO:$GIT_SHA"
+
+
+# only create and push a new image if we are merging to main
+if [[ "$GIT_BRANCH" == "main" ]]; then
+    docker build -t strava/polynote:latest -f docker/dev/Dockerfile .
+
+    BRANCH_TAG="$REPO:$GIT_BRANCH"
+    docker tag strava/polynote:latest $COMMIT_TAG
+
+    docker push $COMMIT_TAG
+fi

--- a/scripts/pre.sh
+++ b/scripts/pre.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [[ "$GIT_BRANCH" == "main" ]]; then
+    cd "${0%/*}"
+
+    cd polynote-frontend; npm install; npm run dist
+
+    cd ..
+
+    sbt dist
+fi


### PR DESCRIPTION
We need to compile Polynote (npm frontend + sbt) as part of the Butler process. Previously, we manually ran the following commands to compile Polynote and get the image on to ECR:

```shell
# frontend
cd polynote-frontend; npm install; npm run dist
cd ..

# sbt
sbt dist

# docker
docker build --no-cache -t strava/polynote:dev -f docker/dev/Dockerfile .
docker tag strava/polynote:dev docker.strava.com/strava/polynote:test
docker push docker.strava.com/strava/polynote:test
```