### PR TITLE
Allow StringRepr to be a little longer

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/messages/package.scala
+++ b/polynote-kernel/src/main/scala/polynote/messages/package.scala
@@ -31,6 +31,10 @@ package object messages {
     else
       str.asInstanceOf[ShortString]
 
+    def truncatePretty(str: String): ShortString = if (str.length > Short.MaxValue) {
+      (str.substring(0, Short.MaxValue - 2) + "…").asInstanceOf[ShortString]
+    } else str.asInstanceOf[ShortString]
+
     def unapply(str: ShortString): Option[String] = Option(str)
   }
 

--- a/polynote-server/src/main/scala/polynote/server/Server.scala
+++ b/polynote-server/src/main/scala/polynote/server/Server.scala
@@ -150,8 +150,8 @@ class Server {
 
         gzipped orElse nogzip orElse fromJar
       }.catchAll {
-        case err: HTTPError => ZIO.fail(err)
-        case err => Logging.error("Error serving file", err) *> ZIO.fail(InternalServerError("Error serving file", Some(err)))
+        case err: HTTPError => Logging.error(s"Error serving file: $name", err) *> ZIO.fail(err)
+        case err => Logging.error(s"Error serving file: $name", err) *> ZIO.fail(InternalServerError(s"Error serving file: $name", Some(err)))
       }
 
       val serveStatic: PartialFunction[Request, ZIO[RequestEnv, HTTPError, Response]] = {


### PR DESCRIPTION
Instances of classes with long-ish String reprs (not _that_ long), like the following, get truncated fairly aggressively:

![image](https://github.com/polynote/polynote/assets/5430417/80050027-1fe6-4993-9ea7-9166afd6c7f0)

This can be kind of annoying if you were counting on that output and forgot you needed to `println` it. This PR changes the generated `StringRepr` for these classes into a `ShortString`.

Weirdly, though, the truncation doesn't happen with a long, single-line string 🤔

![image](https://github.com/polynote/polynote/assets/5430417/90e1bff1-7b86-4bed-a77f-cf864797c06c)

Any idea what that could be, @jeremyrsmith ?

Addresses https://github.com/polynote/polynote/issues/1398