### PR TITLE
Stop publishing scaladoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,9 +60,12 @@ val commonSettings = Seq(
   ),
   version := "0.5.1",
   publishTo := sonatypePublishToBundle.value,
+  // disable scalaDoc generation because it's causing weird compiler errors and we don't use it anyways
+  Compile / packageDoc / publishArtifact := false,
   developers := List(
     Developer(id = "jeremyrsmith", name = "Jeremy Smith", email = "", url = url("https://github.com/jeremyrsmith")),
-    Developer(id = "jonathanindig", name = "Jonathan Indig", email = "", url = url("https://github.com/jonathanindig"))
+    Developer(id = "jonathanindig", name = "Jonathan Indig", email = "", url = url("https://github.com/jonathanindig")),
+    Developer(id = "omidmogasemi", name = "Omid Mogasemi", email = "", url = url("https://github.com/omidmogasemi"))
   ),
   scalacOptions ++= Seq(
     "-language:higherKinds",


### PR DESCRIPTION
It's causing weird compiler errors for some reason and no one is using it! 

```
08:09:45 [error] knownDirectSubclasses of CompletionType observed before subclass Term registered
08:09:45 [error] knownDirectSubclasses of CompletionType observed before subclass Field registered
08:09:45 [error] knownDirectSubclasses of CompletionType observed before subclass Method registered
08:09:45 [error] knownDirectSubclasses of CompletionType observed before subclass Package registered
08:09:45 [error] knownDirectSubclasses of CompletionType observed before subclass TraitType registered
08:09:45 [error] knownDirectSubclasses of CompletionType observed before subclass ClassType registered
08:09:45 [error] knownDirectSubclasses of CompletionType observed before subclass Module registered
08:09:45 [error] knownDirectSubclasses of CompletionType observed before subclass TypeAlias registered
08:09:45 [error] knownDirectSubclasses of CompletionType observed before subclass Keyword registered
08:09:45 [error] knownDirectSubclasses of CompletionType observed before subclass Unknown registered
08:09:59 [info] No documentation generated with unsuccessful compiler run
08:09:59 [error] 10 errors found
08:09:59 [error] Scaladoc generation failed
```