### PR TITLE
Fix several bugs and regressions

### DIFF
--- a/polynote-frontend/polynote/data/messages.ts
+++ b/polynote-frontend/polynote/data/messages.ts
@@ -1057,13 +1057,13 @@ export class Location {
 }
 
 export class GoToDefinitionResponse extends Message {
-    static codec = combined(int32, arrayCodec(uint8, Location.codec), optional(str)).to(GoToDefinitionResponse);
+    static codec = combined(int32, arrayCodec(uint8, Location.codec)).to(GoToDefinitionResponse);
     static get msgTypeId() { return 37; }
     static unapply(inst: GoToDefinitionResponse): ConstructorParameters<typeof GoToDefinitionResponse> {
-        return [inst.reqId, inst.location, inst.source];
+        return [inst.reqId, inst.location];
     }
 
-    constructor(readonly reqId: number, readonly location: Location[], readonly source?: string) {
+    constructor(readonly reqId: number, readonly location: Location[]) {
         super();
         Object.freeze(this);
     }

--- a/polynote-frontend/polynote/messaging/receiver.ts
+++ b/polynote-frontend/polynote/messaging/receiver.ts
@@ -137,13 +137,13 @@ export class NotebookMessageReceiver extends MessageReceiver<NotebookState> {
                 return NoUpdate
             }
         });
-        this.receive(messages.GoToDefinitionResponse, (s, reqId, location, source) => {
+        this.receive(messages.GoToDefinitionResponse, (s, reqId, location) => {
             if (s.requestedDefinition) {
                 const definition: Definition = location.map(location => {
                     const loc: languages.Location = {uri: Uri.parse(location.uri), range: posToRange(location)};
                     return loc
                 })
-                s.requestedDefinition.resolve(new GoToDefinitionResponse(reqId, location, source));
+                s.requestedDefinition.resolve(new GoToDefinitionResponse(reqId, location));
                 return {
                     requestedDefinition: destroy()
                 }

--- a/polynote-frontend/polynote/state/notebook_state.ts
+++ b/polynote-frontend/polynote/state/notebook_state.ts
@@ -36,7 +36,7 @@ import {deepEquals, Deferred} from "../util/helpers";
 import {notReceiver} from "../messaging/receiver";
 import {ConstView, ProxyStateView} from "./state_handler";
 import {ServerStateHandler} from "./server_state";
-import {languages} from "monaco-editor";
+import {IPosition, languages} from "monaco-editor";
 import Definition = languages.Definition;
 import {Either, Left, Right} from "../data/codec_types";
 
@@ -97,6 +97,7 @@ export interface NotebookState {
     kernel: KernelState,
     // ephemeral states
     activeCellId: number | undefined,
+    requestedCellPosition: [number, IPosition] | undefined,
     activeCompletion: { cellId: number, offset: number, resolve: (completion: CompletionHint) => void, reject: (reason?: any) => void } | undefined,
     activeSignature: { cellId: number, offset: number, resolve: (signature: SignatureHint) => void, reject: (reason?: any) => void } | undefined,
     requestedDefinition: { cellOrFile: Left<string> | Right<number>, offset: number, resolve: (definition: GoToDefinitionResponse) => void, reject: (reason?: any) => void } | undefined,
@@ -189,6 +190,7 @@ export class NotebookStateHandler extends BaseHandler<NotebookState> {
             },
             activePresence: {},
             activeCellId: undefined,
+            requestedCellPosition: undefined,
             activeCompletion: undefined,
             activeSignature: undefined,
             requestedDefinition: undefined,
@@ -279,6 +281,12 @@ export class NotebookStateHandler extends BaseHandler<NotebookState> {
         })
 
         return id
+    }
+
+    selectCellAt(cell: number, position: IPosition) {
+        this.selectCell(cell);
+        const value: [number, IPosition] = [cell, position];
+        this.updateField("requestedCellPosition", () => value)
     }
 
     /**

--- a/polynote-frontend/polynote/state/server_state.ts
+++ b/polynote-frontend/polynote/state/server_state.ts
@@ -240,7 +240,8 @@ export class ServerStateHandler extends BaseHandler<ServerState> {
                         ServerStateHandler.updateState(state => {
                             if (!of) return NoUpdate;
                             return {
-                                notebooks: updateProperty(path, false)
+                                notebooks: updateProperty(path, false),
+                                openFiles: removeFromArray(state.openFiles, of)
                             }
                         });
 

--- a/polynote-frontend/polynote/ui/component/notebook/cell.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/cell.ts
@@ -91,7 +91,7 @@ import {UserPreferences, UserPreferencesHandler} from "../../../state/preference
 import {plotToVegaCode, validatePlot} from "../../input/plot_selector";
 import {MarkdownIt} from "../../input/markdown-it";
 import Definition = languages.Definition;
-import {goToDefinition} from "./common";
+import {findDefinitionLocation, IOpenInput, openDefinition} from "./common";
 import {Either} from "../../../data/codec_types";
 
 
@@ -786,6 +786,15 @@ abstract class MonacoCell extends Cell {
             // overflowWidgetsDomNode: this.overflowDomNode
         });
 
+        // None of the official ways to do this seem to work
+
+        (this.editor as any)._codeEditorService.openCodeEditor = (input: IOpenInput, source: any, sideBySide: any) => {
+            return openDefinition(notebookState, this.state.language, {
+                uri: input.resource,
+                range: input.options?.selection || new Range(1, 0, 1, 0)
+            })
+        }
+
         this.editor.onDidChangeCursorSelection(evt => {
             if (this.applyingServerEdits) return // ignore when applying server edits.
 
@@ -810,6 +819,13 @@ abstract class MonacoCell extends Cell {
         // NOTE: this uses some private monaco APIs. If this ever ends up breaking after we update monaco it's a signal
         //       we'll need to rethink this stuff.
         this.editor.onKeyDown((evt: IKeyboardEvent | KeyboardEvent) => this.onKeyDown(evt))
+
+        notebookState.observeKey("requestedCellPosition", pos => {
+            if (pos && pos[0] === this.id) {
+                this.editor.focus();
+                this.editor.setPosition(pos[1]);
+            }
+        }).disposeWith(this)
 
         this.el = div(['cell-container', this.state.language, 'code-cell'], [
             div(['cell-input'], [
@@ -1514,7 +1530,7 @@ export class CodeCell extends MonacoCell {
     }
 
     goToDefinition(offset: number): Promise<Definition> {
-        return goToDefinition(this.notebookState, Either.right(this.id), offset);
+        return findDefinitionLocation(this.notebookState, Either.right(this.id), offset);
     }
 
     private setErrorMarkers(error: RuntimeError | CompileErrors, markers: IMarkerData[]) {
@@ -1991,8 +2007,17 @@ class CodeCellOutput extends Disposable {
                             ]);
 
                             if (report.position) {
-                                const lineNumber = linePosAt(this.cellState.state.content, report.position.point)
-                                el.appendChild(span(['error-link'], [`(Line ${lineNumber})`]))
+                                // TODO: this is really discombobulated. Why does this have to call this function
+                                //        when the cell uses the editor model to translate the position? It's not
+                                //        "cleaner". I guess the cell should have a mapped view of the compile errors
+                                //        and pass that to the output component instead?
+                                const linePos = linePosAt(this.cellState.state.content, report.position.point)
+                                const lineNumber = linePos[0] + 1 // linePosAt is 0-based, humans are 1-based
+                                const column = linePos[1] + 1
+                                el.appendChild(
+                                    span(['error-link'], [`(Line ${lineNumber})`])
+                                        .click(() => this.notebookState.selectCellAt(this.cellState.state.id, { lineNumber, column }))
+                                )
                             }
 
                             return el;

--- a/polynote-frontend/polynote/ui/component/notebook/cell.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/cell.ts
@@ -789,7 +789,7 @@ abstract class MonacoCell extends Cell {
         // None of the official ways to do this seem to work
 
         (this.editor as any)._codeEditorService.openCodeEditor = (input: IOpenInput, source: any, sideBySide: any) => {
-            return openDefinition(notebookState, this.state.language, {
+            return openDefinition(notebookState, source.getModel().getLanguageId(), {
                 uri: input.resource,
                 range: input.options?.selection || new Range(1, 0, 1, 0)
             })

--- a/polynote-frontend/polynote/ui/component/notebook/common.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/common.ts
@@ -1,14 +1,15 @@
 import {GoToDefinitionResponse} from "../../../data/messages";
 import {append, NoUpdate, setProperty, setValue, updateProperty} from "../../../state";
-import {languages, Uri} from "monaco-editor";
+import {languages, Uri, Range, IRange} from "monaco-editor";
 import {ServerStateHandler} from "../../../state/server_state";
 import Definition = languages.Definition;
+import Location = languages.Location;
 import {NotebookStateHandler} from "../../../state/notebook_state";
 import {Either, Left, Right} from "../../../data/codec_types";
-import {arrExists, posToRange} from "../../../util/helpers";
+import {arrExists, nameFromPath, posToRange} from "../../../util/helpers";
 
 
-export function goToDefinition(
+export function findDefinitionLocation(
     notebookState: NotebookStateHandler,
     cellOrFile: Left<string> | Right<number>,
     offset: number
@@ -18,35 +19,64 @@ export function goToDefinition(
         notebookState.state.requestedDefinition?.reject("cancelled");
         return notebookState.updateField("requestedDefinition", () => setValue({cellOrFile: cellOrFile, offset, resolve, reject}));
     }).then(result => {
-        // TODO: if the location is a notebook cell?
-        if (result.source && result.location && result.location[0]) {
-            const loc = result.location[0];
-            const uri = Uri.parse(loc.uri);
-            const depSrc = {
-                language: uri.scheme,
-                content: result.source!,
-                position: { lineNumber: loc.line, column: loc.column },
-                sourceNotebook: notebookState
-            }
-            ServerStateHandler.get.updateAsync(state => {
-                const dependencyLoaded = loc.uri in state.dependencySources;
-                const fileIsOpen = arrExists(state.openFiles, of => of.path === loc.uri);
-                return {
-                    dependencySources: updateProperty(
-                        loc.uri,
-                        dependencyLoaded ? setProperty("position", depSrc.position)
-                                         : setValue(depSrc)),
-                    openFiles: fileIsOpen ? NoUpdate
-                                          : append({ type: "dependency_source", path: loc.uri })
-                };
-            }).then(() => {
-                ServerStateHandler.selectFile(loc.uri)
-            })
 
-        }
-        return result.location.map(loc => ({
-            uri: Uri.parse(loc.uri),
-            range: posToRange(loc)
-        }))
+        return result.location.map(loc => {
+            const absolute = loc.uri.startsWith("#") ? loc.uri : new URL(loc.uri, document.location.href).href;
+            return {
+                uri: Uri.parse(absolute),
+                range: posToRange(loc)
+            }
+        })
     })
+}
+
+export function openDefinition(notebookState: NotebookStateHandler, lang: string, location: Location): Promise<void> {
+    const uriString = location.uri.toString()
+
+    // even a relative "#X" URI gets turned into a file:///#X URI by the Microsoft thing. So really just have to
+    // assume that any fragment is a cell link
+    if (location.uri.fragment) {
+        const cellId = cellIdFromHash(location.uri.fragment);
+        notebookState.selectCellAt(cellId, Range.getStartPosition(location.range));
+        return Promise.resolve();
+    }
+
+    if (uriString in ServerStateHandler.state.dependencySources) {
+        return ServerStateHandler.get.updateAsync(state => {
+            const fileIsOpen = arrExists(state.openFiles, of => of.path === uriString);
+            return {
+                dependencySources: updateProperty(uriString, {position: Range.getStartPosition(location.range)}),
+                openFiles: fileIsOpen ? NoUpdate : append({type: "dependency_source", path: uriString})
+            };
+        }).then(() => ServerStateHandler.selectFile(uriString))
+    } else {
+        return fetch(uriString, {
+            method: "GET",
+            mode: "same-origin",
+        }).then(response => response.text()).then(source => {
+            ServerStateHandler.get.updateAsync(state => ({
+                dependencySources: updateProperty(
+                    uriString,
+                    setValue({
+                        language: lang,
+                        content: source,
+                        position: Range.getStartPosition(location.range),
+                        sourceNotebook: notebookState
+                    })
+                ),
+                openFiles: append({ type: "dependency_source", path: uriString })
+            }))
+        }).then(() => ServerStateHandler.selectFile(uriString))
+    }
+}
+
+export interface IOpenInput {
+    options?: {
+        selection?: IRange
+    },
+    resource: Uri
+}
+
+export function cellIdFromHash(hash: string): number {
+    return parseInt(hash.slice("Cell".length))
 }

--- a/polynote-frontend/polynote/ui/component/notebook/notebook.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/notebook.ts
@@ -10,6 +10,7 @@ import {CellState, NotebookStateHandler} from "../../../state/notebook_state";
 import {NotebookScrollLocationsHandler} from "../../../state/preferences";
 import {ServerStateHandler} from "../../../state/server_state";
 import {Main} from "../../../main";
+import {cellIdFromHash} from "./common";
 
 type CellInfo = {cell: CellContainer, handler: StateHandler<CellState>, el: TagElement<"div">};
 
@@ -207,7 +208,7 @@ export class Notebook extends Disposable {
         // the hash can (potentially) have two parts: the selected cell and selected position.
         // for example: #Cell2,6-12 would mean Cell2, positions at offset 6 to 12
         const [hashId, pos] = hash.slice(1).split(",");
-        const cellId = parseInt(hashId.slice("Cell".length))
+        const cellId = cellIdFromHash(hashId)
         // cell might not yet be loaded, so be sure to wait for it
         this.waitForCell(cellId).then(() => {
             this.notebookState.selectCell(cellId)

--- a/polynote-frontend/polynote/ui/component/tabs.ts
+++ b/polynote-frontend/polynote/ui/component/tabs.ts
@@ -43,7 +43,9 @@ export class Tabs extends Disposable {
                                     depSrc.position,
                                     depSrc.sourceNotebook).el
                             }).otherwise(undefined);
-                        this.add(path, this.mkTitle(path), newTabEl);
+                        const title: TagElement<"span"> = of.type == "dependency_source" ? this.mkDependencyTitle(path)
+                                                                                         : this.mkTitle(path)
+                        this.add(path, title, newTabEl);
                     }
                 })
             } else {
@@ -166,5 +168,10 @@ export class Tabs extends Disposable {
 
     private mkTitle(path: string): TagElement<"span"> {
        return span(['notebook-tab-title'], [nameFromPath(path)]);
+    }
+
+    private mkDependencyTitle(uri: string): TagElement<"span"> {
+        const dep = new URLSearchParams(new URL(uri).search).get("dependency") || ""
+        return span(['notebook-tab-title', 'dependency-source-tab-title'], [dep]);
     }
 }

--- a/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
+++ b/polynote-kernel/src/main/scala/polynote/config/PolynoteConfig.scala
@@ -243,7 +243,7 @@ final case class PolynoteConfig(
   repositories: List[RepositoryConfig] = Nil,
   exclusions: List[String] = Nil,
   dependencies: Map[String, List[String]] = Map.empty,
-  downloadSources: Boolean = true,
+  downloadSources: Boolean = false,
   spark: Option[SparkConfig] = None,
   behavior: Behavior = Behavior(),
   security: Security = Security(),

--- a/polynote-kernel/src/main/scala/polynote/kernel/Kernel.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/Kernel.scala
@@ -32,7 +32,12 @@ trait Kernel {
   /**
     * Provide a location for the definition of whatever is at the given position in the given cell
     */
-  def goToDefinition(fileOrCell: Either[String, CellID], pos: Int): TaskC[(List[DefinitionLocation], Option[String])]
+  def goToDefinition(fileOrCell: Either[String, CellID], pos: Int): TaskC[List[DefinitionLocation]]
+
+  /**
+    * Retrieve the source of the given dependency identifier from the given language
+    */
+  def dependencySource(language: String, dependency: String): RIO[BaseEnv with GlobalEnv, String]
 
   /**
     * Perform any initialization for the kernel

--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/Interpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/Interpreter.scala
@@ -49,9 +49,9 @@ trait Interpreter {
   def parametersAt(code: String, pos: Int, state: State): RIO[Blocking, Option[Signatures]]
 
   // TODO: probably remove Logging capability from these after initial spike
-  def goToDefinition(code: String, pos: Int, state: State): RIO[Blocking with Logging, (List[DefinitionLocation], Option[String])]
+  def goToDefinition(code: String, pos: Int, state: State): RIO[BaseEnv with CellEnv, List[DefinitionLocation]]
 
-  def goToDependencyDefinition(uri: String, pos: Int): RIO[BaseEnv, (List[DefinitionLocation], Option[String])]
+  def goToDependencyDefinition(uri: String, pos: Int): RIO[BaseEnv with CellEnv, List[DefinitionLocation]]
 
   def getDependencyContent(uri: String): RIO[Blocking, String]
 

--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/SemanticDbScan.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/SemanticDbScan.scala
@@ -26,7 +26,10 @@ class SemanticDbScan (compiler: ScalaCompiler) {
   val semanticdbGlobal: interactive.Global = InteractiveSemanticdb.newCompiler(classpath, List())
   private val compileUnits = new ConcurrentHashMap[AbstractFile, semanticdbGlobal.RichCompilationUnit]
   semanticdbGlobal.settings.stopAfter.value = List("namer")
-  var run = new semanticdbGlobal.Run()
+
+  // TODO: this should be a ref
+  private var run = new semanticdbGlobal.Run()
+  
   private val importer = semanticdbGlobal.mkImporter(compiler.global)
 
   def init: RIO[BaseEnv with TaskManager, Unit] = TaskManager.run("semanticdb", "Scanning sources")(scanSources).flatMap {
@@ -34,8 +37,8 @@ class SemanticDbScan (compiler: ScalaCompiler) {
   }
 
   def lookupPosition(sym: Global#Symbol): semanticdbGlobal.Position = {
-    val pos = importer.importSymbol(sym.asInstanceOf[compiler.global.Symbol]).pos
-    pos
+    val imported = importer.importSymbol(sym.asInstanceOf[compiler.global.Symbol])
+    imported.pos
   }
 
   def treeAt(file: AbstractFile, offset: Int): RIO[Blocking with Clock, semanticdbGlobal.Tree] = {

--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/SemanticDbScan.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/SemanticDbScan.scala
@@ -127,7 +127,7 @@ class SemanticDbScan (compiler: ScalaCompiler) {
       file =>
         val unit = new semanticdbGlobal.RichCompilationUnit(file)
         compileUnits.put(file.file, unit)
-        if (file.isJava)
+        if (file.file.name.endsWith(".java"))
           javaMapping.put(file.path.split("!").last.stripSuffix(".java").replace('/', '.'), unit)
         unit
     }

--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/protocol.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/protocol.scala
@@ -106,6 +106,9 @@ object KeepAliveRequest extends RemoteRequestCompanion[KeepAliveRequest](15)
 final case class RemoteGoToDefinitionRequest(reqId: Int, id: Either[String, CellID], pos: Int) extends RemoteRequest
 object RemoteGoToDefinitionRequest extends RemoteRequestCompanion[RemoteGoToDefinitionRequest](16)
 
+final case class RemoteDependencySourceRequest(reqId: Int, language: String, dependency: String) extends RemoteRequest
+object RemoteDependencySourceRequest extends RemoteRequestCompanion[RemoteDependencySourceRequest](17)
+
 
 object RemoteRequest {
   implicit val discriminated: Discriminated[RemoteRequest, Byte] = Discriminated(byte)
@@ -179,9 +182,11 @@ object ErrorResponse extends RemoteResponseCompanion[ErrorResponse](14) {
   )
 }
 
-final case class RemoteGoToDefinitionResponse(reqId: Int, locations: List[DefinitionLocation], source: Option[String]) extends RemoteRequestResponse
+final case class RemoteGoToDefinitionResponse(reqId: Int, locations: List[DefinitionLocation]) extends RemoteRequestResponse
 object RemoteGoToDefinitionResponse extends RemoteResponseCompanion[RemoteGoToDefinitionResponse](16)
 
+final case class RemoteDependencySourceResponse(reqId: Int, source: String) extends RemoteRequestResponse
+object RemoteDependencySourceResponse extends RemoteResponseCompanion[RemoteDependencySourceResponse](17)
 
 object RemoteResponse {
   implicit val discriminated: Discriminated[RemoteResponse, Byte] = Discriminated(byte)

--- a/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
+++ b/polynote-kernel/src/main/scala/polynote/messages/Messages.scala
@@ -466,7 +466,7 @@ object GoToDefinitionRequest extends MessageCompanion[GoToDefinitionRequest](36)
   */
 final case class DefinitionLocation(uri: String, line: Int, column: Int)
 
-final case class GoToDefinitionResponse(reqId: Int, location: TinyList[DefinitionLocation], source: Option[String]) extends Message
+final case class GoToDefinitionResponse(reqId: Int, location: TinyList[DefinitionLocation]) extends Message
 object GoToDefinitionResponse extends MessageCompanion[GoToDefinitionResponse](37)
 
 

--- a/polynote-kernel/src/test/scala/polynote/config/PolynoteConfigSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/config/PolynoteConfigSpec.scala
@@ -103,7 +103,7 @@ class PolynoteConfigSpec extends FlatSpec with Matchers with EitherValues {
       ),
       List("org.typelevel", "com.mycompany"),
       Map("scala" -> List("org.typelevel:cats-core_2.11:1.6.0", "com.mycompany:my-library:jar:all:1.0.0")),
-      true,
+      false,
       Some(SparkConfig(Map("spark.driver.userClasspathFirst" -> "true", "spark.executor.userClasspathFirst" -> "true"), Some("testing"))),
       credentials = Credentials(
         coursier = Some(Credentials.Coursier("~/.config/coursier/credentials.properties"))

--- a/polynote-server/src/main/scala/polynote/server/KernelPublisher.scala
+++ b/polynote-server/src/main/scala/polynote/server/KernelPublisher.scala
@@ -89,6 +89,8 @@ class KernelPublisher private (
       kernelRef.set(None) *>
       closeIfNoSubscribers
 
+  val kernelIfStarted: UIO[Option[Kernel]] = kernelRef.get
+
   val kernel: RIO[BaseEnv with GlobalEnv, Kernel] = kernelRef.get.flatMap {
     case Some(kernel) =>
       ZIO.succeed(kernel)
@@ -146,7 +148,7 @@ class KernelPublisher private (
     signatures  <- kernel.parametersAt(cellID, pos).provideSomeLayer[BaseEnv with GlobalEnv](cellEnv(cellID))
   } yield signatures
 
-  def goToDefinition(cellID: Either[String, CellID], pos: Int): RIO[BaseEnv with GlobalEnv, (List[DefinitionLocation], Option[String])] = for {
+  def goToDefinition(cellID: Either[String, CellID], pos: Int): RIO[BaseEnv with GlobalEnv, List[DefinitionLocation]] = for {
     kernel <- kernel
     env     = cellID.fold(_ => depEnv, id => cellEnv(id))
     result <- kernel.goToDefinition(cellID, pos).provideSomeLayer[BaseEnv with GlobalEnv](env)

--- a/polynote-server/src/main/scala/polynote/server/NotebookSession.scala
+++ b/polynote-server/src/main/scala/polynote/server/NotebookSession.scala
@@ -57,7 +57,7 @@ class NotebookSession(
     case GoToDefinitionRequest(source, pos, reqId) =>
       for {
         definitions <- subscriber.publisher.goToDefinition(source, pos)
-        _           <- PublishMessage(GoToDefinitionResponse(reqId, definitions._1, definitions._2))
+        _           <- PublishMessage(GoToDefinitionResponse(reqId, definitions))
       } yield ()
 
     case KernelStatus( _) => for {

--- a/polynote-server/src/main/scala/polynote/server/Server.scala
+++ b/polynote-server/src/main/scala/polynote/server/Server.scala
@@ -215,6 +215,20 @@ class Server {
               case "download=true" => downloadFile(req.uri.getPath.stripPrefix("/notebook/"), req)
               case _ => getIndex.map(Response.html(_))
             }
+          case req if req.uri.getPath startsWith "/dependency/" =>
+            val queryParams = Option(req.uri.getQuery).map(Server.parseQuery).getOrElse(Map.empty)
+            val result = for {
+              lang <- ZIO.fromOption(queryParams.get("lang").flatMap(_.headOption))
+              dep  <- ZIO.fromOption(queryParams.get("dependency").flatMap(_.headOption))
+              kernel <- NotebookManager.getKernel(req.uri.getPath.stripPrefix("/dependency/")).some
+              source <- kernel.dependencySource(lang, dep).catchAll {
+                err => Logging.error(err) *> ZIO.fail(None)
+              }
+            } yield Response.plain(source)
+
+            result.catchAll {
+              none => Logging.error(s"Request for a dependency source at ${req.uri} failed") *> ZIO.fail(NotFound(req.uri.toString))
+            }
         } .handleSome(staticHandler)
           .handleSome(authRoutes)
           .logRequests(ServerLogger.noLogRequests)
@@ -251,4 +265,16 @@ object Server {
       }
     }
   }
+
+  /**
+    * Very simply (and not very robustly) parse a query string like "foo=wizzle&bar=wozzle". Returns a map of key to list
+    * of all values that appeared with that key. Parameters that aren't key/value (e.g. "foo&bar&baz") are treated as
+    * values of the empty key "".
+    */
+  def parseQuery(query: String): Map[String, List[String]] = query.split('&').toList.map {
+    param => param.indexOf('=') match {
+      case -1 => ("", param)
+      case n  => (param.substring(0, n), if (n < param.length - 1) param.substring(n + 1) else "")
+    }
+  }.groupBy(_._1).mapValues(_.map(_._2))
 }

--- a/polynote-server/src/main/scala/polynote/server/Server.scala
+++ b/polynote-server/src/main/scala/polynote/server/Server.scala
@@ -276,5 +276,5 @@ object Server {
       case -1 => ("", param)
       case n  => (param.substring(0, n), if (n < param.length - 1) param.substring(n + 1) else "")
     }
-  }.groupBy(_._1).mapValues(_.map(_._2))
+  }.groupBy(_._1).mapValues(_.map(_._2)).toMap
 }

--- a/polynote-spark/src/main/scala/polynote/kernel/LocalSparkKernel.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/LocalSparkKernel.scala
@@ -130,7 +130,7 @@ class LocalSparkKernelFactory extends Kernel.Factory.LocalService {
     session          <- startSparkSession(sparkJars, classLoader)
     busyState        <- SubscriptionRef.make(KernelBusyState(busy = true, alive = true))
     interpreters     <- RefMap.empty[String, Interpreter]
-    scalaInterpreter <- interpreters.getOrCreate("scala")(ScalaSparkInterpreter().provideSomeLayer[BaseEnv with TaskManager](ZLayer.succeed(compiler)))
+    scalaInterpreter <- interpreters.getOrCreate("scala")(ScalaSparkInterpreter().provideSomeLayer[BaseEnv with Config with TaskManager](ZLayer.succeed(compiler)))
     interpState      <- InterpreterState.access
     closed           <- Promise.make[Throwable, Unit]
   } yield new LocalSparkKernel(compiler, session, interpState, interpreters, busyState, closed)

--- a/polynote-spark/src/main/scala/polynote/kernel/interpreter/sql/SparkSqlInterpreter.scala
+++ b/polynote-spark/src/main/scala/polynote/kernel/interpreter/sql/SparkSqlInterpreter.scala
@@ -62,9 +62,9 @@ class SparkSqlInterpreter(compiler: ScalaCompiler) extends Interpreter {
 
   def parametersAt(code: String, pos: Int, state: State): Task[Option[Signatures]] = ZIO.succeed(None)
 
-  override def goToDefinition(code: String, pos: RunId, state: State): RIO[Blocking, (List[DefinitionLocation], Option[String])] = ZIO.succeed(Nil -> None)
+  override def goToDefinition(code: String, pos: RunId, state: State): RIO[Blocking, List[DefinitionLocation]] = ZIO.succeed(Nil)
 
-  override def goToDependencyDefinition(uri: String, pos: RunId): RIO[Blocking with Logging, (List[DefinitionLocation], Option[String])] = ZIO.succeed(Nil -> None)
+  override def goToDependencyDefinition(uri: String, pos: RunId): RIO[Blocking with Logging, List[DefinitionLocation]] = ZIO.succeed(Nil)
 
   override def getDependencyContent(uri: String): RIO[Blocking, String] = ZIO.succeed("")
 


### PR DESCRIPTION
- Jump-to-definition broke on merge, largely because of Monaco version change. This PR significantly reworks it. It doesn't seem to work in Python (jedi returns nulls); will try to solve that in a future release.
- Fixed regression where closed tabs reappear on reload
- Fixed off-by-one error (Fixes #1407 - but not properly)
- Compile error line-number links now jump to that spot in the cell