### PR TITLE
Fix Scala version dropdown resetting to default on reload

### DIFF
--- a/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
@@ -557,6 +557,7 @@ class KernelConf extends Disposable {
             }
         }
         setEnv(envHandler.state);
+        scalaVersionHandler.addObserver(version => this.scalaVersionInput.setSelectedValue(version || ""));
         envHandler.addObserver(env => setEnv(env));
         jvmArgsHandler.addObserver(strs => this.jvmArgsInput.value = joinQuotedArgs(strs) || "");
 


### PR DESCRIPTION
add observer to scala version handler when loading notebook config