### PR TITLE
Fix resolvers not copying to clipboard correctly 

### DIFF
--- a/polynote-frontend/polynote/data/data.ts
+++ b/polynote-frontend/polynote/data/data.ts
@@ -84,6 +84,19 @@ export class IvyRepository extends RepositoryConfig {
         return 0;
     }
 
+    // enable parsing when copy-pasting configurations
+    toJSON(): any {
+        return {
+            type: "ivy",
+            resolver: {
+                url: this.url,
+                artifactPattern: this.artifactPattern,
+                metadataPattern: this.metadataPattern,
+                changing: this.changing
+            }
+        }
+    }
+
     constructor(readonly url: string, readonly artifactPattern?: string, readonly metadataPattern?: string, readonly changing?: boolean) {
         super();
         Object.freeze(this);
@@ -104,6 +117,17 @@ export class MavenRepository extends RepositoryConfig {
         super();
         Object.freeze(this);
     }
+
+    // enable parsing when copy-pasting configurations
+    toJSON(): any {
+        return {
+            type: "maven",
+            resolver: {
+                url: this.url,
+                changing: this.changing
+            }
+        }
+    }
 }
 
 export class PipRepository extends RepositoryConfig {
@@ -119,6 +143,16 @@ export class PipRepository extends RepositoryConfig {
     constructor(readonly url: string) {
         super();
         Object.freeze(this);
+    }
+
+    // enable parsing when copy-pasting configurations
+    toJSON(): any {
+        return {
+            type: "pip",
+            resolver: {
+                url: this.url
+            }
+        }
     }
 }
 

--- a/polynote-frontend/polynote/data/data.ts
+++ b/polynote-frontend/polynote/data/data.ts
@@ -72,10 +72,10 @@ export abstract class RepositoryConfig extends CodecContainer {
     static msgTypeId: number;
 
     abstract url: string;
-    abstract repositoryTypeName: "ivy" | "maven" | "pip";
+    abstract repositoryTypeName: RepositoryTypeNames;
 
     // enable parsing when copy-pasting configurations
-    toJSON():{ type: "ivy" | "maven" | "pip",  resolver: RepositoryConfig } {
+    toJSON(): WrappedResolver {
         return {
             type: this.repositoryTypeName,
             resolver: {...this}
@@ -93,7 +93,7 @@ export class IvyRepository extends RepositoryConfig {
         return 0;
     }
 
-    get repositoryTypeName(): "ivy" | "maven" | "pip" {
+    get repositoryTypeName(): RepositoryTypeNames {
         return "ivy";
     }
 
@@ -113,7 +113,7 @@ export class MavenRepository extends RepositoryConfig {
         return 1;
     }
 
-    get repositoryTypeName(): "ivy" | "maven" | "pip" {
+    get repositoryTypeName(): RepositoryTypeNames {
         return "maven";
     }
 
@@ -133,7 +133,7 @@ export class PipRepository extends RepositoryConfig {
         return 2;
     }
 
-    get repositoryTypeName(): "ivy" | "maven" | "pip" {
+    get repositoryTypeName(): RepositoryTypeNames {
         return "pip";
     }
 
@@ -142,6 +142,13 @@ export class PipRepository extends RepositoryConfig {
         Object.freeze(this);
     }
 }
+
+export type RepositoryTypeNames = "ivy" | "maven" | "pip";
+
+export type WrappedResolver = {
+    type: RepositoryTypeNames,
+    resolver: RepositoryConfig
+};
 
 RepositoryConfig.codecs = [
     IvyRepository,   // 0

--- a/polynote-frontend/polynote/data/data.ts
+++ b/polynote-frontend/polynote/data/data.ts
@@ -71,7 +71,15 @@ export abstract class RepositoryConfig extends CodecContainer {
     static codecs: typeof RepositoryConfig[];
     static msgTypeId: number;
 
-    abstract url: string
+    abstract url: string;
+    abstract repositoryTypeName: "ivy" | "maven" | "pip";
+
+    toJSON():{ type: "ivy" | "maven" | "pip",  resolver: RepositoryConfig } {
+        return {
+            type: this.repositoryTypeName,
+            resolver: {...this}
+        }
+    }
 }
 
 export class IvyRepository extends RepositoryConfig {
@@ -84,17 +92,8 @@ export class IvyRepository extends RepositoryConfig {
         return 0;
     }
 
-    // enable parsing when copy-pasting configurations
-    toJSON(): any {
-        return {
-            type: "ivy",
-            resolver: {
-                url: this.url,
-                artifactPattern: this.artifactPattern,
-                metadataPattern: this.metadataPattern,
-                changing: this.changing
-            }
-        }
+    get repositoryTypeName(): "ivy" | "maven" | "pip" {
+        return "ivy";
     }
 
     constructor(readonly url: string, readonly artifactPattern?: string, readonly metadataPattern?: string, readonly changing?: boolean) {
@@ -113,20 +112,13 @@ export class MavenRepository extends RepositoryConfig {
         return 1;
     }
 
+    get repositoryTypeName(): "ivy" | "maven" | "pip" {
+        return "maven";
+    }
+
     constructor(readonly url: string, readonly changing?: boolean) {
         super();
         Object.freeze(this);
-    }
-
-    // enable parsing when copy-pasting configurations
-    toJSON(): any {
-        return {
-            type: "maven",
-            resolver: {
-                url: this.url,
-                changing: this.changing
-            }
-        }
     }
 }
 
@@ -140,19 +132,13 @@ export class PipRepository extends RepositoryConfig {
         return 2;
     }
 
+    get repositoryTypeName(): "ivy" | "maven" | "pip" {
+        return "pip";
+    }
+
     constructor(readonly url: string) {
         super();
         Object.freeze(this);
-    }
-
-    // enable parsing when copy-pasting configurations
-    toJSON(): any {
-        return {
-            type: "pip",
-            resolver: {
-                url: this.url
-            }
-        }
     }
 }
 

--- a/polynote-frontend/polynote/data/data.ts
+++ b/polynote-frontend/polynote/data/data.ts
@@ -74,6 +74,7 @@ export abstract class RepositoryConfig extends CodecContainer {
     abstract url: string;
     abstract repositoryTypeName: "ivy" | "maven" | "pip";
 
+    // enable parsing when copy-pasting configurations
     toJSON():{ type: "ivy" | "maven" | "pip",  resolver: RepositoryConfig } {
         return {
             type: this.repositoryTypeName,

--- a/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
@@ -28,8 +28,6 @@ import {NBConfig} from "../../../state/notebook_state";
 import {joinQuotedArgs, parseQuotedArgs} from "../../../util/helpers";
 import {ServerStateHandler} from "../../../state/server_state";
 import {copyToClipboard} from "./cell";
-import {wrap} from "vega-lite/build/src/log";
-
 export class NotebookConfigEl extends Disposable {
     readonly el: TagElement<"div">;
     private readonly stateHandler: StateHandler<NBConfig>;

--- a/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
@@ -118,7 +118,7 @@ export class NotebookConfigEl extends Disposable {
 
             try {
                 paste = JSON.parse(clipText);
-                let resolvers = Resolvers.parseWrappedResolvers(paste.repositories);
+                let resolvers = Resolvers.parseWrappedResolvers((paste.repositories as unknown) as [{type: "ivy" | "maven" | "pip", resolver: RepositoryConfig}]);
                 conf = new NotebookConfig(paste.dependencies, paste.exclusions, resolvers, paste.sparkConfig, paste.sparkTemplate, paste.env, paste.scalaVersion, paste.jvmArgs);
                 this.saveConfig(conf);
                 this.pasteErrorMessage.classList.add('hide');
@@ -352,16 +352,19 @@ class Resolvers extends Disposable {
         });
     }
 
-    static parseWrappedResolvers(wrappedResolvers: any): RepositoryConfig[] {
-        return wrappedResolvers.map((wrappedResolver: any) => {
-            let resolver = wrappedResolver.resolver;
+    static parseWrappedResolvers(wrappedResolvers: [{type: "ivy" | "maven" | "pip", resolver: RepositoryConfig}]): RepositoryConfig[] {
+        return wrappedResolvers.map((wrappedResolver: {type: "ivy" | "maven" | "pip", resolver: RepositoryConfig}) => {
+            let resolver;
             if (wrappedResolver.type === "ivy") {
+                resolver = wrappedResolver.resolver as IvyRepository;
                 return new IvyRepository(resolver.url, resolver.artifactPattern, resolver.metadataPattern, resolver.changing);
             }
             else if (wrappedResolver.type === "maven") {
+                resolver = wrappedResolver.resolver as MavenRepository;
                 return new MavenRepository(resolver.url, resolver.changing);
             }
             else if (wrappedResolver.type == "pip") {
+                resolver = wrappedResolver.resolver as PipRepository;
                 return new PipRepository(resolver.url);
             }
             else {


### PR DESCRIPTION
- previously, calling JSON.stringify on the configuration object caused the resolver to not be able to be parsed as a specific type of RepositoryConfig. this breaks copy-pasting 
- this changeset adds a toJSON method on each child class of RepositoryConfig to wrap the object along with a "type" property (one of "ivy", "maven", or "pip") and uses that when parsing the JSON back to a NotebookConfig object 

fixes #1403 