### PR TITLE
Build stylesheets when in watch mode 

### DIFF
--- a/polynote-frontend/webpack.config.js
+++ b/polynote-frontend/webpack.config.js
@@ -3,6 +3,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
 const path = require('path');
+const {exec} = require("child_process");
 
 module.exports = {
   entry: './polynote/main.ts',
@@ -50,7 +51,17 @@ module.exports = {
         { from: 'favicon.ico', to: 'favicon.ico' },
         { from: 'favicon.svg', to: 'favicon.svg' },
       ]
-    })
+    }),
+    {
+      apply: (compiler) => {
+        compiler.hooks.watchRun.tap('HtmlWebpackPlugin', (compilation) => {
+          exec('./build_style', (err, stdout, stderr) => {
+            if (stdout) process.stdout.write(stdout);
+            if (stderr) process.stderr.write(stderr);
+          });
+        });
+      }
+    }
   ],
   mode: "development"
 };

--- a/polynote-frontend/webpack.config.js
+++ b/polynote-frontend/webpack.config.js
@@ -55,10 +55,15 @@ module.exports = {
     {
       apply: (compiler) => {
         compiler.hooks.watchRun.tap('HtmlWebpackPlugin', (compilation) => {
-          exec('./build_style', (err, stdout, stderr) => {
-            if (stdout) process.stdout.write(stdout);
-            if (stderr) process.stderr.write(stderr);
-          });
+          if (compilation.modifiedFiles) {
+            let changedFiles = Array.from(compilation.modifiedFiles);
+            if (changedFiles.some(path => path.includes(".less"))) {
+              exec('./build_style', (err, stdout, stderr) => {
+                if (stdout) process.stdout.write(stdout);
+                if (stderr) process.stderr.write(stderr);
+              });
+            }
+          }
         });
       }
     }


### PR DESCRIPTION
Previously, `npm run watch` would not pick up changes to stylesheets because of our usage of `less.js`, requiring an `npm run build` if a styling change was made. This webpack config change adds a hook to run `build_style` when in watch mode and a `.less` file is modified. 