### PR TITLE
Improvements to jump-to-definition

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ val sparkHome: SettingKey[String] = settingKey("Location of specific Spark insta
 val versions = new {
   val coursier   = "2.0.0-RC5-6"
   val zio        = "1.0.11"
+  val javaparser = "3.25.5"
 }
 
 
@@ -189,6 +190,8 @@ val `polynote-kernel` = project.settings(
     "io.circe" %% "circe-generic-extras" % circeVersion.value,
     "io.circe" %% "circe-parser" % circeVersion.value,
     "net.sf.py4j" % "py4j" % "0.10.7",
+    "com.github.javaparser" % "javaparser-core" % versions.javaparser,
+    "com.github.javaparser" % "javaparser-symbol-solver-core" % versions.javaparser,
     "org.scalamock" %% "scalamock" % "4.4.0" % "test"
   ),
   distFiles := Seq(assembly.value) ++ (Compile / dependencyClasspath).value.collect {

--- a/polynote-frontend/polynote/interpreter/file_extensions.ts
+++ b/polynote-frontend/polynote/interpreter/file_extensions.ts
@@ -1,0 +1,9 @@
+const FileExtensions: Record<string, string> = {
+    "py": "python"
+}
+
+export function languageOfExtension(extension?: string): string | undefined {
+    if (!extension)
+        return undefined;
+    return FileExtensions[extension] || extension;
+}

--- a/polynote-frontend/polynote/main.ts
+++ b/polynote-frontend/polynote/main.ts
@@ -279,6 +279,12 @@ monaco.languages.registerDefinitionProvider("scala", {
     }
 });
 
+monaco.languages.registerDefinitionProvider("java", {
+    provideDefinition: (doc, pos, cancelToken) => {
+        return (doc as CodeCellModel).goToDefinition(doc.getOffsetAt(pos));
+    }
+});
+
 monaco.languages.registerDefinitionProvider("python", {
     provideDefinition: (doc, pos, cancelToken) => {
         return (doc as CodeCellModel).goToDefinition(doc.getOffsetAt(pos));

--- a/polynote-frontend/polynote/ui/component/notebook/common.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/common.ts
@@ -7,6 +7,7 @@ import Location = languages.Location;
 import {NotebookStateHandler} from "../../../state/notebook_state";
 import {Either, Left, Right} from "../../../data/codec_types";
 import {arrExists, nameFromPath, posToRange} from "../../../util/helpers";
+import {languageOfExtension} from "../../../interpreter/file_extensions";
 
 
 export function findDefinitionLocation(
@@ -44,7 +45,8 @@ export function openDefinition(notebookState: NotebookStateHandler, lang: string
     const params = new URLSearchParams(location.uri.query);
     const filename = params.get("dependency");
     const filePieces = filename?.split('.')
-    const fileLanguage = filePieces?.[filePieces.length - 1] || lang;
+    const fileExtension = filePieces?.[filePieces.length - 1]
+    const fileLanguage = languageOfExtension(fileExtension) || lang;
 
     if (uriString in ServerStateHandler.state.dependencySources) {
         return ServerStateHandler.get.updateAsync(state => {

--- a/polynote-frontend/polynote/ui/component/tabs.ts
+++ b/polynote-frontend/polynote/ui/component/tabs.ts
@@ -171,7 +171,8 @@ export class Tabs extends Disposable {
     }
 
     private mkDependencyTitle(uri: string): TagElement<"span"> {
-        const dep = new URLSearchParams(new URL(uri).search).get("dependency") || ""
-        return span(['notebook-tab-title', 'dependency-source-tab-title'], [dep]);
+        const dep = new URLSearchParams(new URL(uri).search).get("dependency") || "";
+        const pathParts = dep.split('/');
+        return span(['notebook-tab-title', 'dependency-source-tab-title'], [pathParts[pathParts.length - 1]]).attr('title', dep);
     }
 }

--- a/polynote-kernel/src/main/scala/polynote/kernel/LocalKernel.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/LocalKernel.scala
@@ -137,10 +137,10 @@ class LocalKernel private[kernel] (
           case Left(uri) =>
             val ext = uri.split('.').last
             val lookup = for {
-              interps   <- interpreters.values
-              interp    <- ZIO.succeed(interps.find(_.fileExtensions.contains(ext))).someOrFailException
-              locations <- interp.goToDependencyDefinition(uri, pos)
-            } yield locations.map(asDepURL(ext))
+              interps        <- interpreters.entries
+              (lang, interp) <- ZIO.succeed(interps.find(_._2.fileExtensions.contains(ext))).someOrFailException
+              locations      <- interp.goToDependencyDefinition(uri, pos)
+            } yield locations.map(asDepURL(lang))
             lookup.onError(Logging.error).catchAll(_ => ZIO.succeed(Nil))
         }
     }

--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/JavaTreeFinder.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/JavaTreeFinder.scala
@@ -15,36 +15,8 @@ import java.util.Optional
 import scala.reflect.io.AbstractFile
 
 class JavaTreeFinder extends GenericVisitorAdapter[AbstractFile, JPosition] {
-  // See https://scalameta.org/docs/semanticdb/specification.html#signature-2 for how to represent symbols in Strings
-  /*override def visit(n: TypeParameter, arg: JPosition): String = ???
-
-  override def visit(n: LineComment, arg: JPosition): String = ???
-
-  override def visit(n: BlockComment, arg: JPosition): String = ???
-
-  override def visit(n: ClassOrInterfaceDeclaration, arg: JPosition): String = ???
-
-  override def visit(n: RecordDeclaration, arg: JPosition): String = ???
-
-  override def visit(n: CompactConstructorDeclaration, arg: JPosition): String = ???
-
-  override def visit(n: EnumDeclaration, arg: JPosition): String = ???
-
-  override def visit(n: EnumConstantDeclaration, arg: JPosition): String = ???
-
-  override def visit(n: AnnotationDeclaration, arg: JPosition): String = ???
-
-  override def visit(n: AnnotationMemberDeclaration, arg: JPosition): String = ???
-
-  override def visit(n: FieldDeclaration, arg: JPosition): String = ???
-
-  override def visit(n: VariableDeclarator, arg: JPosition): String = ???
-
-  override def visit(n: ConstructorDeclaration, arg: JPosition): String = ???
-
-  override def visit(n: MethodDeclaration, arg: JPosition): String = n.resolve()*/
-
-  // unfortunately this has to return null instead of option for the super methods to function.
+  // unfortunately this has to return null instead of option in order for the super methods to function – they rely on
+  // non-null to signal success
 
   override def visit(n: Parameter, arg: JPosition): AbstractFile =
     Option(super.visit(n, arg)).orElse(associable(n, arg)).orNull

--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/JavaTreeFinder.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/JavaTreeFinder.scala
@@ -1,0 +1,144 @@
+package polynote.kernel.interpreter.scal
+
+import com.github.javaparser.ast.`type`.{ArrayType, ClassOrInterfaceType}
+import com.github.javaparser.ast.body.Parameter
+import com.github.javaparser.ast.expr._
+import com.github.javaparser.ast.stmt.ExplicitConstructorInvocationStmt
+import com.github.javaparser.ast.visitor.GenericVisitorAdapter
+import com.github.javaparser.ast.{CompilationUnit, Node}
+import com.github.javaparser.resolution.Resolvable
+import com.github.javaparser.resolution.declarations.AssociableToAST
+import com.github.javaparser.resolution.types.{ResolvedReferenceType, ResolvedType}
+import com.github.javaparser.{Position => JPosition}
+
+import java.util.Optional
+import scala.reflect.io.AbstractFile
+
+class JavaTreeFinder extends GenericVisitorAdapter[AbstractFile, JPosition] {
+  // See https://scalameta.org/docs/semanticdb/specification.html#signature-2 for how to represent symbols in Strings
+  /*override def visit(n: TypeParameter, arg: JPosition): String = ???
+
+  override def visit(n: LineComment, arg: JPosition): String = ???
+
+  override def visit(n: BlockComment, arg: JPosition): String = ???
+
+  override def visit(n: ClassOrInterfaceDeclaration, arg: JPosition): String = ???
+
+  override def visit(n: RecordDeclaration, arg: JPosition): String = ???
+
+  override def visit(n: CompactConstructorDeclaration, arg: JPosition): String = ???
+
+  override def visit(n: EnumDeclaration, arg: JPosition): String = ???
+
+  override def visit(n: EnumConstantDeclaration, arg: JPosition): String = ???
+
+  override def visit(n: AnnotationDeclaration, arg: JPosition): String = ???
+
+  override def visit(n: AnnotationMemberDeclaration, arg: JPosition): String = ???
+
+  override def visit(n: FieldDeclaration, arg: JPosition): String = ???
+
+  override def visit(n: VariableDeclarator, arg: JPosition): String = ???
+
+  override def visit(n: ConstructorDeclaration, arg: JPosition): String = ???
+
+  override def visit(n: MethodDeclaration, arg: JPosition): String = n.resolve()*/
+
+  // unfortunately this has to return null instead of option for the super methods to function.
+
+  override def visit(n: Parameter, arg: JPosition): AbstractFile =
+    Option(super.visit(n, arg)).orElse(associable(n, arg)).orNull
+
+  override def visit(n: ClassOrInterfaceType, arg: JPosition): AbstractFile = {
+    if (!n.getRange.asScala.exists(_.contains(arg))) {
+      return null
+    }
+    val result1 = super.visit(n, arg)
+    if (result1 != null) {
+      return result1
+    }
+    val resolved = n.resolve()
+    val decl = resolved.asReferenceType().getTypeDeclaration.asScala
+    decl.flatMap {
+      decl =>
+        val ast = decl.toAst().asScala
+        ast.map {
+          node =>
+            var n = node
+            while (!n.isInstanceOf[CompilationUnit]) {
+              n = n.getParentNode.get()
+            }
+            n.getData(SemanticDbScan.OriginalSource)
+        }
+    }.orNull
+  }
+
+  override def visit(n: ArrayType, arg: JPosition): AbstractFile =
+    Option(super.visit(n, arg)).orElse(refType(n, arg)).orNull
+
+  override def visit(n: FieldAccessExpr, arg: JPosition): AbstractFile =
+    Option(super.visit(n, arg)).orElse(associable(n, arg)).orNull
+
+  override def visit(n: MethodCallExpr, arg: JPosition): AbstractFile =
+    Option(super.visit(n, arg)).orElse(associable(n, arg)).orNull
+
+  override def visit(n: NameExpr, arg: JPosition): AbstractFile =
+    Option(super.visit(n, arg)).orElse(associable(n, arg)).orNull
+
+  override def visit(n: ObjectCreationExpr, arg: JPosition): AbstractFile =
+    Option(super.visit(n, arg)).orElse(associable(n, arg)).orNull
+
+  override def visit(n: ThisExpr, arg: JPosition): AbstractFile =
+    Option(super.visit(n, arg)).orElse(associable(n, arg)).orNull
+
+  override def visit(n: MarkerAnnotationExpr, arg: JPosition): AbstractFile =
+    Option(super.visit(n, arg)).orElse(associable(n, arg)).orNull
+
+  override def visit(n: SingleMemberAnnotationExpr, arg: JPosition): AbstractFile =
+    Option(super.visit(n, arg)).orElse(associable(n, arg)).orNull
+
+  override def visit(n: NormalAnnotationExpr, arg: JPosition): AbstractFile =
+    Option(super.visit(n, arg)).orElse(associable(n, arg)).orNull
+
+  override def visit(n: ExplicitConstructorInvocationStmt, arg: JPosition): AbstractFile =
+    Option(super.visit(n, arg)).orElse(associable(n, arg)).orNull
+
+  override def visit(n: MethodReferenceExpr, arg: JPosition): AbstractFile =
+    Option(super.visit(n, arg)).orElse(associable(n, arg)).orNull
+
+  private def impl1[T](node: Node with Resolvable[T], pos: JPosition)(fn: T => Option[Node]): Option[AbstractFile] =
+    node.getRange.asScala.filter(_.contains(pos)).flatMap {
+      _ => try {
+        val resolved = node.resolve()
+        fn(resolved).flatMap(getPath)
+      } catch {
+        case err: Throwable =>
+          throw err
+          None
+      }
+    }
+
+  private def refType[T <: ResolvedType](node: Node with Resolvable[T], pos: JPosition) = impl1(node, pos) {
+    case ref: ResolvedReferenceType => ref.getTypeDeclaration.asScala.flatMap(_.toAst.asScala) // it should be a ResolvedReferenceType
+    case _ => None
+  }
+
+  private def associable[T <: AssociableToAST](node: Node with Resolvable[T], pos: JPosition): Option[AbstractFile] =
+    impl1[T](node, pos)(_.toAst.asScala)
+
+  private def getPath(node: Node): Option[AbstractFile] = node match {
+    case node: CompilationUnit => Option(node.getData(SemanticDbScan.OriginalSource))
+    case node => node.getParentNode.asScala.flatMap(getPath)
+  }
+
+  private def attempt[N <: Node](n: N, pos: JPosition)(fn: N => Option[AbstractFile]): Option[AbstractFile] =
+    if (n.getRange.isPresent && n.getRange.get.contains(pos)) {
+      try fn(n) catch {
+        case err: Throwable => None
+      }
+    } else None
+
+  implicit class OptionalInterop[T <: AnyRef](private val self: Optional[T]) {
+    def asScala: Option[T] = if (self.isPresent) Option(self.orElse(null.asInstanceOf[T])) else None
+  }
+}

--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/LazyParsingTypeSolver.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/LazyParsingTypeSolver.scala
@@ -1,14 +1,68 @@
 package polynote.kernel.interpreter.scal
 
-import com.github.javaparser.resolution.TypeSolver
-import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration
+import com.github.javaparser.{JavaParser, StaticJavaParser}
+import com.github.javaparser.resolution.{Navigator, TypeSolver}
+import com.github.javaparser.resolution.declarations.{ResolvedReferenceTypeDeclaration, ResolvedTypeDeclaration}
 import com.github.javaparser.resolution.model.SymbolReference
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade
 
-class LazyParsingTypeSolver extends TypeSolver {
+import java.io.File
+import java.nio.file.Paths
+import java.util.concurrent.ConcurrentHashMap
+import scala.reflect.io.ZipArchive
+import scala.tools.nsc.interactive
+import scala.collection.JavaConverters._
 
-  override def getParent: TypeSolver = ???
+class LazyParsingTypeSolver[Global <: interactive.Global](
+  val global: Global,
+  semanticDbScan: SemanticDbScan,
+  units: ConcurrentHashMap[String, Global#RichCompilationUnit],
+  underlying: TypeSolver
+) extends TypeSolver {
 
-  override def setParent(parent: TypeSolver): Unit = ???
+  private val cache = new ConcurrentHashMap[String, ResolvedReferenceTypeDeclaration]()
+  private var parent: Option[TypeSolver] = None
 
-  override def tryToSolveType(name: String): SymbolReference[ResolvedReferenceTypeDeclaration] = ???
+  override def getParent: TypeSolver = parent.orNull
+  override def setParent(parent: TypeSolver): Unit = this.parent = Some(parent)
+
+  override def tryToSolveType(name: String): SymbolReference[ResolvedReferenceTypeDeclaration] =
+    if (cache.containsKey(name)) {
+      val cached = cache.get(name)
+      if (cached != null) {
+        SymbolReference.solved(cached)
+      } else SymbolReference.unsolved()
+    } else {
+      val solved = impl(name)
+      if (solved.isSolved) {
+        cache.putIfAbsent(name, solved.getCorrespondingDeclaration)
+        solved
+      } else SymbolReference.unsolved()
+    }
+
+  private def impl(name: String): SymbolReference[ResolvedReferenceTypeDeclaration] = {
+    val outerClassName = name.indexOf('$') match {
+      case -1 => name
+      case n => name.substring(0, n)
+    }
+    if (units.containsKey(outerClassName)) {
+      try {
+        val unit = units.get(outerClassName)
+        val content = new String(unit.source.content)
+        val parseResult = semanticDbScan.javaParser.parse(content)
+        val parsed = parseResult.getResult.get
+        parsed.setData(SemanticDbScan.OriginalSource, unit.source.file)
+        val pkgFromPath = unit.source.path.split('!').last.split('/').dropRight(1).mkString(".")
+        val foundType = Navigator.findType(parsed, name.stripPrefix(pkgFromPath).stripPrefix("."))
+        if (foundType.isPresent) {
+          SymbolReference.solved(JavaParserFacade.get(this).getTypeDeclaration(foundType.get()))
+        } else SymbolReference.unsolved()
+      } catch {
+        case err: Throwable => SymbolReference.unsolved()
+      }
+    } else {
+      underlying.tryToSolveType(name)
+    }
+  }
+
 }

--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/LazyParsingTypeSolver.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/LazyParsingTypeSolver.scala
@@ -1,0 +1,14 @@
+package polynote.kernel.interpreter.scal
+
+import com.github.javaparser.resolution.TypeSolver
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration
+import com.github.javaparser.resolution.model.SymbolReference
+
+class LazyParsingTypeSolver extends TypeSolver {
+
+  override def getParent: TypeSolver = ???
+
+  override def setParent(parent: TypeSolver): Unit = ???
+
+  override def tryToSolveType(name: String): SymbolReference[ResolvedReferenceTypeDeclaration] = ???
+}

--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/ScalaInterpreter.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/ScalaInterpreter.scala
@@ -83,7 +83,7 @@ class ScalaInterpreter private[scal] (
 
   override def shutdown(): Task[Unit] = ZIO.unit
 
-  override def fileExtensions: Set[String] = Set("scala")
+  override def fileExtensions: Set[String] = Set("scala", "java")
 
   override def getDependencyContent(uri: String): RIO[Blocking, String] = ZIO {
     val parsed = new URI(uri)

--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/ScalaJavaParser.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/ScalaJavaParser.scala
@@ -1,5 +1,0 @@
-package polynote.kernel.interpreter.scal
-
-class ScalaJavaParser {
-
-}

--- a/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/ScalaJavaParser.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/interpreter/scal/ScalaJavaParser.scala
@@ -1,0 +1,5 @@
+package polynote.kernel.interpreter.scal
+
+class ScalaJavaParser {
+
+}

--- a/polynote-kernel/src/main/scala/polynote/kernel/util/RefMap.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/RefMap.scala
@@ -76,6 +76,10 @@ class RefMap[K, V] private (
     case Right(ref) => ref.get
   })
 
+  def entries: UIO[List[(K, V)]] = ZIO.collectAll(underlying.asScala.toList.collect {
+    case (key, Right(ref)) => ref.get.map(value => (key, value))
+  })
+
   def isEmpty: UIO[Boolean] = ZIO.effectTotal(underlying.isEmpty)
 }
 


### PR DESCRIPTION
* Much better support for jumping around amongst Java sources – uses [JavaParser](https://github.com/javaparser/javaparser)'s parsing and symbol solving instead of the Scala compiler's limited Java support.
* Fixes some issues with Python jump-to-definition:
  * Plugs a potential security hole, by maintaining an allowed-list of legit definition locations
  * Fixes syntax highlighting of Python files
* Shorten the dependency path to just the filename in the tab (but keep the full path on hover) 