### PR TITLE
Fix bug with renaming notebooks 

### DIFF
--- a/polynote-frontend/polynote/state/server_state.ts
+++ b/polynote-frontend/polynote/state/server_state.ts
@@ -213,6 +213,7 @@ export class ServerStateHandler extends BaseHandler<ServerState> {
             ServerStateHandler.notebooks[newPath] = nbInfo
             delete ServerStateHandler.notebooks[oldPath]
 
+            // perform state updates on server
             ServerStateHandler.updateStateAsync(state =>  {
                 const pathIdx = state.openFiles.findIndex(of => of.type === 'notebook' && of.path === oldPath);
                 return {
@@ -222,7 +223,7 @@ export class ServerStateHandler extends BaseHandler<ServerState> {
                 }
             })
                 .then(() => {
-                    ServerStateHandler.selectFile(newPath);
+                    ServerStateHandler.selectFile(newPath); // now select the newly renamed notebook
             })
         }
     }

--- a/polynote-frontend/polynote/state/server_state.ts
+++ b/polynote-frontend/polynote/state/server_state.ts
@@ -120,6 +120,10 @@ export class ServerStateHandler extends BaseHandler<ServerState> {
         return ServerStateHandler.get.update(update, updateSource)
     }
 
+    static updateStateAsync(update: Updater<ServerState>, updateSource?: any) {
+        return ServerStateHandler.get.updateAsync(update, updateSource)
+    }
+
     // only for testing
     static clear() {
         if (ServerStateHandler.inst) {
@@ -209,13 +213,16 @@ export class ServerStateHandler extends BaseHandler<ServerState> {
             ServerStateHandler.notebooks[newPath] = nbInfo
             delete ServerStateHandler.notebooks[oldPath]
 
-            ServerStateHandler.updateState(state =>  {
+            ServerStateHandler.updateStateAsync(state =>  {
                 const pathIdx = state.openFiles.findIndex(of => of.type === 'notebook' && of.path === oldPath);
                 return {
                     notebooks: renameKey(oldPath, newPath),
-                    openFiles: pathIdx >= 0 ? replaceArrayValue({type: 'notebook', newPath}, pathIdx) : NoUpdate,
+                    openFiles: pathIdx >= 0 ? replaceArrayValue({type: 'notebook', path: newPath}, pathIdx) : NoUpdate,
                     notebookTimestamps: renameKey(oldPath, newPath),
                 }
+            })
+                .then(() => {
+                    ServerStateHandler.selectFile(newPath);
             })
         }
     }

--- a/polynote-frontend/polynote/state/server_state.ts
+++ b/polynote-frontend/polynote/state/server_state.ts
@@ -7,7 +7,7 @@ import {
     removeFromArray,
     removeKey,
     renameKey,
-    replaceArrayValue,
+    replaceArrayValue, setValue,
     StateHandler,
     StateView,
     updateProperty
@@ -208,23 +208,29 @@ export class ServerStateHandler extends BaseHandler<ServerState> {
         const nbInfo = ServerStateHandler.notebooks[oldPath]
         if (nbInfo) {
             // update the path in the notebook's handler
-            nbInfo.handler.updateField("path", () => newPath);
-            // update our notebooks dictionary
-            ServerStateHandler.notebooks[newPath] = nbInfo
-            delete ServerStateHandler.notebooks[oldPath]
-
-            // perform state updates on server
-            ServerStateHandler.updateStateAsync(state =>  {
-                const pathIdx = state.openFiles.findIndex(of => of.type === 'notebook' && of.path === oldPath);
+            nbInfo.handler.updateAsync(state=> {
                 return {
-                    notebooks: renameKey(oldPath, newPath),
-                    openFiles: pathIdx >= 0 ? replaceArrayValue({type: 'notebook', path: newPath}, pathIdx) : NoUpdate,
-                    notebookTimestamps: renameKey(oldPath, newPath),
+                    path: setValue(newPath)
                 }
-            })
-                .then(() => {
-                    ServerStateHandler.selectFile(newPath); // now select the newly renamed notebook
-            })
+            }).then(() => {
+                // update our notebooks dictionary
+                ServerStateHandler.notebooks[newPath] = nbInfo
+                delete ServerStateHandler.notebooks[oldPath]
+
+                // perform state updates on server
+                ServerStateHandler.updateStateAsync(state =>  {
+                    const pathIdx = state.openFiles.findIndex(of => of.type === 'notebook' && of.path === oldPath);
+                    return {
+                        notebooks: renameKey(oldPath, newPath),
+                        openFiles: pathIdx >= 0 ? replaceArrayValue({type: 'notebook', path: newPath}, pathIdx) : NoUpdate,
+                        notebookTimestamps: renameKey(oldPath, newPath),
+                    }
+                })
+                    .then(() => {
+                        ServerStateHandler.selectFile(newPath); // now select the newly renamed notebook
+                    });
+            });
+
         }
     }
 

--- a/polynote-frontend/polynote/ui/component/tabs.ts
+++ b/polynote-frontend/polynote/ui/component/tabs.ts
@@ -110,7 +110,7 @@ export class Tabs extends Disposable {
                     this.tabContainer.replaceChild(newTab, tab.tab)
                     this.tabs[newPath] = {...tab, tab: newTab};
                     if (this.currentTab?.path === oldPath) {
-                        this.activate(newPath, true);
+                        this.activate(newPath, true); // should not update currentNotebook yet, other state changes not completed
                     }
                 }
             ).disposeWith(this);

--- a/polynote-frontend/polynote/ui/component/tabs.ts
+++ b/polynote-frontend/polynote/ui/component/tabs.ts
@@ -110,7 +110,7 @@ export class Tabs extends Disposable {
                     this.tabContainer.replaceChild(newTab, tab.tab)
                     this.tabs[newPath] = {...tab, tab: newTab};
                     if (this.currentTab?.path === oldPath) {
-                        this.activate(newPath)
+                        this.activate(newPath, true);
                     }
                 }
             ).disposeWith(this);
@@ -119,7 +119,7 @@ export class Tabs extends Disposable {
         }
     }
 
-    activate(path: string) {
+    activate(path: string, skipSelectingFile?: boolean) {
         if (this.currentTab === undefined || this.currentTab.tab.classList.contains("active")) {
             const tab = this.tabs[path];
             const current = this.currentTab;
@@ -131,7 +131,9 @@ export class Tabs extends Disposable {
             }
             tab.tab.classList.add("active");
             this.currentTab = {path, tab: tab.tab, content: tab.content};
-            ServerStateHandler.selectFile(path)
+            if (!skipSelectingFile) {
+                ServerStateHandler.selectFile(path);
+            }
         }
     }
 


### PR DESCRIPTION
- previously, renaming an open notebook and then refreshing the page would leave the old notebook tab open because the state updates execute in the incorrect order, meaning the list of open files is not correct by the time a process in main.ts attempts to update the url of the page to the new notebook 
- this changeset adds a check in tabs.ts in the observer for the notebook path property - if the change comes from a rename, then `ServerStateHandler.selectFile` should not be called yet - the rest of the state updates have not been completed. Instead, make the other state updates async and call `ServerStateHandler.selectFile` after those have executed

fixes #1422  