### PR TITLE
Fix build setup race condition

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -279,7 +279,7 @@ val sparkSettings = Seq(
       } else {
         println("Lock file no longer exists, test setup must have finished")
       }
-    } else {t
+    } else {
       baseDir.mkdirs()
       lockFile.createNewFile()
 

--- a/build.sbt
+++ b/build.sbt
@@ -280,7 +280,6 @@ val sparkSettings = Seq(
       println(s"Extracting $pkgFile to $baseDir")
       // debugging
       println(Seq("ls", "-la", baseDir.toString).!!)
-      println(Seq("md5", pkgFile.toString).!!)
       println(Seq("tar", "-zxpf", pkgFile.toString, "-C", baseDir.toString).!!)
     }
   },

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,4 @@
 import java.io.File
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.atomic.AtomicBoolean
 import scala.util.Try
 
 name := "polynote"
@@ -281,7 +279,7 @@ val sparkSettings = Seq(
       } else {
         println("Lock file no longer exists, test setup must have finished")
       }
-    } else {
+    } else {t
       baseDir.mkdirs()
       lockFile.createNewFile()
 

--- a/build.sbt
+++ b/build.sbt
@@ -261,6 +261,10 @@ val sparkSettings = Seq(
     val filename = s"$pkgName.tgz"
     val distUrl = url(s"${sparkDistUrl(distVersion)}/$filename")
     val destDir = baseDir / pkgName
+    // debugging
+    println("**** BEFORE DOWNLOAD ****")
+    println(Seq("ls", "-la", baseDir.toString).!!)
+
     if (!destDir.exists()) {
       baseDir.mkdirs()
       val pkgFile = baseDir / filename
@@ -270,17 +274,26 @@ val sparkSettings = Seq(
 //        (distUrl #> pkgFile).!! // this seems to be somehow unreliable...
         println(Seq("curl", "-o", pkgFile.toString, distUrl.toString).!!)
       }
-      println("Verifying checksum...")
+
+      // debugging
+      println("**** AFTER DOWNLOAD ****")
+      println(Seq("ls", "-la", baseDir.toString).!!)
+
+      println(s"Verifying checksum...for $pkgFile for $distVersion")
       val expectedChecksum = sparkChecksums(distVersion)
       val actualChecksum = Seq("sha512sum", pkgFile.toString).!!.trim.split(" ").head
-      if (actualChecksum != expectedChecksum) {
+      if (actualChecksum == expectedChecksum) {
+        println(s"Checksum verified for $pkgFile for $distVersion")
+      } else {
         throw new Exception(s"Checksum mismatch for $pkgFile for $distVersion. Expected:\n$expectedChecksum\nGot:\n$actualChecksum")
       }
 
       println(s"Extracting $pkgFile to $baseDir")
-      // debugging
+      println("**** BEFORE EXTRACT ****")
       println(Seq("ls", "-la", baseDir.toString).!!)
       println(Seq("tar", "-zxpf", pkgFile.toString, "-C", baseDir.toString).!!)
+      println("**** AFTER EXTRACT ****")
+      println(Seq("ls", "-la", baseDir.toString).!!)
     }
   },
   Test / envVars ++= {

--- a/build.sbt
+++ b/build.sbt
@@ -256,10 +256,13 @@ val sparkSettings = Seq(
       if (!pkgFile.exists()) {
         pkgFile.createNewFile()
         println(s"Downloading $distUrl to $pkgFile...")
-        (distUrl #> (baseDir / filename)).!!
+        (distUrl #> pkgFile).!!
       }
       println(s"Extracting $pkgFile to $baseDir")
-      Seq("tar", "-zxpf", (baseDir / filename).toString, "-C", baseDir.toString).!!
+      // debugging
+      println(Seq("ls", "-lah", baseDir.toString).!!)
+      println(Seq("ls", "-lah", pkgFile.toString).!!)
+      Seq("tar", "-zxpf", pkgFile.toString, "-C", baseDir.toString).!!
     }
   },
   Test / envVars ++= {

--- a/build.sbt
+++ b/build.sbt
@@ -256,10 +256,10 @@ val sparkSettings = Seq(
       if (!pkgFile.exists()) {
         pkgFile.createNewFile()
         println(s"Downloading $distUrl to $pkgFile...")
-        (distUrl #> (baseDir / filename)).!
+        (distUrl #> (baseDir / filename)).!!
       }
       println(s"Extracting $pkgFile to $baseDir")
-      Seq("tar", "-zxpf", (baseDir / filename).toString, "-C", baseDir.toString).!
+      Seq("tar", "-zxpf", (baseDir / filename).toString, "-C", baseDir.toString).!!
     }
   },
   Test / envVars ++= {

--- a/build.sbt
+++ b/build.sbt
@@ -271,13 +271,15 @@ val sparkSettings = Seq(
       println(s"Lock file $lockFile exists, test setup is already running. Waiting for it to finish...")
       val start = System.currentTimeMillis()
       val timeout = 10 * 60 * 1000 // 10 minutes
-      val checkInterval = 30 * 1000 // 30 seconds
+      val checkInterval = 10 * 1000 // 10 seconds
       while (System.currentTimeMillis() < start + timeout && lockFile.exists()) {
         println(s"Lock file $lockFile still exists after ${System.currentTimeMillis() - start}ms. Waiting...")
         Thread.sleep(checkInterval)
       }
       if (lockFile.exists()) {
         throw new Exception(s"Lock file $lockFile still exists after $timeout ms. Aborting.")
+      } else {
+        println("Lock file no longer exists, test setup must have finished")
       }
     } else {
       baseDir.mkdirs()
@@ -290,8 +292,7 @@ val sparkSettings = Seq(
         if (!pkgFile.exists()) {
           pkgFile.createNewFile()
           println(s"Downloading $distUrl to $pkgFile...")
-          (distUrl #> pkgFile).!! // this seems to be somehow unreliable...
-//          println(Seq("curl", "-o", pkgFile.toString, distUrl.toString).!!)
+          (distUrl #> pkgFile).!!
         }
 
         println(s"Verifying checksum for $pkgFile for $distVersion...")

--- a/build.sbt
+++ b/build.sbt
@@ -260,7 +260,7 @@ val sparkSettings = Seq(
       }
       println(s"Extracting $pkgFile to $baseDir")
       // debugging
-      println(Seq("ls", "-lah", baseDir.toString).!!)
+      println(Seq("ls", "-la", baseDir.toString).!!)
       println(Seq("tar", "-zxpf", pkgFile.toString, "-C", baseDir.toString).!!)
     }
   },

--- a/build.sbt
+++ b/build.sbt
@@ -264,20 +264,15 @@ val sparkSettings = Seq(
     val distUrl = url(s"${sparkDistUrl(distVersion)}/$filename")
     val destDir = baseDir / pkgName
     // debugging
-    println("**** START TEST SETUP ****")
     // It seems that this Tests.Setup block gets run concurrently, which can sometimes cause weirdness to happen.
     // So we try to use a lockfile to ensure that it only ever runs once
     // (Yes there still the possibility of a race condition here, but I don't know how to properly synchronize SBT tasks...)
     val lockFile = baseDir / s"spark_${scalaBinaryVersion.value}_test_setup_is_running.lock"
-    println(s"**** CHECKING LOCK FILE $lockFile ****")
     if (lockFile.exists()) {
       println(s"Lock file $lockFile exists, test setup is already running.")
     } else {
-      println(s"**** CREATING BASE DIR ${baseDir} ****")
       baseDir.mkdirs()
-      println(s"**** CREATING LOCK FILE $lockFile ****")
       lockFile.createNewFile()
-      println(s"**** CREATED LOCK FILE ${lockFile.exists()} ****")
 
       if (destDir.exists()) {
         println(s"$destDir already exists, skipping download and extract")
@@ -286,13 +281,9 @@ val sparkSettings = Seq(
         if (!pkgFile.exists()) {
           pkgFile.createNewFile()
           println(s"Downloading $distUrl to $pkgFile...")
-          //        (distUrl #> pkgFile).!! // this seems to be somehow unreliable...
-          println(Seq("curl", "-o", pkgFile.toString, distUrl.toString).!!)
+          (distUrl #> pkgFile).!! // this seems to be somehow unreliable...
+//          println(Seq("curl", "-o", pkgFile.toString, distUrl.toString).!!)
         }
-
-        // debugging
-        println("**** AFTER DOWNLOAD ****")
-        println(Seq("ls", "-la", baseDir.toString).!!)
 
         println(s"Verifying checksum for $pkgFile for $distVersion...")
         val expectedChecksum = sparkChecksums(distVersion)
@@ -304,14 +295,9 @@ val sparkSettings = Seq(
         }
 
         println(s"Extracting $pkgFile to $baseDir")
-        println("**** BEFORE EXTRACT ****")
-        println(Seq("ls", "-la", baseDir.toString).!!)
         println(Seq("tar", "-zxpf", pkgFile.toString, "-C", baseDir.toString).!!)
-        println("**** AFTER EXTRACT ****")
-        println(Seq("ls", "-la", baseDir.toString).!!)
       }
 
-      println(s"**** DELETING LOCK FILE $lockFile ****")
       lockFile.delete()
     }
   },

--- a/build.sbt
+++ b/build.sbt
@@ -263,7 +263,6 @@ val sparkSettings = Seq(
     val destDir = baseDir / pkgName
     // debugging
     println("**** BEFORE DOWNLOAD ****")
-    println(Seq("ls", "-la", baseDir.toString).!!)
 
     if (!destDir.exists()) {
       baseDir.mkdirs()

--- a/build.sbt
+++ b/build.sbt
@@ -261,8 +261,7 @@ val sparkSettings = Seq(
       println(s"Extracting $pkgFile to $baseDir")
       // debugging
       println(Seq("ls", "-lah", baseDir.toString).!!)
-      println(Seq("ls", "-lah", pkgFile.toString).!!)
-      Seq("tar", "-zxpf", pkgFile.toString, "-C", baseDir.toString).!!
+      println(Seq("tar", "-zxpf", pkgFile.toString, "-C", baseDir.toString).!!)
     }
   },
   Test / envVars ++= {


### PR DESCRIPTION
Our build setup is implemented in sbt as a `Tests.Setup` value which I guess gets run in parallel. I couldn't figure out a way to make it run only once using sbt so now the setup uses a lock file.. 🤷 