### PR TITLE
Update "notebooks" learn more icon url

### DIFF
--- a/polynote-frontend/polynote/ui/component/notebooklist.ts
+++ b/polynote-frontend/polynote/ui/component/notebooklist.ts
@@ -234,7 +234,7 @@ export class NotebookList extends Disposable {
         this.header = h2(['ui-panel-header', 'notebooks-list-header'], [
             'Notebooks',
             span(['left-buttons'], [
-                helpIconButton([], "https://polynote.org/latest/docs/notebooks-list/"),
+                helpIconButton([], "https://polynote.org/docs/notebooks-list/"),
             ]),
             span(['right-buttons'], [
                 iconButton(['create-notebook'], 'Create new notebook', 'plus-circle', 'New').click(evt => {


### PR DESCRIPTION
This PR updates the notebook learn more icon's URL (See image for details).

<img width="437" alt="Screenshot 2024-04-08 at 1 53 29 PM" src="https://github.com/polynote/polynote/assets/71363540/c7fd6980-0aad-4566-b2c2-ba5efafdbd1a">

closes: [Issue 1439](https://github.com/polynote/polynote/issues/1439)
