### PR TITLE
Updates to latest SBT to run in modern JDK

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -88,7 +88,7 @@ val commonSettings = Seq(
       oldStrategy(x)
   },
   assembly / assemblyOption := {
-    (assembly / assemblyOption).value.copy(includeScala = false)
+    (assembly / assemblyOption).value.withIncludeScala(false)
   },
   Global / cancelable := true,
   addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3"),
@@ -342,9 +342,9 @@ lazy val `polynote-spark` = project.settings(
     "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided"
   ),
   assembly / assemblyOption := {
-    (assembly / assemblyOption).value.copy(
-      includeScala = false,
-      prependShellScript = Some(
+    (assembly / assemblyOption).value
+      .withIncludeScala(false)
+      .withPrependShellScript(Some(
         IO.read(file(".") / "scripts/polynote").linesIterator.toSeq
       ))
   },

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.10.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.8")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.2.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.12.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")


### PR DESCRIPTION
When starting SBT with newer JDKs we would get an error. Updating to latest SBT makes it work. Note this is independent of what JDK is targeted by compilation.