### PR TITLE
Cancelling a comment doesn't work

### DIFF
--- a/polynote-frontend/polynote/ui/component/notebook/comment.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/comment.ts
@@ -431,7 +431,14 @@ class NewComment extends Disposable {
                 evt.preventDefault();
                 doCreate()
             }),
-            button(['cancel'], {}, ['Cancel']).mousedown(() => {hide ? hide() : controls.classList.add("hide")})
+            button(['cancel'], {}, ['Cancel']).mousedown(() => {
+                if (!hide) {
+                    controls.classList.add("hide");
+                    this.text.value = "";
+                    return;
+                }
+                hide(); 
+            })
         ])
         this.text = textarea(['comment-text'], '', '')
             .listener('keydown', (evt: KeyboardEvent) => {

--- a/polynote-frontend/polynote/ui/component/notebook/comment.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/comment.ts
@@ -387,7 +387,7 @@ class CommentButton extends MonacoRightGutterOverlay{
 
             this.clicked = true;
 
-            const newComment = new NewComment(commentsState, () => range)
+            const newComment = new NewComment(commentsState, () => range, this.hide.bind(this))
             newComment.display(this)
                 .then(() => this.hide())
         });
@@ -407,8 +407,8 @@ class NewComment extends Disposable {
     text: TagElement<"textarea">;
 
     constructor(readonly commentsState: StateHandler<Record<string, CellComment>>,
-                readonly range: () => PosRange) {
-
+        readonly range: () => PosRange,
+        readonly hide?: () => void) {
         super()
         this.currentIdentity = ServerStateHandler.state.identity;
 
@@ -431,7 +431,7 @@ class NewComment extends Disposable {
                 evt.preventDefault();
                 doCreate()
             }),
-            button(['cancel'], {}, ['Cancel']).mousedown(() => controls.classList.add("hide"))
+            button(['cancel'], {}, ['Cancel']).mousedown(() => {hide ? hide() : controls.classList.add("hide")})
         ])
         this.text = textarea(['comment-text'], '', '')
             .listener('keydown', (evt: KeyboardEvent) => {


### PR DESCRIPTION
### This is a PR for the issue: [#1435](https://github.com/polynote/polynote/issues/1435)

Issue Description: "When writing a new root comment or replying to an existing one, hitting the 'cancel' button unfocuses the text box but doesn't actually delete the in-progress comment and hide the text field."

### Example of the Issue:

![CommentCancelBug](https://github.com/user-attachments/assets/a847f872-a0df-4be6-91e6-1afb999ab103)

### Desired Response:

![CommentCancelFix](https://github.com/user-attachments/assets/0b92ecc0-c487-49b0-8127-c6b3a8f4a045)

**Note:** The functionality for pressing the 'cancel' button when replying to an existing comment remains unchanged. I chose to do this because if the new comment is hidden, the UI leaves it unclear how to leave a reply.
