### PR TITLE
Bincompat for ByteBuffer#rewind

### DIFF
--- a/polynote-kernel/src/main/scala/polynote/kernel/LocalKernel.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/LocalKernel.scala
@@ -1,6 +1,6 @@
 package polynote.kernel
 
-import java.nio.ByteBuffer
+import java.nio.{Buffer, ByteBuffer}
 import java.util.concurrent.TimeUnit
 import polynote.kernel.Kernel.InterpreterNotStarted
 import polynote.kernel.dependency.CoursierFetcher
@@ -166,13 +166,13 @@ class LocalKernel private[kernel] (
       case Lazy =>
         for {
           handle <- ZIO.fromOption(LazyDataRepr.getHandle(handleId)).mapError(_ => new NoSuchElementException(s"Lazy#$handleId"))
-        } yield Array(ByteVector32(ByteVector(handle.data.rewind().asInstanceOf[ByteBuffer])))
+        } yield Array(ByteVector32(ByteVector((handle.data:Buffer).rewind().asInstanceOf[ByteBuffer])))
 
       case Updating =>
         for {
           handle <- ZIO.fromOption(UpdatingDataRepr.getHandle(handleId))
             .mapError(_ => new NoSuchElementException(s"Updating#$handleId"))
-        } yield handle.lastData.map(data => ByteVector32(ByteVector(data.rewind().asInstanceOf[ByteBuffer]))).toArray
+        } yield handle.lastData.map(data => ByteVector32(ByteVector((data:Buffer).rewind().asInstanceOf[ByteBuffer]))).toArray
 
       case Streaming => StreamingHandles.getStreamData(handleId, count)
     }

--- a/polynote-kernel/src/main/scala/polynote/kernel/package.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/package.scala
@@ -1,6 +1,6 @@
 package polynote
 
-import java.nio.ByteBuffer
+import java.nio.{Buffer, ByteBuffer}
 import java.util.concurrent.ConcurrentHashMap
 import polynote.kernel.environment.{Config, CurrentNotebook, CurrentRuntime, CurrentTask, PublishResult, PublishStatus}
 import polynote.kernel.interpreter.{Interpreter, InterpreterState}
@@ -116,7 +116,7 @@ package object kernel {
                 case None => for {
                   handle     <- ZIO.effectTotal(StreamingDataRepr.getHandle(handleId)).get.mapError(_ => new NoSuchElementException(s"Invalid streaming handle ID $handleId"))
                     iter       <- effectBlocking(handle.iterator)
-                    handleIter  = new HandleIterator(handleId, handle.iterator.map(buf => ByteVector32(ByteVector(buf.rewind().asInstanceOf[ByteBuffer]))))
+                    handleIter  = new HandleIterator(handleId, handle.iterator.map(buf => ByteVector32(ByteVector((buf:Buffer).rewind().asInstanceOf[ByteBuffer]))))
                     _          <- ZIO.effectTotal(streams.put(handleId, handleIter))
                     arr        <- takeElems(handleIter, count)
                 } yield arr

--- a/polynote-kernel/src/main/scala/polynote/kernel/remote/transport.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/remote/transport.scala
@@ -3,7 +3,7 @@ package remote
 
 import java.io.{BufferedReader, File, InputStreamReader}
 import java.net.{BindException, InetSocketAddress}
-import java.nio.ByteBuffer
+import java.nio.{Buffer, ByteBuffer}
 import java.nio.channels.{ClosedChannelException, ServerSocketChannel, SocketChannel}
 import java.nio.file.{Path, Paths}
 import java.util.concurrent.{Semaphore, TimeUnit}
@@ -474,7 +474,7 @@ object SocketTransport {
     private val writeLock = new Semaphore(1)
 
     private def readBuffer(): Take[Nothing, Option[ByteBuffer]] = incomingLengthBuffer.synchronized {
-      incomingLengthBuffer.rewind()
+      (incomingLengthBuffer:Buffer).rewind()
       while(incomingLengthBuffer.hasRemaining) {
         if(socketChannel.read(incomingLengthBuffer) == -1) {
           return Take.end
@@ -492,7 +492,7 @@ object SocketTransport {
           socketChannel.read(msgBuffer)
         }
 
-        msgBuffer.rewind()
+        (msgBuffer:Buffer).rewind()
         Take.single(Some(msgBuffer))
       }
     }
@@ -520,7 +520,7 @@ object SocketTransport {
 
     // MUST SYNCHRONIZE on writeLock to invoke this!
     private def writeSize(size: Int) = {
-      outgoingLengthBuffer.rewind()
+      (outgoingLengthBuffer:Buffer).rewind()
       outgoingLengthBuffer.putInt(0, size)
       socketChannel.write(outgoingLengthBuffer)
     }

--- a/polynote-kernel/src/main/scala/polynote/kernel/util/ResultOutputStream.scala
+++ b/polynote-kernel/src/main/scala/polynote/kernel/util/ResultOutputStream.scala
@@ -1,7 +1,7 @@
 package polynote.kernel.util
 
 import java.io.{OutputStream, PrintStream}
-import java.nio.ByteBuffer
+import java.nio.{Buffer, ByteBuffer}
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.AtomicBoolean
 import polynote.kernel.{Output, Result}
@@ -27,10 +27,10 @@ class ResultOutputStream(publishSync: Result => Unit, rel: String, bufSize: Int 
         if (len > 0) {
           val b = ByteBuffer.allocate(buf.position())
           val arr = new Array[Byte](buf.position())
-          buf.rewind()
+          (buf:Buffer).rewind()
           buf.get(arr)
           publishSync(Output(contentType, new String(arr, StandardCharsets.UTF_8)))
-          buf.rewind()
+          (buf:Buffer).rewind()
         }
       }
     }

--- a/polynote-kernel/src/test/scala/polynote/kernel/interpreter/python/PandasSpec.scala
+++ b/polynote-kernel/src/test/scala/polynote/kernel/interpreter/python/PandasSpec.scala
@@ -9,6 +9,8 @@ import polynote.testing.InterpreterSpec
 import polynote.testing.kernel.MockEnv
 import shapeless.Witness
 
+import java.nio.Buffer
+
 class PandasSpec extends FreeSpec with Matchers with InterpreterSpec {
   val interpreter: PythonInterpreter = PythonInterpreter(None).provide(ScalaCompiler.Provider.of(compiler)).runIO()
   interpreter.init(State.Root).provideSomeLayer(MockEnv.init).runIO()
@@ -44,7 +46,7 @@ class PandasSpec extends FreeSpec with Matchers with InterpreterSpec {
               buf =>
                 val d = buf.getDouble()
                 val i = buf.getLong()
-                buf.rewind()
+                (buf:Buffer).rewind()
                 (d, i)
             }
 
@@ -106,7 +108,7 @@ class PandasSpec extends FreeSpec with Matchers with InterpreterSpec {
             val List(row1, row2) = handle2.iterator.map {
               buf =>
                 val struct = (buf.getLong(), (buf.getDouble(), buf.getDouble(), buf.getDouble(), buf.getDouble(), buf.getDouble(), buf.getDouble()), buf.getDouble(), buf.getDouble())
-                buf.rewind()
+                (buf:Buffer).rewind()
                 struct
             }.toList
 

--- a/polynote-runtime/src/main/scala/polynote/runtime/DataEncoder.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/DataEncoder.scala
@@ -1,9 +1,8 @@
 package polynote.runtime
 
 import java.io.DataOutput
-import java.nio.ByteBuffer
+import java.nio.{Buffer, ByteBuffer}
 import java.nio.charset.StandardCharsets
-
 import scala.collection.GenTraversable
 import polynote.runtime.macros.StructDataEncoderMacros
 import polynote.runtime.util.stringPrefix
@@ -131,7 +130,7 @@ object DataEncoder extends DataEncoder0 {
   implicit val byteBuffer: DataEncoder[ByteBuffer] = sizedInstance[ByteBuffer](BinaryType, buf => buf.limit() + 4) {
     (out, bytes) =>
       val b = bytes.duplicate()
-      b.rewind()
+      (b:Buffer).rewind()
       out.writeInt(b.limit())
       val buf = new Array[Byte](1024)
       while (b.hasRemaining) {
@@ -217,7 +216,7 @@ object DataEncoder extends DataEncoder0 {
     case size if size >= 0 =>
       val buf = ByteBuffer.allocate(size)
       dataEncoder.encode(new BufferOutput(buf), value)
-      buf.rewind()
+      (buf:Buffer).rewind()
       buf
     case _ =>
       import java.io.{DataOutputStream, ByteArrayOutputStream}

--- a/polynote-runtime/src/main/scala/polynote/runtime/ReprsOf.scala
+++ b/polynote-runtime/src/main/scala/polynote/runtime/ReprsOf.scala
@@ -1,7 +1,7 @@
 package polynote.runtime
 
 import java.io.DataOutput
-import java.nio.ByteBuffer
+import java.nio.{Buffer, ByteBuffer}
 import java.nio.charset.StandardCharsets
 import polynote.runtime
 
@@ -51,7 +51,7 @@ object ReprsOf extends ExpandedScopeReprs {
         val buf = ByteBuffer.allocate(bytes.length + 4)
         buf.putInt(bytes.length)
         buf.put(bytes)
-        buf.rewind()
+        (buf:Buffer).rewind()
         buf
     }
 

--- a/polynote-runtime/src/test/scala/polynote/runtime/test/CollectionReprsSpec.scala
+++ b/polynote-runtime/src/test/scala/polynote/runtime/test/CollectionReprsSpec.scala
@@ -1,9 +1,8 @@
 package polynote.runtime.test
 
-import java.nio.ByteBuffer
+import java.nio.{Buffer, ByteBuffer}
 import java.nio.charset.StandardCharsets
 import scala.collection.JavaConverters._
-
 import org.scalatest.{FreeSpec, Matchers}
 import polynote.runtime.{DataEncoder, GroupAgg, ReprsOf, StreamingDataRepr}
 
@@ -20,7 +19,7 @@ class CollectionReprsSpec extends FreeSpec with Matchers {
         val Right(h1) = h.modify(List(GroupAgg(List("label"), List("i" -> "mean", "d" -> "mean")))).right.map(_.apply(1))
 
         def decode(buf: ByteBuffer) = {
-          buf.rewind()
+          (buf:Buffer).rewind()
           val labelLength = buf.getInt()
           val labelArr = new Array[Byte](labelLength)
           buf.get(labelArr)

--- a/polynote-spark-runtime/src/test/scala/polynote/runtime/spark/reprs/SparkReprsOfSuite.scala
+++ b/polynote-spark-runtime/src/test/scala/polynote/runtime/spark/reprs/SparkReprsOfSuite.scala
@@ -4,7 +4,7 @@ import org.apache.spark.sql.{Encoders, Row, SparkSession}
 import org.scalatest.{FreeSpec, Matchers}
 import polynote.runtime.{DoubleType, IntType, OptionalType, ReprsOf, StreamingDataRepr, StringType, StructField, StructType}
 
-import java.nio.ByteBuffer
+import java.nio.{Buffer, ByteBuffer}
 import java.nio.charset.StandardCharsets
 
 case class Example(label: String, i: Int, d: Double)
@@ -45,7 +45,7 @@ class SparkReprsOfSuite extends FreeSpec with Matchers {
         val result = representation(rows)
 
         def decode(buf: ByteBuffer) = {
-          buf.rewind()
+          (buf:Buffer).rewind()
           val present = buf.get()
           val label = if (present == 1) {
             val labelLength = buf.getInt()


### PR DESCRIPTION
JDK17 introduces a new overload of this method. When you build on JDK17, it selects that version which makes in binary incompatible with JDK8.

This fixes it by only using `rewind` from the parent class `Buffer`.