### PR TITLE
Add dependency override for shapeless

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,8 @@ lazy val scalaBinaryVersions = scalaVersions.map {
   ver => ver.split('.').take(2).mkString(".")
 }.distinct
 
+val shapelessVersion = Map("2.12" -> "2.3.2", "2.13" -> "2.3.3")
+
 val commonSettings = Seq(
   scalaVersion := "2.12.15",
   crossScalaVersions := scalaVersions,
@@ -187,7 +189,7 @@ val `polynote-kernel` = project.settings(
     "com.github.javaparser" % "javaparser-symbol-solver-core" % versions.javaparser,
     "org.scalamock" %% "scalamock" % "4.4.0" % "test"
   ),
-  dependencyOverrides += "com.chuusai" %% "shapeless" % "2.3.2",
+  dependencyOverrides += "com.chuusai" %% "shapeless" % shapelessVersion(scalaBinaryVersion.value),
   distFiles := Seq(assembly.value) ++ (Compile / dependencyClasspath).value.collect {
     case jar if jar.data.name.matches(".*scala-(library|reflect|compiler|collection-compat|xml).*") => jar.data
   },

--- a/build.sbt
+++ b/build.sbt
@@ -187,6 +187,7 @@ val `polynote-kernel` = project.settings(
     "com.github.javaparser" % "javaparser-symbol-solver-core" % versions.javaparser,
     "org.scalamock" %% "scalamock" % "4.4.0" % "test"
   ),
+  dependencyOverrides += "com.chuusai" %% "shapeless" % "2.3.2",
   distFiles := Seq(assembly.value) ++ (Compile / dependencyClasspath).value.collect {
     case jar if jar.data.name.matches(".*scala-(library|reflect|compiler|collection-compat|xml).*") => jar.data
   },

--- a/build.sbt
+++ b/build.sbt
@@ -62,6 +62,7 @@ val commonSettings = Seq(
     )
   ),
   version := "0.6.1",
+  dependencyOverrides += "com.chuusai" %% "shapeless" % shapelessVersion(scalaBinaryVersion.value),
   publishTo := sonatypePublishToBundle.value,
   // disable scalaDoc generation because it's causing weird compiler errors and we don't use it anyways
   Compile / packageDoc / publishArtifact := false,
@@ -189,7 +190,6 @@ val `polynote-kernel` = project.settings(
     "com.github.javaparser" % "javaparser-symbol-solver-core" % versions.javaparser,
     "org.scalamock" %% "scalamock" % "4.4.0" % "test"
   ),
-  dependencyOverrides += "com.chuusai" %% "shapeless" % shapelessVersion(scalaBinaryVersion.value),
   distFiles := Seq(assembly.value) ++ (Compile / dependencyClasspath).value.collect {
     case jar if jar.data.name.matches(".*scala-(library|reflect|compiler|collection-compat|xml).*") => jar.data
   },


### PR DESCRIPTION
Resolves a compiletime/runtime mismatch when Spark is in user classpath