### PR TITLE
Exclude sys.pycache_prefix from search for jep in python startup script

### DIFF
--- a/scripts/polynote.py
+++ b/scripts/polynote.py
@@ -8,7 +8,8 @@ import shlex
 # The sys module contains a bunch of *_prefix attributes that point to various locations where these libraries might be, 
 # such as https://docs.python.org/3/library/sys.html#sys.exec_prefix 
 # We set both the PYTHONPATH and the LD_LIBRARY_PATH just in case
-sys_prefixes = {getattr(sys, sys_prefix) for sys_prefix in filter(lambda name: "prefix" in name, dir(sys))}
+is_valid_prefix = lambda name: "prefix" in name and name != "pycache_prefix"
+sys_prefixes = {getattr(sys, sys_prefix) for sys_prefix in filter(is_valid_prefix, dir(sys))}
 if not os.environ.get('PYTHONPATH'):
     os.environ['PYTHONPATH'] = os.pathsep.join(sys_prefixes)
 else: 


### PR DESCRIPTION
Previously running the polynote.py startup script gave me the following error (WSL2, Ubuntu 22.04.1 LTS, Python 3.12.3)

`Traceback (most recent call last):
  File "/home/janukan/projects/polynote/scripts/polynote.py", line 13, in <module>
    os.environ['PYTHONPATH'] = os.pathsep.join(sys_prefixes)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: sequence item 0: expected str instance, NoneType found`

This error is caused by sys_prefixes including the value for sys.pycache_prefix. When sys.pycache_prefix is not set by a command-line option or an environment variable, it defaults to None. As sys.pycache_prefix determines where bytecode files are stored, it seems safe to exclude this from the search for jep.