### PR TITLE
bump circe

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -122,7 +122,7 @@ val commonSettings = Seq(
   },
   scalacOptions += "-deprecation",
   assembly / test := {},
-  circeVersion := "0.14.3",
+  circeVersion := "0.14.10",
   circeYamlVersion := "0.15.2"
 )
 


### PR DESCRIPTION
To fix error like: https://github.com/polynote/polynote/actions/runs/19282178855/job/55135456426?pr=1481

```
   |     /opt/hostedtoolcache/jdk/8.0.472/x64/jre/bin/java -cp /home/runner/work/polynote/polynote/polynote-server/target/scala-2.12/test-classes:/home/runner/work/polynote/polynote/polynote-server/target/scala-2.12/classes:/home/runner/work/polynote/polynote/polynote-runtime/target/scala-2.12/classes:/home/runner/work/polynote/polynote/polynote-macros/target/scala-2.12/classes:/home/runner/work/polynote/polynote/polynote-kernel/target/scala-2.12/classes:/home/runner/work/polynote/polynote/polynote-env/target/scala-2.12/classes:/home/runner/work/polynote/polynote/polynote-kernel/target/scala-2.12/test-classes:/home/runner/.ivy2/maven-cache/org/scala-lang/scala-library/2.12.20/scala-library-2.12.20.jar:/home/runner/.ivy2/maven-cache/org/polynote/uzhttp_2.12/0.2.8/uzhttp_2.12-0.2.8.jar:/home/runner/.ivy2/maven-cache/dev/zio/zio_2.12/1.0.11/zio_2.12-1.0.11.jar:/home/runner/.ivy2/maven-cache/dev/zio/zio-stacktracer_2.12/1.0.11/zio-stacktracer_2.12-1.0.11.jar:/home/runner/.ivy2/maven-cache/dev/zio/izumi-reflect_2.12/1.1.3/izumi-reflect_2.12-1.1.3.jar:/home/runner/.ivy2/maven-cache/dev/zio/izumi-reflect-thirdparty-boopickle-shaded_2.12/1.1.3/izumi-reflect-thirdparty-boopickle-shaded_2.12-1.1.3.jar:/home/runner/.ivy2/maven-cache/dev/zio/zio-streams_2.12/1.0.11/zio-streams_2.12-1.0.11.jar:/home/runner/.ivy2/maven-cache/com/vladsch/flexmark/flexmark/0.34.32/flexmark-0.34.32.jar:/home/runner/.ivy2/maven-cache/com/vladsch/flexmark/flexmark-util/0.34.32/flexmark-util-0.34.32.jar:/home/runner/.ivy2/maven-cache/com/vladsch/flexmark/flexmark-ext-yaml-front-matter/0.34.32/flexmark-ext-yaml-front-matter-0.34.32.jar:/home/runner/.ivy2/maven-cache/com/vladsch/flexmark/flexmark-formatter/0.34.32/flexmark-formatter-0.34.32.jar:/home/runner/.ivy2/maven-cache/org/slf4j/slf4j-simple/1.7.25/slf4j-simple-1.7.25.jar:/home/runner/.ivy2/maven-cache/org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar:/home/runner/.ivy2/maven-cache/black/ninia/jep/4.2.1/jep-4.2.1.jar:/home/runner/.ivy2/maven-cache/org/scalameta/semanticdb-scalac-core_2.12.20/4.9.9/semanticdb-scalac-core_2.12.20-4.9.9.jar:/home/runner/.ivy2/maven-cache/org/scala-lang/scala-compiler/2.12.20/scala-compiler-2.12.20.jar:/home/runner/.ivy2/maven-cache/org/scala-lang/scala-reflect/2.12.20/scala-reflect-2.12.20.jar:/home/runner/.ivy2/maven-cache/org/scala-lang/modules/scala-xml_2.12/2.3.0/scala-xml_2.12-2.3.0.jar:/home/runner/.ivy2/maven-cache/org/scalameta/semanticdb-shared_2.12.20/4.9.9/semanticdb-shared_2.12.20-4.9.9.jar:/home/runner/.ivy2/maven-cache/org/scalameta/scalameta_2.12/4.9.9/scalameta_2.12-4.9.9.jar:/home/runner/.ivy2/maven-cache/org/scalameta/parsers_2.12/4.9.9/parsers_2.12-4.9.9.jar:/home/runner/.ivy2/maven-cache/org/scalameta/trees_2.12/4.9.9/trees_2.12-4.9.9.jar:/home/runner/.ivy2/maven-cache/org/scalameta/common_2.12/4.9.9/common_2.12-4.9.9.jar:/home/runner/.ivy2/maven-cache/com/lihaoyi/sourcecode_2.12/0.4.2/sourcecode_2.12-0.4.2.jar:/home/runner/.ivy2/maven-cache/org/scala-lang/scalap/2.12.20/scalap-2.12.20.jar:/home/runner/.ivy2/maven-cache/com/thesamet/scalapb/scalapb-runtime_2.12/0.11.17/scalapb-runtime_2.12-0.11.17.jar:/home/runner/.ivy2/maven-cache/com/thesamet/scalapb/lenses_2.12/0.11.17/lenses_2.12-0.11.17.jar:/home/runner/.ivy2/maven-cache/org/scala-lang/modules/scala-collection-compat_2.12/2.12.0/scala-collection-compat_2.12-2.12.0.jar:/home/runner/.ivy2/maven-cache/com/google/protobuf/protobuf-java/3.19.6/protobuf-java-3.19.6.jar:/home/runner/.ivy2/maven-cache/org/scodec/scodec-core_2.12/1.11.4/scodec-core_2.12-1.11.4.jar:/home/runner/.ivy2/maven-cache/org/scodec/scodec-bits_2.12/1.1.12/scodec-bits_2.12-1.1.12.jar:/home/runner/.ivy2/maven-cache/com/chuusai/shapeless_2.12/2.3.2/shapeless_2.12-2.3.2.jar:/home/runner/.ivy2/maven-cache/org/typelevel/macro-compat_2.12/1.1.1/macro-compat_2.12-1.1.1.jar:/home/runner/.ivy2/maven-cache/io/get-coursier/coursier_2.12/2.0.0-RC5-6/coursier_2.12-2.0.0-RC5-6.jar:/home/runner/.ivy2/maven-cache/io/get-coursier/coursier-core_2.12/2.0.0-RC5-6/coursier-core_2.12-2.0.0-RC5-6.jar:/home/runner/.ivy2/maven-cache/io/get-coursier/coursier-util_2.12/2.0.0-RC5-6/coursier-util_2.12-2.0.0-RC5-6.jar:/home/runner/.ivy2/maven-cache/io/get-coursier/coursier-cache_2.12/2.0.0-RC5-6/coursier-cache_2.12-2.0.0-RC5-6.jar:/home/runner/.ivy2/maven-cache/com/github/alexarchambault/argonaut-shapeless_6.2_2.12/1.2.0-M11/argonaut-shapeless_6.2_2.12-1.2.0-M11.jar:/home/runner/.ivy2/maven-cache/io/argonaut/argonaut_2.12/6.2.3/argonaut_2.12-6.2.3.jar:/home/runner/.ivy2/maven-cache/io/github/classgraph/classgraph/4.8.47/classgraph-4.8.47.jar:/home/runner/.ivy2/maven-cache/org/scala-lang/modules/scala-java8-compat_2.12/0.9.0/scala-java8-compat_2.12-0.9.0.jar:/home/runner/.ivy2/maven-cache/io/circe/circe-yaml_2.12/0.15.2/circe-yaml_2.12-0.15.2.jar:/home/runner/.ivy2/maven-cache/io/circe/circe-yaml-common_2.12/0.15.2/circe-yaml-common_2.12-0.15.2.jar:/home/runner/.ivy2/maven-cache/io/circe/circe-core_2.12/0.14.7/circe-core_2.12-0.14.7.jar:/home/runner/.ivy2/maven-cache/io/circe/circe-numbers_2.12/0.14.7/circe-numbers_2.12-0.14.7.jar:/home/runner/.ivy2/maven-cache/org/typelevel/cats-core_2.12/2.10.0/cats-core_2.12-2.10.0.jar:/home/runner/.ivy2/maven-cache/org/typelevel/cats-kernel_2.12/2.10.0/cats-kernel_2.12-2.10.0.jar:/home/runner/.ivy2/maven-cache/org/yaml/snakeyaml/2.2/snakeyaml-2.2.jar:/home/runner/.ivy2/maven-cache/io/circe/circe-generic_2.12/0.14.3/circe-generic_2.12-0.14.3.jar:/home/runner/.ivy2/maven-cache/io/circe/circe-generic-extras_2.12/0.14.3/circe-generic-extras_2.12-0.14.3.jar:/home/runner/.ivy2/maven-cache/io/circe/circe-parser_2.12/0.14.3/circe-parser_2.12-0.14.3.jar:/home/runner/.ivy2/maven-cache/io/circe/circe-jawn_2.12/0.14.3/circe-jawn_2.12-0.14.3.jar:/home/runner/.ivy2/maven-cache/org/typelevel/jawn-parser_2.12/1.4.0/jawn-parser_2.12-1.4.0.jar:/home/runner/.ivy2/maven-cache/net/sf/py4j/py4j/0.10.7/py4j-0.10.7.jar:/home/runner/.ivy2/maven-cache/com/github/javaparser/javaparser-core/3.25.5/javaparser-core-3.25.5.jar:/home/runner/.ivy2/maven-cache/com/github/javaparser/javaparser-symbol-solver-core/3.25.5/javaparser-symbol-solver-core-3.25.5.jar:/home/runner/.ivy2/maven-cache/org/javassist/javassist/3.29.2-GA/javassist-3.29.2-GA.jar:/home/runner/.ivy2/maven-cache/com/google/guava/guava/32.1.2-jre/guava-32.1.2-jre.jar:/home/runner/.ivy2/maven-cache/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar:/home/runner/.ivy2/maven-cache/com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar:/home/runner/.ivy2/maven-cache/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar:/home/runner/.ivy2/maven-cache/org/checkerframework/checker-qual/3.33.0/checker-qual-3.33.0.jar:/home/runner/.ivy2/maven-cache/com/google/errorprone/error_prone_annotations/2.18.0/error_prone_annotations-2.18.0.jar:/home/runner/.ivy2/maven-cache/com/google/j2objc/j2objc-annotations/2.8/j2objc-annotations-2.8.jar:/home/runner/.ivy2/maven-cache/org/scalatest/scalatest_2.12/3.0.8/scalatest_2.12-3.0.8.jar:/home/runner/.ivy2/maven-cache/org/scalactic/scalactic_2.12/3.0.8/scalactic_2.12-3.0.8.jar:/home/runner/.ivy2/maven-cache/org/scalacheck/scalacheck_2.12/1.14.0/scalacheck_2.12-1.14.0.jar:/home/runner/.ivy2/maven-cache/org/scala-sbt/test-interface/1.0/test-interface-1.0.jar:/home/runner/.ivy2/maven-cache/org/scalamock/scalamock_2.12/4.4.0/scalamock_2.12-4.4.0.jar:/home/runner/.sbt/boot/scala-2.12.19/org.scala-sbt/sbt/1.10.0/test-agent-1.10.0.jar:/home/runner/.sbt/boot/scala-2.12.19/org.scala-sbt/sbt/1.10.0/test-interface-1.0.jar -Dlog4j.configuration=log4j.properties -Djava.library.path=/home/runner/work/polynote/polynote/.venv/lib/python3.7/site-packages/jep:.:/home/runner/work/polynote/polynote/.venv/lib/python3.7/site-packages/jep:/home/runner/work/polynote/polynote/.venv/lib/python3.7/site-packages:/home/runner/work/polynote/polynote/.venv/lib:/opt/hostedtoolcache/Python/3.7.17/x64/lib polynote.kernel.remote.RemoteKernelClient --address 127.0.0.1 --port 43027 --kernelFactory polynote.kernel.LocalKernelFactory
[INFO]   Kernel closed
[info] - gracefully handles death of kernel
[ERROR]  Error starting kernel; shutting it down (Logged from KernelPublisher.scala:116)
   |     polynote.server.KernelPublisherIntegrationTest$FailedToStart$1: The kernel fails to start. What do you do?
   |     polynote.server.KernelPublisherIntegrationTest$FailedToStart$2$.apply(KernelPublisherIntegrationTest.scala:118)
   |     polynote.server.KernelPublisherIntegrationTest$FailedToStart$2$.apply(KernelPublisherIntegrationTest.scala:118)
   |     zio.ZIO$.$anonfun$fail$1(ZIO.scala:2849)
   |     zio.internal.FiberContext.evaluateNow(FiberContext.scala:407)
   |     zio.internal.FiberContext.$anonfun$evaluateLater$1(FiberContext.scala:776)
   |     java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
   |     java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
   |     java.lang.Thread.run(Thread.java:750)
[INFO]   Kernel closed
[INFO]   Closing /i/am/fake.ipynb (idle with no more subscribers)
[info] - gracefully handles startup failure of kernel
[info]   handles concurrent edits
[INFO]   Kernel process ended with 0
[info]   - repeatedly adding and deleting in the same place
[info]   - check
[info] FileBasedRepositorySpec:
[info] A FileBasedRepository
[info] - should roundtrip the notebook if the format exists
[info] - should fail to save the notebook if the format can't be found
[info] - should list all available, supported notebooks
[info] - should correctly check whether notebooks exist
[info] - should generate a URI for existing notebooks
[info] - should generate unique notebook names when paths collide
[info] - should create empty notebooks
[info] - should create notebooks with content
[info] - should rename notebooks
[info] - should copy notebooks
[info] - should delete notebooks
[info] HeaderIdentityProviderSpec:
[info] HeaderIdentityProvider
[info] - loads from config YAML
[info]   when specified header is missing
[info]   - fails when allowAnonymous = false
[info]   - succeeds when allowAnonymous = true
[info]   provides a user identity
[info]   - non-empty when header is present
[info]   - empty when header is absent
[info]   checks permissions
[info]   - for known users
[info]   - for unknown users
[info] Run completed in 1 minute, 7 seconds.
[info] Total number of tests run: 185
[info] Suites: completed 13, aborted 0
[info] Tests: succeeded 185, failed 0, canceled 0, ignored 2, pending 0
[info] All tests passed.
[info] Run completed in 59 seconds, 115 milliseconds.
[info] Total number of tests run: 72
[info] Suites: completed 10, aborted 0
[info] Tests: succeeded 72, failed 0, canceled 0, ignored 1, pending 0
[info] All tests passed.
[error] sbt.librarymanagement.ResolveException: unresolved dependency: org.typelevel#macro-compat_2.12;1.1.1: not found
[error] 	at sbt.internal.librarymanagement.IvyActions$.resolveAndRetrieve(IvyActions.scala:333)
[error] 	at sbt.internal.librarymanagement.IvyActions$.$anonfun$updateEither$1(IvyActions.scala:210)
[error] 	at sbt.internal.librarymanagement.IvySbt$Module.$anonfun$withModule$1(Ivy.scala:267)
[error] 	at sbt.internal.librarymanagement.IvySbt.$anonfun$withIvy$1(Ivy.scala:212)
[error] 	at sbt.internal.librarymanagement.IvySbt.sbt$internal$librarymanagement$IvySbt$$action$1(Ivy.scala:72)
[error] 	at sbt.internal.librarymanagement.IvySbt$$anon$1.call(Ivy.scala:82)
[error] 	at xsbt.boot.Locks$GlobalLock.withChannel$1(Locks.scala:100)
[error] 	at xsbt.boot.Locks$GlobalLock.withChannelRetries$1(Locks.scala:80)
[error] 	at xsbt.boot.Locks$GlobalLock.withFileLock$$anonfun$1(Locks.scala:103)
[error] 	at xsbt.boot.Using$.withResource(Using.scala:14)
[error] 	at xsbt.boot.Using$.apply(Using.scala:11)
[error] 	at xsbt.boot.Locks$GlobalLock.withFileLock(Locks.scala:103)
[error] 	at xsbt.boot.Locks$GlobalLock.ignoringDeadlockAvoided(Locks.scala:64)
[error] 	at xsbt.boot.Locks$GlobalLock.withLock(Locks.scala:55)
[error] 	at xsbt.boot.Locks$.apply0(Locks.scala:45)
[error] 	at xsbt.boot.Locks$.apply(Locks.scala:36)
[error] 	at sbt.internal.librarymanagement.IvySbt.withDefaultLogger(Ivy.scala:82)
[error] 	at sbt.internal.librarymanagement.IvySbt.withIvy(Ivy.scala:206)
[error] 	at sbt.internal.librarymanagement.IvySbt.withIvy(Ivy.scala:203)
[error] 	at sbt.internal.librarymanagement.IvySbt$Module.withModule(Ivy.scala:266)
[error] 	at sbt.internal.librarymanagement.IvyActions$.updateEither(IvyActions.scala:194)
[error] 	at sbt.librarymanagement.ivy.IvyDependencyResolution.update(IvyDependencyResolution.scala:22)
[error] 	at sbt.librarymanagement.DependencyResolution.update(DependencyResolution.scala:60)
[error] 	at sbt.internal.LibraryManagement$.resolve$1(LibraryManagement.scala:60)
[error] 	at sbt.internal.LibraryManagement$.$anonfun$cachedUpdate$12(LibraryManagement.scala:134)
[error] 	at sbt.util.Tracked$.$anonfun$lastOutput$1(Tracked.scala:74)
[error] 	at sbt.internal.LibraryManagement$.$anonfun$cachedUpdate$20(LibraryManagement.scala:147)
[error] 	at scala.util.control.Exception$Catch.apply(Exception.scala:228)
[error] 	at sbt.internal.LibraryManagement$.$anonfun$cachedUpdate$11(LibraryManagement.scala:147)
[error] 	at sbt.internal.LibraryManagement$.$anonfun$cachedUpdate$11$adapted(LibraryManagement.scala:128)
[error] 	at sbt.util.Tracked$.$anonfun$inputChangedW$1(Tracked.scala:220)
[error] 	at sbt.internal.LibraryManagement$.cachedUpdate(LibraryManagement.scala:161)
[error] 	at sbt.Classpaths$.$anonfun$updateTask0$1(Defaults.scala:3867)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:63)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:69)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:283)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:24)
[error] 	at sbt.Execute.work(Execute.scala:292)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:283)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:65)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error] 	at java.lang.Thread.run(Thread.java:750)
[error] (polynote-spark-runtime / update) sbt.librarymanagement.ResolveException: unresolved dependency: org.typelevel#macro-compat_2.12;1.1.1: not found
[error] Total time: 361 s (06:01), completed Nov 12, 2025 12:24:45 AM
```