### PR TITLE
Fix build timeout: download spark packages from github instead

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -233,6 +233,9 @@ val sparkChecksums = Map(
   "3.2.1" -> "2ec9f1cb65af5ee7657ca83a1abaca805612b8b3a1d8d9bb67e317106025c81ba8d44d82ad6fdb45bbe6caa768d449cd6a4945ec050ce9390f806f46c5cb1397"
 )
 
+// Downloading from https://archive.apache.org/dist/spark is very slow, so we download the packages manually then upload to GitHub Releases
+// to work around the issue.
+// For new spark versions, add the package via https://github.com/polynote/polynote/releases/edit/0.6.1
 val sparkDistUrl: String => String =
   ver => s"https://github.com/polynote/polynote/releases/download/0.6.1"
 


### PR DESCRIPTION
Downloading from https://archive.apache.org/dist/spark is super slow, causing build to timeout, so I've uploaded the packages directly to https://github.com/polynote/polynote/releases/tag/0.6.1 as a workaround.

The checksums do not change.