### PR TITLE
Fix sbt waring

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -121,9 +121,7 @@ val commonSettings = Seq(
     destFiles
   },
   scalacOptions += "-deprecation",
-  assembly / test := {},
-  circeVersion := "0.14.3",
-  circeYamlVersion := "0.15.2"
+  assembly / test := {}
 )
 
 lazy val `polynote-macros` = project.settings(
@@ -173,6 +171,8 @@ val `polynote-env` = project.settings(
 
 val `polynote-kernel` = project.settings(
   commonSettings,
+  circeVersion := "0.14.3",
+  circeYamlVersion := "0.15.2",
   libraryDependencies ++= Seq(
     "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
     "org.scala-lang" % "scala-compiler" % scalaVersion.value % "test",


### PR DESCRIPTION
### Problem
```
[warn] there are 14 keys that are not used by any other settings/tasks:
[warn]  
[warn] * polynote / circeVersion
[warn]   +- /Users/yic/workspace/poly/polynote/build.sbt:125
[warn] * polynote / circeYamlVersion
[warn]   +- /Users/yic/workspace/poly/polynote/build.sbt:126
[warn] * polynote-env / circeVersion
[warn]   +- /Users/yic/workspace/poly/polynote/build.sbt:125
[warn] * polynote-env / circeYamlVersion
[warn]   +- /Users/yic/workspace/poly/polynote/build.sbt:126
[warn] * polynote-macros / circeVersion
[warn]   +- /Users/yic/workspace/poly/polynote/build.sbt:125
[warn] * polynote-macros / circeYamlVersion
[warn]   +- /Users/yic/workspace/poly/polynote/build.sbt:126
[warn] * polynote-runtime / circeVersion
[warn]   +- /Users/yic/workspace/poly/polynote/build.sbt:125
[warn] * polynote-runtime / circeYamlVersion
[warn]   +- /Users/yic/workspace/poly/polynote/build.sbt:126
[warn] * polynote-server / circeVersion
[warn]   +- /Users/yic/workspace/poly/polynote/build.sbt:125
[warn] * polynote-server / circeYamlVersion
[warn]   +- /Users/yic/workspace/poly/polynote/build.sbt:126
[warn] * polynote-spark / circeVersion
[warn]   +- /Users/yic/workspace/poly/polynote/build.sbt:125
[warn] * polynote-spark / circeYamlVersion
[warn]   +- /Users/yic/workspace/poly/polynote/build.sbt:126
[warn] * polynote-spark-runtime / circeVersion
[warn]   +- /Users/yic/workspace/poly/polynote/build.sbt:125
[warn] * polynote-spark-runtime / circeYamlVersion
[warn]   +- /Users/yic/workspace/poly/polynote/build.sbt:126
[warn]  
```

### Solution

Move it to the project that uses them.