### PR TITLE
Allow `?nocache` only for http url artifacts

### DIFF
--- a/docs-site/docs/docs/notebook-configuration.md
+++ b/docs-site/docs/docs/notebook-configuration.md
@@ -56,25 +56,26 @@ Note that this method will automatically cache all of the dependencies from the 
 
 #### Dependency Caching
 
-By default, Polynote caches JVM dependencies that are specified with URLs, as well as the [virtual environment created
-for your notebook](python.md#python-dependencies). 
+By default, Polynote caches JVM dependencies that are specified with HTTP/HTTPS URLs, as well as the [virtual environment created
+for your notebook](python.md#python-dependencies).
 
-You can choose to manually bust the cache by either appending `?nocache` to the end of the dependency, or by 
-unfolding the Advanced Options pane for your dependency by clicking on the `...` button next to it. 
+You can choose to manually bust the cache by either appending `?nocache` to the end of the dependency, or by
+unfolding the Advanced Options pane for your dependency by clicking on the `...` button next to it.
 
 ![Dependency Caching](images/notebook-configuration-cache.png)
 
-Changing the cache option affects different types of dependencies differently. 
+Changing the cache option affects different types of dependencies differently.
 
 - **JVM Dependencies**
-    - URL-based dependencies are affected by this setting. If using the cache, Polynote uses the cached file (if 
-      present) instead of downloading it again. Conversely, if the cache is disabled for this dependency then Polynote 
+    - HTTP/HTTPS URL-based dependencies are affected by this setting. If using the cache, Polynote uses the cached file (if
+      present) instead of downloading it again. Conversely, if the cache is disabled for this dependency then Polynote
       will download the jar anew each time.
+    - Other URL schemes (such as `s3://` or `file://`) are not affected by this setting and do not support caching.
     - GAV notation dependencies are unaffected by this change (Coursier caches these dependencies itself and we don't
       expose any way to change that for now)
 - **Python Dependencies**
-    - Python dependencies are affected by this setting. Since they share a virtual environment for this notebook, 
-      **bypassing the cache for any Python dependency will bust the cache for all Python dependencies**, since this is 
+    - Python dependencies are affected by this setting. Since they share a virtual environment for this notebook,
+      **bypassing the cache for any Python dependency will bust the cache for all Python dependencies**, since this is
       implmemented as a simple deletion and recreation of the virtual environment. 
       
 !!!question "Feedback requested"

--- a/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
@@ -262,12 +262,10 @@ class Dependencies extends Disposable {
     get conf(): Record<string, string[]> {
         return Array.from(this.container.children).reduce<Record<string, string[]>>((acc, row: DepRow) => {
             if (row.data.dep) {
-                const shouldSupportCache = this.shouldSupportCaching(row.data.lang, row.data.dep);
-
                 if (row.data.cache) {
                     // Remove ?nocache if present
                     row.data.dep = row.data.dep.endsWith("?nocache") ? row.data.dep.substr(0, row.data.dep.length - "?nocache".length) : row.data.dep;
-                } else if (shouldSupportCache) {
+                } else if (this.shouldSupportCaching(row.data.lang, row.data.dep)) {
                     // Only add ?nocache for HTTP/HTTPS URLs or pip dependencies
                     row.data.dep = row.data.dep.endsWith("?nocache") ? row.data.dep : row.data.dep + "?nocache";
                 }

--- a/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
@@ -149,6 +149,12 @@ class Dependencies extends Disposable {
         }
     }
 
+    private shouldSupportCaching(lang: string, dep: string): boolean {
+        const isPython = lang === 'python';
+        const isHttp = this.isHttpUrl(dep);
+        return isPython || isHttp;
+    }
+
     constructor(dependenciesHandler: StateView<Record<string, string[]> | undefined>, stateHandler: StateHandler<NBConfig>) {
         super()
 
@@ -195,9 +201,7 @@ class Dependencies extends Disposable {
         const data = item ?? {lang: this.defaultLang, dep: "", cache: true}
 
         const updateAdvancedVisibility = () => {
-            const isPython = data.lang === 'python';
-            const isHttp = this.isHttpUrl(data.dep);
-            const shouldShowCache = isPython || isHttp;
+            const shouldShowCache = this.shouldSupportCaching(data.lang, data.dep);
 
             if (shouldShowCache) {
                 detail.style.display = '';
@@ -258,9 +262,7 @@ class Dependencies extends Disposable {
     get conf(): Record<string, string[]> {
         return Array.from(this.container.children).reduce<Record<string, string[]>>((acc, row: DepRow) => {
             if (row.data.dep) {
-                const isPython = row.data.lang === 'python';
-                const isHttp = this.isHttpUrl(row.data.dep);
-                const shouldSupportCache = isPython || isHttp;
+                const shouldSupportCache = this.shouldSupportCaching(row.data.lang, row.data.dep);
 
                 if (row.data.cache) {
                     // Remove ?nocache if present

--- a/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
@@ -140,6 +140,15 @@ class Dependencies extends Disposable {
     readonly el: TagElement<"div">;
     private container: TagElement<"div">;
 
+    private isHttpUrl(dep: string): boolean {
+        try {
+            const url = new URL(dep);
+            return url.protocol === 'http:' || url.protocol === 'https:';
+        } catch {
+            return false;
+        }
+    }
+
     constructor(dependenciesHandler: StateView<Record<string, string[]> | undefined>, stateHandler: StateHandler<NBConfig>) {
         super()
 
@@ -185,25 +194,9 @@ class Dependencies extends Disposable {
     private addDep(item?: DepRow["data"]) {
         const data = item ?? {lang: this.defaultLang, dep: "", cache: true}
 
-        const type = dropdown(['dependency-type'], {scala: 'scala/jvm', python: 'pip'}, data.lang).change(evt => {
-            row.classList.remove(data.lang);
-            data.lang = type.options[type.selectedIndex].value;
-            row.classList.add(data.lang);
-            updateAdvancedVisibility();
-        });
-
-        const isHttpUrl = (dep: string): boolean => {
-            try {
-                const url = new URL(dep);
-                return url.protocol === 'http:' || url.protocol === 'https:';
-            } catch {
-                return false;
-            }
-        };
-
         const updateAdvancedVisibility = () => {
             const isPython = data.lang === 'python';
-            const isHttp = isHttpUrl(data.dep);
+            const isHttp = this.isHttpUrl(data.dep);
             const shouldShowCache = isPython || isHttp;
 
             if (shouldShowCache) {
@@ -213,6 +206,13 @@ class Dependencies extends Disposable {
                 row.classList.remove("show-advanced");
             }
         };
+
+        const type = dropdown(['dependency-type'], {scala: 'scala/jvm', python: 'pip'}, data.lang).change(evt => {
+            row.classList.remove(data.lang);
+            data.lang = type.options[type.selectedIndex].value;
+            row.classList.add(data.lang);
+            updateAdvancedVisibility();
+        });
 
         const input = textbox(['dependency'], 'Dependency coordinate, URL, pip package', data.dep).change(evt => {
             data.dep = input.value.trim();
@@ -256,19 +256,10 @@ class Dependencies extends Disposable {
     }
 
     get conf(): Record<string, string[]> {
-        const isHttpUrl = (dep: string): boolean => {
-            try {
-                const url = new URL(dep);
-                return url.protocol === 'http:' || url.protocol === 'https:';
-            } catch {
-                return false;
-            }
-        };
-
         return Array.from(this.container.children).reduce<Record<string, string[]>>((acc, row: DepRow) => {
             if (row.data.dep) {
                 const isPython = row.data.lang === 'python';
-                const isHttp = isHttpUrl(row.data.dep);
+                const isHttp = this.isHttpUrl(row.data.dep);
                 const shouldSupportCache = isPython || isHttp;
 
                 if (row.data.cache) {

--- a/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
+++ b/polynote-frontend/polynote/ui/component/notebook/notebookconfig.ts
@@ -189,11 +189,34 @@ class Dependencies extends Disposable {
             row.classList.remove(data.lang);
             data.lang = type.options[type.selectedIndex].value;
             row.classList.add(data.lang);
-
+            updateAdvancedVisibility();
         });
 
+        const isHttpUrl = (dep: string): boolean => {
+            try {
+                const url = new URL(dep);
+                return url.protocol === 'http:' || url.protocol === 'https:';
+            } catch {
+                return false;
+            }
+        };
+
+        const updateAdvancedVisibility = () => {
+            const isPython = data.lang === 'python';
+            const isHttp = isHttpUrl(data.dep);
+            const shouldShowCache = isPython || isHttp;
+
+            if (shouldShowCache) {
+                detail.style.display = '';
+            } else {
+                detail.style.display = 'none';
+                row.classList.remove("show-advanced");
+            }
+        };
+
         const input = textbox(['dependency'], 'Dependency coordinate, URL, pip package', data.dep).change(evt => {
-            data.dep = input.value.trim()
+            data.dep = input.value.trim();
+            updateAdvancedVisibility();
         });
 
         const remove = iconButton(['remove'], 'Remove', 'minus-circle-red', 'Remove').click(evt => {
@@ -215,7 +238,7 @@ class Dependencies extends Disposable {
             div([], [
                 para([], [
                     "Should Polynote use a cached version of this dependency, if available?",
-                    " Applicable to URL or pip dependencies only."]),
+                    " Applicable to HTTP/HTTPS URL or pip dependencies only."]),
                 para([], ["Note that if any pip dependency bypasses the cache, the entire virtual environment will be recreated."]),
                 cache
             ])
@@ -229,16 +252,34 @@ class Dependencies extends Disposable {
             div(['dependency-row', 'notebook-config-row'], [type, input, detail, remove, add, advanced]),
             { data })
         this.container.appendChild(row)
+        updateAdvancedVisibility();
     }
 
     get conf(): Record<string, string[]> {
+        const isHttpUrl = (dep: string): boolean => {
+            try {
+                const url = new URL(dep);
+                return url.protocol === 'http:' || url.protocol === 'https:';
+            } catch {
+                return false;
+            }
+        };
+
         return Array.from(this.container.children).reduce<Record<string, string[]>>((acc, row: DepRow) => {
             if (row.data.dep) {
+                const isPython = row.data.lang === 'python';
+                const isHttp = isHttpUrl(row.data.dep);
+                const shouldSupportCache = isPython || isHttp;
+
                 if (row.data.cache) {
+                    // Remove ?nocache if present
                     row.data.dep = row.data.dep.endsWith("?nocache") ? row.data.dep.substr(0, row.data.dep.length - "?nocache".length) : row.data.dep;
-                } else {
+                } else if (shouldSupportCache) {
+                    // Only add ?nocache for HTTP/HTTPS URLs or pip dependencies
                     row.data.dep = row.data.dep.endsWith("?nocache") ? row.data.dep : row.data.dep + "?nocache";
                 }
+                // For other URL types (s3, file, etc.), ignore cache setting and don't add ?nocache
+
                 acc[row.data.lang] = [...(acc[row.data.lang] || []), row.data.dep]
             }
             return acc


### PR DESCRIPTION
# Restrict Dependency Cache Busting to HTTP/HTTPS URLs Only

## Problem

The `?nocache` cache-busting feature is being applied to **all** URL-based dependencies, including S3 URLs. This causes issues when the dependency URLs are passed to Spark via `spark.jars`, as Spark attempts to download URLs like:

```
s3://<bucket>/XYZ..jar?nocache
```

S3 (and other non-HTTP protocols) don't support the `?nocache` query parameter, leading to errors when Spark tries to resolve these dependencies.

### Root Cause

When a user disables caching for a dependency, the frontend appends `?nocache` as a sentinel value to the dependency string. This was originally designed for HTTP-based artifact servers (Artifactory, Nexus) where the same URL can point to different file versions during development. However, the implementation didn't restrict this to HTTP/HTTPS URLs only, allowing it to be applied to S3, file://, and other protocols where it's invalid.

The `?nocache` suffix propagates through the system:
1. Frontend adds `?nocache` to the dependency string
2. Backend uses this for cache control when downloading to Polynote's local cache
3. The URL **with `?nocache`** is passed to Spark via `spark.jars`
4. Spark fails to download from S3 because `?nocache` makes the URL invalid

## Solution

### Changes Made

1. **Frontend UI (`notebookconfig.ts`)**:
   - Added `isHttpUrl()` private method to the `Dependencies` class to check if a dependency is an HTTP/HTTPS URL
   - Hide the "Advanced Options" (`...`) button for non-HTTP URLs (S3, file://, etc.)
   - Only append `?nocache` for HTTP/HTTPS URLs and pip dependencies in the `conf` getter
   - Updated help text to clarify: "Applicable to HTTP/HTTPS URL or pip dependencies only"

2. **Behavior**:
   - **HTTP/HTTPS URLs**: Cache option visible and functional (e.g., Artifactory, Nexus)
   - **Pip dependencies**: Cache option visible and functional (recreates virtualenv)
   - **S3 URLs**: Cache option hidden, `?nocache` never added
   - **file:// URLs**: Cache option hidden, `?nocache` never added
   - **Other protocols**: Cache option hidden, `?nocache` never added

### Why This Approach?

This solution prevents the problem **at the source** rather than stripping `?nocache` in the backend:
- ✅ Cleaner separation of concerns
- ✅ UI accurately reflects what's supported
- ✅ No invalid URLs are ever created
- ✅ Backward compatible - existing notebooks with HTTP URLs continue to work
- ✅ Aligns with the original design intent (HTTP artifact servers)

### Technical Details

The check uses JavaScript's `URL` constructor to parse the dependency string:

```typescript
private isHttpUrl(dep: string): boolean {
    try {
        const url = new URL(dep);
        return url.protocol === 'http:' || url.protocol === 'https:';
    } catch {
        return false;
    }
}
```

This safely handles:
- Valid HTTP/HTTPS URLs → returns `true`
- S3/file/other URLs → returns `false`
- Maven coordinates (not URLs) → returns `false` (caught by exception)

## Testing

### Manual Testing Steps

1. **Build and run Polynote**:
   ```bash
   cd polynote-frontend && npm run dist && cd ..
   sbt dist
   cd target/dist/polynote && ./polynote.py
   ```

2. **Create a new notebook** and open Configuration → Dependencies

3. **Test S3 URL** (cache option should be hidden):
   ```
   s3://bucket/path/file.jar
   ```
   - Verify the `...` button is **not visible**
   - Save and check `.ipynb` file - no `?nocache` appended

4. **Test HTTP URL** (cache option should be visible):
   ```
   https://repo1.maven.org/maven2/com/google/guava/guava/31.0-jre/guava-31.0-jre.jar
   ```
   - Verify the `...` button **is visible**
   - Click it, select "Don't cache"
   - Save and check `.ipynb` file - `?nocache` is appended

5. **Test pip dependency** (cache option should be visible):
   ```
   requests
   ```
   - Switch to `pip` type
   - Verify the `...` button **is visible**

6. **Test Maven coordinates** (cache option should be hidden):
   ```
   org.apache.commons:commons-lang3:3.12.0
   ```
   - Verify the `...` button is **not visible**

### Expected Behavior

| Dependency Type | Cache Option Visible? | `?nocache` Added? |
|----------------|----------------------|-------------------|
| HTTP/HTTPS URL | ✅ Yes | ✅ Yes (if disabled) |
| S3 URL | ❌ No | ❌ No |
| file:// URL | ❌ No | ❌ No |
| Pip package | ✅ Yes | ✅ Yes (if disabled) |
| Maven coordinate | ❌ No | ❌ No |

## Backward Compatibility

- ✅ Existing notebooks with HTTP URLs and `?nocache` continue to work
- ✅ Existing notebooks with S3 URLs (without `?nocache`) continue to work
- ⚠️ If any notebooks currently have S3 URLs with `?nocache` (invalid state), they will be saved without `?nocache` on next save
- ✅ No data model changes required
- ✅ No backend changes required

## Effect

<img width="850" height="355" alt="image" src="https://github.com/user-attachments/assets/a1e598ec-edcc-496b-abd0-1320e115756d" />

When url is http, there would be option to select cache or no cache.

For non-http url, there would be no option to do so.